### PR TITLE
Add seven causal-inference skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-academic-workflow
 
-An academic-research workflow for Claude Code: skills for reading papers, running literature reviews, auditing bibliographies, drafting preregistrations, checking drafts before submission, writing R&R responses, assembling replication packages, compiling LaTeX, iterating TikZ figures, and a Quarto reveal.js slide system with render-time quality gates. It was built for quantitative marketing and economics; most of it transfers to any empirical field.
+An academic-research workflow for Claude Code: skills for reading papers, running literature reviews, auditing bibliographies, designing and analyzing causal-inference studies (difference-in-differences, regression discontinuity, instrumental variables, synthetic control, randomized experiments), drafting preregistrations, checking drafts before submission, writing R&R responses, assembling replication packages, compiling LaTeX, iterating TikZ figures, and a Quarto reveal.js slide system with render-time quality gates. It was built for quantitative marketing and economics; most of it transfers to any empirical field.
 
 Everything in this repository, including the two example decks and their figures, is AI-generated with Claude Code, as a proof of concept for what an agent-built research workflow looks like. Generated content is the responsibility of whoever uses it: verify citations, numbers, and claims before relying on them, the same way you would verify a research assistant's first draft.
 
@@ -27,6 +27,12 @@ Then read [SETUP.md](SETUP.md): it names every path and helper the skills assume
 | `reading-papers` | Looks up and reads a specific paper from a link, DOI, title, or vague description, across marketing, economics, psychology, and CS venues. |
 | `litreview` | Finds, ranks, and synthesizes the literature on a topic across Semantic Scholar, OpenAlex, and arXiv, then reads the top hits with parallel subagents. |
 | `bibcheck` | Audits a `.bib` file entry by entry against canonical metadata and writes a corrected copy; catches wrong years, mis-cited authors, and hallucinated entries. |
+| `causal-design` | Triages a causal question to the identification strategy the data can actually support, then hands off to the skill that owns it. Carries the selection-on-observables branch itself: overlap, doubly robust estimation, double machine learning, causal forests, sensitivity analysis. |
+| `did` | Runs a difference-in-differences analysis with the heterogeneity-robust estimators, event-study diagnostics, and honest bounds on pre-trend violations. |
+| `synthetic-control` | Builds and validates synthetic control comparisons, including synthetic difference-in-differences, the augmented and penalized variants, and factor-model alternatives. |
+| `rdd` | Runs a regression discontinuity in both the continuity and local-randomization frameworks, with the design gate and the full falsification battery. |
+| `iv` | Estimates instrumental-variables designs with weak-instrument-robust inference, shift-share and formula instruments, and an explicit exclusion-restriction argument. |
+| `field-experiment` | Designs and analyzes randomized experiments: stratified and clustered assignment, randomization inference, power, attrition bounds, and pre-specified heterogeneity. |
 | `preregister` | Drafts a registry-ready preregistration (AsPredicted, OSF, AEA RCT) with clarity flags and placeholders instead of invented content. |
 | `council` | Spawns five independent critic subagents in parallel on any target, then a synthesis pass that ranks findings by how load-bearing they are. |
 | `review-paper` | Runs a simulated referee review of your own draft with six agents in parallel, triaged CRITICAL/MAJOR/MINOR against a named target journal. See the [note of caution](#a-note-of-caution-on-reviewing) below. |

--- a/SETUP.md
+++ b/SETUP.md
@@ -10,6 +10,7 @@ Everything here was extracted from one researcher's working configuration, so th
 - A TeX distribution (MacTeX or TeX Live) with `latexmk`, for `compile-latex` and `tikz-iterate`; ghostscript for rasterizing.
 - `uv`, for the self-contained Python helpers (`paper.py` and the `pdfread.py` PDF helper run via `uv run` shebangs).
 - R with ggplot2 if you render the example decks (their figures are R chunks).
+- R with the estimation packages, for the causal-inference skills. Their script templates are the reference implementations, and each one loads only what its own design needs, so install per skill rather than all at once. The CRAN side spans `fixest`, `did`, `didimputation`, `staggered`, `bacondecomp`, `TwoWayFEWeights`, `HonestDiD`, `rdrobust`, `rddensity`, `rdlocrand`, `rdpower`, `rdmulti`, `ivreg`, `ivmodel`, `ivDiag`, `ivmte`, `Synth`, `tidysynth`, `scpi`, `SCtools`, `fect`, `CausalImpact`, `grf`, `policytree`, `WeightIt`, `sensemakr`, `estimatr`, `marginaleffects`, `randomizr`, `DeclareDesign`, `ri2`, `qte`, `clubSandwich`, `summclust`, `fwildclusterboot`, `ShiftShareSE`, `bpbounds`, and `zoo`. Six live on GitHub and need `remotes::install_github()`: `ebenmichael/augsynth`, `jonathandroth/pretrends`, `synth-inference/synthdid`, `kylebutts/ssaggregate`, `kwuthrich/scinference`, and `kolesarm/ManyIV`. Each skill's `references/details.md` carries a package index with the version the template was written against and the API quirks worth knowing.
 
 ## Install
 

--- a/skills/causal-design/SKILL.md
+++ b/skills/causal-design/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: causal-design
+description: Triage any causal question to the identification strategy the data can support, then hand off to the owning method skill; owns the selection-on-observables branch (overlap, doubly robust estimation, double ML, causal forests, policy learning, sensitivity analysis) and the inference rules shared across designs. Produces the design recommendation with the assumption that licenses it, the estimand and its subpopulation, R estimation code for the observables branch, and a drafted taxonomy paragraph. TRIGGER on "causal inference", "identification strategy", "which method", "research design", "endogeneity", "quasi-experiment", "natural experiment", "observational study", "selection on observables", "unconfoundedness", "conditional ignorability", "matching", "propensity score", "doubly robust", "AIPW", "double machine learning", "DML", "causal forest", "CATE", "policy learning", "targeting", "sensitivity analysis", "omitted variable bias", "Oster bounds", "coefficient stability", "overlap", "trimming", "marketplace experiment", "surrogate index", "mediation", "mediation analysis", "indirect effect", or any "how do I estimate the effect of X on Y" question with no design chosen yet. Once a design is chosen, the method skills own it: field-experiment, did, synthetic-control, rdd, iv.
+---
+
+# Causal design triage
+
+The router of the family, grounded in a read canon of two hand-picked reviews
+(references/canon.md, current as of 2026-07-28): Imbens (2024) supplies the assumption axis
+(what licenses identification), and Li, Luo, and Pattabhiramaiah (2024, hereafter AMA) the
+marketing data-shape axis (how many treated units, how many pre-periods, how rich the
+covariates). The deliverable is a design recommendation carrying four things: the assumption
+that licenses it, the estimand it actually identifies WITH its subpopulation named, the
+handoff to the owning skill, and, for the one branch no method skill owns (selection on
+observables), estimation code and a methods paragraph. Marketing's framing throughout:
+randomization is the gold standard, and quasi-experimental work substitutes statistical rigor
+for design rigor (AMA); a design that fails its gate is a verdict, not an obstacle.
+
+Refresh path: the panel-methods corner moves fastest. To update, run the litreview skill on
+quasi-experimental methods in marketing since the canon date and fold results into
+references/canon.md as flagged addenda.
+
+## The triage: three questions in order
+
+1. Was assignment randomized, or as good as (lottery, randomized rollout)? Yes:
+   field-experiment. Two cautions at this gate: naive sample means from adaptive/bandit
+   experiments are biased (the arm that looked worse early is truncated; Imbens), and
+   suspected interference changes the DESIGN, not just the analysis (routing below).
+2. If observational: is unconfoundedness defensible with PRETREATMENT covariates only? The
+   conditioning set may contain only non-descendants of treatment and outcome, normally
+   justified by temporal precedence. Verbatim, because it is the highest-frequency error
+   (Imbens 2024): "In practice, using variables causally affected by the treatment or
+   outcome is the most common mistake in choosing variables to condition on in estimating
+   average treatment effects using unconfoundedness approaches." The marketing case where
+   yes is credible: the targeting rule is known and observable (a campaign targeted on
+   demographics or behavior selects on observables by construction; AMA). Tiebreak: a
+   known DETERMINISTIC rule (treatment jumps at a cutoff on an observed score) is the rdd
+   case, question 3, not this branch; the observables branch needs probabilistic
+   assignment, since a deterministic rule makes every propensity 0 or 1 and leaves no
+   overlap to estimate on. Yes: the selection-on-observables branch below, owned by this
+   skill.
+3. If unconfoundedness is not plausible, look for structure in assignment:
+   - An incentive or cost shifter moves treatment with no direct path to the outcome: iv.
+     It identifies the LATE for compliers only; the ATE needs substantially stronger
+     assumptions, and the complier population is the focus because it is the only one
+     identifiable (Imbens).
+   - Treatment switches at a threshold on a running variable: rdd (fuzzy RD is IV at the
+     cutoff).
+   - Treatment switches on over time for some units with untreated comparisons: the panel
+     branch below, routed by data shape between did and synthetic-control.
+   - No structure at all: bounds and sensitivity analysis (the ladder below), or advise
+     against the causal claim. Estimate under the best defensible conditioning anyway and
+     report how much calibrated confounding overturns it, or report Manski bounds alone;
+     the sensitivity report, not the point estimate, is the deliverable.
+   - Marketing's regression-based endogeneity corrections (control functions, Gaussian
+     copulas; the third leaf of the AMA figure) sit outside this family's coverage: the iv
+     skill's exclusion and relevance discipline is the nearest relative, and copula
+     identification rests on distributional assumptions that need their own defense.
+
+## The panel branch: routing by data shape
+
+The AMA heuristic: DiD/SC-family methods match on outcomes (pretreatment paths),
+propensity-family methods match on covariates; pick the branch by which matching the data
+supports. Within outcomes-matching, crossed with the Arkhangelsky-Imbens (2024) three-axis
+taxonomy (data type, frame shape, assignment mechanism; did skill):
+
+- Many treated units, parallel trends plausible (only its pretreatment shadow is testable;
+  did owns the statement of which variant is imposed): did. Same-time adoption: TWFE is
+  fine; staggered: Callaway-Sant'Anna, Sun-Abraham, or stacked regression (whose implicit
+  weights carry a caveat in did), and justify the clean controls (AMA).
+- One or few treated aggregate units, long pre-period: synthetic-control (few treated
+  CLUSTERS of micro units with plausible parallel trends stay in did on its few-clusters
+  map). The AMA gate, both parts: plot treated vs fitted counterfactual and verify
+  pretreatment fit, AND run a backdating exercise; "only using the methods that satisfy
+  both best practices." Both parts are necessary, never sufficient: backdating assumes
+  strict exogeneity and backfires under selection on recent shocks, and
+  synthetic-control's fuller feasibility gate (pre-fit quality, T0 length, overfitting
+  screens) controls the final verdict.
+- The routing result between them: under selection on lagged outcomes with autocorrelated
+  errors, DiD is inconsistent while SC is consistent (Arkhangelsky-Hirshberg, via the
+  panel survey, Arkhangelsky and Imbens 2024). The DiD-to-SC-to-SDID decision path lives
+  in did and synthetic-control.
+- Data-shape fan-out when neither default fits (estimator details in synthetic-control's
+  extensions map): treated outcome outside the donor convex hull: augmented DiD (Li and
+  Van den Bulte 2023); outcome in range but too few pre-periods for SC: forward DiD (Li
+  2024); control units far fewer than pre-periods: HCW OLS (Hsiao, Ching, and Wan 2012);
+  many treated units or short panels: generalized synthetic control / factor models (Xu
+  2017) or matrix completion (Athey et al. 2021), with the warning that the gsynth
+  parametric bootstrap yields biased CIs, subsampling or the Li-Sonnier corrections
+  instead (Li and Sonnier 2023, via AMA); unit AND time reweighting wanted: synthetic DiD;
+  the inference-procedure-by-data-shape rules live in synthetic-control.
+
+## Selection on observables (the branch this skill owns)
+
+- Overlap before estimation, always: estimate the propensity score and look at its
+  distribution by arm. Violations move the ESTIMAND, not just the estimator: trim with the
+  variance-minimizing rule of Crump et al. (2009) (the 0.1/0.9 rule of thumb is its common
+  approximation) and report the retained population, or switch to overlap weights
+  e(x)(1-e(x)) (Li, Morgan, and Zaslavsky 2018), which target the population that could
+  plausibly receive either treatment.
+- Estimator default: doubly robust (AIPW; Bang and Robins 2005), "the most attractive" under
+  unconfoundedness with many covariates (Imbens): consistent if either the outcome model
+  or the propensity model is consistent, tolerates ML-rate nuisance estimation. In
+  practice: grf's causal forest with its built-in AIPW average effect, or double ML
+  (Chernozhukov et al. 2018) when you want explicit nuisance control. Plain regression or
+  matching are acceptable in low dimensions, with two caveats: fixed-number-of-matches
+  matching is never fully efficient and its bias does not vanish with many covariates
+  (Imbens), and marketing has moved off propensity score matching for its sensitivity to
+  parametric assumptions (AMA).
+- Weight by the ESTIMATED propensity score even when the true one is known; the true score
+  is inefficient (Hirano, Imbens, and Ridder 2003).
+- Heterogeneity has two different goals: describing CATEs (causal forest, Wager and Athey
+  2018, honest inference without prespecified subgroups) and deciding WHO to treat, which
+  is policy learning (Athey and Wager 2021; policytree), where the complexity of the
+  policy class is the key choice. Do not answer a targeting question with a CATE map.
+- Sensitivity analysis is mandatory, because unconfoundedness is untestable. The graded
+  ladder (details in references/details.md): Manski bounds (assumption-free, honest,
+  usually uninformative); calibrated confounder models (Rosenbaum and Rubin 1983, Imbens
+  2003, with Oster 2019 and Cinelli-Hazlett 2020 as the modern reporting standards;
+  sensemakr implements Cinelli-Hazlett); Rosenbaum design sensitivity (Rosenbaum 2002). An
+  estimate that flips under mild confounding indicts the design, not the estimator.
+
+## Rules shared across every design
+
+- Estimand first, subpopulation named: IV and fuzzy RDD identify complier effects; DiD and
+  SC identify the ATT of the treated units; overlap weighting identifies the overlap
+  population. The methods template forces the clause.
+- Clustering is a design property, not a data property (Abadie, Athey, Imbens, and
+  Wooldridge 2023): cluster standard errors at the level at which treatment was assigned
+  or the sample was drawn, and be able to say which; do not cluster by habit at whatever
+  level makes the panel.
+- Interference routing, by structure (designs, estimators, and diagnostics live in
+  field-experiment): clustered interference routes to two-stage randomization (Hudgens
+  and Halloran 2008, Crepon et al. 2013); network interference to exposure mappings
+  (Aronow and Samii 2017) with exact tests (Athey, Eckles, and Imbens 2018); marketplaces
+  and two-sided platforms to multiple randomization designs (Bajari et al. 2023, Johari
+  et al. 2022).
+- Combined experimental and observational data: the surrogate index for long-run outcomes
+  (retention, LTV) from short experiments, valid only when all causal paths from treatment
+  to the long-run outcome pass through the surrogates (Athey, Chetty, Imbens, and Kang
+  2026). The family ships no estimation template for the surrogate index; Athey, Chetty,
+  Imbens, and Kang's own empirical implementation is the recipe to follow, and the
+  router's deliverable stops at the validity argument.
+- Mediation (process evidence, treatment affecting the outcome through a mediator, natural
+  direct and indirect effects) has NO route in this family: sequential ignorability is an
+  assumption regime none of the family's skills carries. Where to go: Imai, Keele, and
+  Tingley (2010) for identification and sensitivity analysis, Pieters (2017) for the
+  marketing-native statement of what a mediation claim requires.
+
+## Implementation
+
+scripts/unconfoundedness_template.R is the runnable path for the branch this skill owns
+(overlap diagnostics and trimming, grf AIPW, CATE and policy learning, sensemakr
+sensitivity reporting), verified against package documentation. Package index with
+versions, links, and traps in references/details.md. Every other branch's code lives in
+the owning skill's template.
+
+## Methods paragraph template
+
+> Following the taxonomy in Imbens (2024), our setting is [randomized / observational with
+> a defensible unconfoundedness argument / observational with assignment structure X /
+> combined]. The assignment structure that identifies the effect is [structure], which
+> points to [estimator], identifying [estimand] for [subpopulation]. [Observables branch:]
+> We condition on [pretreatment covariates], none causally affected by treatment or
+> outcome; overlap is [assessed how, trimmed how, moving the estimand to whom]; estimation
+> is doubly robust [implementation]; and we report [Cinelli-Hazlett robustness values /
+> Oster's delta] against a confounder as strong as [benchmark covariate]. [Panel branch:]
+> Given [T treated units, K pre-periods], we use [method] per the data-shape criteria in
+> Li, Luo, and Pattabhiramaiah (2024). A limitation I accept: [the identifying assumption
+> this design rests on], stated where the choice is made, with its price named.
+
+Every claim traces to references/canon.md; keys live in references/causal.bib.
+
+## Handoffs
+
+- field-experiment: anything randomized, prospective experimental design, interference
+  analysis, power.
+- did: many treated units with timing variation; parallel-trends machinery.
+- synthetic-control: few treated units, long pre-periods; SDID; factor models and matrix
+  completion; the augmented/forward DiD and HCW conditions stated above.
+- rdd: thresholds on running variables; the design gate and falsification battery.
+- iv: instruments, shift-share, formula instruments; weak-instrument inference.
+- preregister: pre-analysis plans once the design is chosen (experiment-first skill;
+  quasi-experimental and measurement PAPs adapt its structure).

--- a/skills/causal-design/references/canon.md
+++ b/skills/causal-design/references/canon.md
@@ -1,0 +1,96 @@
+# Router canon
+
+Current as of 2026-07-28. These two sources are the only canon of the causal-design skill,
+hand-picked, and nothing enters this file without explicit human approval. BibTeX keys
+point into ./causal.bib, which is the one shared bib for the whole skill family. The
+router also leans on `arkhangelsky2024causal` (the three-axis panel taxonomy), a
+cross-reference owned by the did canon, and on `abadie2023clustering` (clustering as a
+design property): the family-wide clustering statement is owned by this skill's own
+SKILL.md, whose frontmatter claims the shared inference rules, while method skills carry
+design-specific instances. Refresh: run litreview on the moving corner (panel estimators)
+since the canon date. Any addendum needs explicit human approval.
+
+## Imbens (2024)
+
+Annual Review of Statistics and Its Application 11:123-152. Key: `imbens2024causal`.
+
+- Role: the assumptions-first spine of the triage. Each design is introduced by the
+  assumption that licenses it and the estimand it identifies; the review's structure is
+  itself the decision tree, and this skill adopts it nearly verbatim.
+- Settles: the assignment-based taxonomy (randomized / unconfounded-observational /
+  confounded-observational / combined data); doubly robust estimators as "the most
+  attractive" under unconfoundedness with many covariates (consistent if either nuisance
+  is, tolerate ML-rate convergence); weighting by the ESTIMATED propensity score beats the
+  true one (Hirano-Imbens-Ridder); fixed-match matching never fully efficient, bias
+  non-vanishing in high dimensions; IV identifies the LATE for compliers only, the ATE
+  needs substantially stronger assumptions; TWFE negative weights under staggered adoption
+  (points to the did canon); local linear over global polynomials in RDD; ex post
+  regression adjustment unbiased and precision-improving, design-stage covariate use
+  preferred; naive sample means from adaptive/bandit experiments are biased; overlap
+  violations move the estimand (Crump trimming, overlap weights); the graded sensitivity
+  ladder (Manski bounds, calibrated Rosenbaum-Rubin, Rosenbaum design sensitivity);
+  interference designs chosen by interference structure (clustered / network /
+  marketplace); the surrogate index for long-run outcomes.
+- Binds when: every triage; the selection-on-observables branch end to end; any
+  sensitivity-analysis request.
+- Scope limits: names no software at all; explicitly excludes dynamic treatment regimes
+  (Robins tradition).
+- Quote (verbatim in SKILL.md): "In practice, using variables causally affected by the
+  treatment or outcome is the most common mistake in choosing variables to condition on in
+  estimating average treatment effects using unconfoundedness approaches."
+
+## Li, Luo, and Pattabhiramaiah (2024)
+
+AMA Marketing News, 2024-11-20; no journal companion, the web page is the citable object.
+Key: `li2024quasiexperimental`.
+
+- Role: the marketing-native data-shape axis, complementary to Imbens' assumption axis.
+  Routes by number of treated units, pre-period length, covariate richness, treatment
+  timing; anchors every method to named JM/JMR/Marketing Science applications (exemplar
+  table in references/details.md).
+- Settles: the summary heuristic that DiD/SC-family methods match on outcomes while
+  propensity-family methods match on covariates, so the branch choice is which matching
+  your data supports; the staggered rule (same-time: TWFE; staggered: Callaway-Sant'Anna,
+  Sun-Abraham, or stacked regression, and justify the clean controls); the two MANDATORY
+  SC-family best practices, stated as a gate ("only using the methods that satisfy both
+  best practices"): pretreatment-fit plot and backdating (the family's adjudication adds a
+  strict-exogeneity caveat to backdating and hands the final verdict to synthetic-control's
+  fuller feasibility gate; SKILL.md carries it); the data-shape fan-out within the panel
+  branch: convex-hull failure -> augmented DiD (Li-Van den Bulte), outcome in range but
+  too few pre-periods -> forward DiD (Li), controls far fewer than pre-periods -> HCW OLS
+  (Hsiao-Ching-Wan), many treated units or short panels -> generalized synthetic control /
+  matrix completion, unit and time reweighting both wanted -> SDID with inference
+  procedure chosen by data shape; PSM "called into question," replaced by AIPW, double ML,
+  causal forests; unconfoundedness often defensible in marketing because targeting rules
+  are known and observable; the Li-Sonnier result that the gsynth parametric bootstrap
+  yields biased CIs ("false precision or false imprecision... lead to incorrect business
+  decisions"); the field vocabulary (design rigor vs statistical rigor, ATT-first, clean
+  controls).
+- Binds when: routing within the panel branch; arguing a method is accepted marketing
+  practice; writing for marketing reviewers.
+- Caveats: read via WebFetch extraction, so re-verify any quotation against the live page
+  before it enters a paper; two of the three authors developed the augmented/forward DiD
+  estimators, so the piece leans toward that family and the synth/did skills weigh those
+  methods independently; silent on RDD and nearly silent on IV, so it never covers the
+  confounded-observational branch beyond panel methods. Figure 1 ("Overview of Design
+  Choices in Quasi-Experimental Settings") was read against the article text on
+  2026-07-28. The figure is coarser than the article text (it lumps augmented DiD under
+  too-few-pre-periods where the text gives it the convex-hull condition; HCW and matrix
+  completion appear only in the text); where they differ, this skill follows the text.
+
+## Primary papers cited through the canon
+
+New to the bib with this skill: `hirano2003efficient` (estimated propensity score),
+`li2018balancing` (overlap weights), `bang2005doubly` (doubly robust), `athey2021policy`
+(policy learning), `aronow2017estimating` (exposure mappings), `bajari2023experimental` and
+`johari2022experimental` (marketplace designs), `athey2026surrogate` (the surrogate index,
+published REStud July 2026, no longer the NBER WP), the sensitivity ladder
+(`manski1990nonparametric`, `rosenbaum1983assessing`, `imbens2003sensitivity`,
+`oster2019unobservable`, `cinelli2020making`, `rosenbaum2002observational`), and the AMA
+panel family (`hsiao2012panel`, `li2020inference`, `li2023augmented`, `li2024forward`,
+`li2023statistical` for Li-Sonnier). Already in the bib from method skills and reused
+here: `crump2009dealing`, `wager2018estimation`, `chernozhukov2018double`,
+`xu2017generalized`, `athey2021matrix`, `crepon2013labor`, `hudgens2008toward`,
+`athey2018exact`, the did/rdd/synth canons. New with the mediation decline:
+`imai2010general` and `pieters2017meaningful`, decline pointers only, NOT canon (the
+router declines mediation and points to them; no skill carries the route).

--- a/skills/causal-design/references/causal.bib
+++ b/skills/causal-design/references/causal.bib
@@ -1,0 +1,1865 @@
+% Shared bibliography for the causal-inference skill family.
+% Every entry is resolver-verified (Crossref/OpenAlex via paper.py) at read time; nothing here
+% is typed from memory. Keys are stable; method skills reference them. Copy this file into a
+% project's Paper/ folder as needed. Current as of 2026-07-28. DiD entries below; other areas
+% get appended as their skills are built.
+
+@article{roth2023whats,
+  title   = {What's trending in difference-in-differences? A synthesis of the recent econometrics literature},
+  author  = {Roth, Jonathan and Sant'Anna, Pedro H. C. and Bilinski, Alyssa and Poe, John},
+  journal = {Journal of Econometrics},
+  year    = {2023},
+  volume  = {235},
+  number  = {2},
+  pages   = {2218--2244},
+  doi     = {10.1016/j.jeconom.2023.03.008}
+}
+
+@article{baker2026did,
+  title   = {Difference-in-Differences Designs: A Practitioner's Guide},
+  author  = {Baker, Andrew and Callaway, Brantly and Cunningham, Scott and Goodman-Bacon, Andrew and Sant'Anna, Pedro H. C.},
+  journal = {Journal of Economic Literature},
+  year    = {2026},
+  volume  = {64},
+  number  = {2},
+  pages   = {498--557},
+  doi     = {10.1257/jel.20251650}
+}
+
+@article{arkhangelsky2024causal,
+  author  = {Arkhangelsky, Dmitry and Imbens, Guido},
+  title   = {Causal Models for Longitudinal and Panel Data: A Survey},
+  journal = {The Econometrics Journal},
+  year    = {2024},
+  volume  = {27},
+  number  = {3},
+  pages   = {C1--C61},
+  doi     = {10.1093/ectj/utae014}
+}
+
+@techreport{abadie2025harvesting,
+  author      = {Abadie, Alberto and Angrist, Joshua and Frandsen, Brigham and Pischke, J{\"o}rn-Steffen},
+  title       = {Harvesting Differences-in-Differences and Event-Study Evidence},
+  institution = {National Bureau of Economic Research},
+  type        = {Working Paper},
+  number      = {34550},
+  year        = {2025},
+  month       = {12},
+  doi         = {10.3386/w34550}
+}
+
+% ---- DiD primary papers, resolver-verified 2026-07-28. Entries marked PREPRINT have no
+% ---- journal version yet; re-check them with bibcheck at manuscript time.
+
+% VoR
+@article{goodmanbacon2021timing,
+  author  = {Andrew Goodman-Bacon},
+  title   = {Difference-in-differences with variation in treatment timing},
+  journal = {Journal of Econometrics},
+  year    = {2021},
+  volume  = {225},
+  number  = {2},
+  pages   = {254--277},
+  doi     = {10.1016/j.jeconom.2021.03.014}
+}
+
+% VoR. Print year 2021 (online-first 2020).
+@article{callaway2021multiple,
+  author  = {Brantly Callaway and Pedro H. C. {Sant'Anna}},
+  title   = {Difference-in-Differences with multiple time periods},
+  journal = {Journal of Econometrics},
+  year    = {2021},
+  volume  = {225},
+  number  = {2},
+  pages   = {200--230},
+  doi     = {10.1016/j.jeconom.2020.12.001}
+}
+
+% VoR. Print year 2021 (online-first 2020).
+@article{sun2021dynamic,
+  author  = {Liyang Sun and Sarah Abraham},
+  title   = {Estimating dynamic treatment effects in event studies with heterogeneous treatment effects},
+  journal = {Journal of Econometrics},
+  year    = {2021},
+  volume  = {225},
+  number  = {2},
+  pages   = {175--199},
+  doi     = {10.1016/j.jeconom.2020.09.006}
+}
+
+% VoR
+@article{dechaisemartin2020twoway,
+  author  = {Cl{\'e}ment de Chaisemartin and Xavier {D'Haultf{\oe}uille}},
+  title   = {Two-Way Fixed Effects Estimators with Heterogeneous Treatment Effects},
+  journal = {American Economic Review},
+  year    = {2020},
+  volume  = {110},
+  number  = {9},
+  pages   = {2964--2996},
+  doi     = {10.1257/aer.20181169}
+}
+
+% VoR as of 2026-07-17 (ReStat 108(4)); supersedes NBER w29873 / "forthcoming" citations.
+@article{dechaisemartin2026intertemporal,
+  author  = {Cl{\'e}ment de Chaisemartin and Xavier {D'Haultf{\oe}uille}},
+  title   = {Difference-in-Differences Estimators of Intertemporal Treatment Effects},
+  journal = {Review of Economics and Statistics},
+  year    = {2026},
+  volume  = {108},
+  number  = {4},
+  pages   = {863--880},
+  doi     = {10.1162/rest_a_01414}
+}
+
+% VoR
+@article{borusyak2024revisiting,
+  author  = {Kirill Borusyak and Xavier Jaravel and Jann Spiess},
+  title   = {Revisiting Event-Study Designs: Robust and Efficient Estimation},
+  journal = {Review of Economic Studies},
+  year    = {2024},
+  volume  = {91},
+  number  = {6},
+  pages   = {3253--3285},
+  doi     = {10.1093/restud/rdae007}
+}
+
+% VoR. Supersedes the 2021 SSRN working paper (10.2139/ssrn.3906345).
+@article{wooldridge2025mundlak,
+  author  = {Jeffrey M. Wooldridge},
+  title   = {Two-way fixed effects, the two-way {Mundlak} regression, and difference-in-differences estimators},
+  journal = {Empirical Economics},
+  year    = {2025},
+  volume  = {69},
+  number  = {5},
+  pages   = {2545--2587},
+  doi     = {10.1007/s00181-025-02807-z}
+}
+
+% VoR
+@article{santanna2020doubly,
+  author  = {Pedro H. C. {Sant'Anna} and Jun Zhao},
+  title   = {Doubly robust difference-in-differences estimators},
+  journal = {Journal of Econometrics},
+  year    = {2020},
+  volume  = {219},
+  number  = {1},
+  pages   = {101--122},
+  doi     = {10.1016/j.jeconom.2020.06.003}
+}
+
+% VoR
+@article{rambachan2023credible,
+  author  = {Ashesh Rambachan and Jonathan Roth},
+  title   = {A More Credible Approach to Parallel Trends},
+  journal = {Review of Economic Studies},
+  year    = {2023},
+  volume  = {90},
+  number  = {5},
+  pages   = {2555--2591},
+  doi     = {10.1093/restud/rdad018}
+}
+
+% VoR
+@article{roth2022pretest,
+  author  = {Jonathan Roth},
+  title   = {Pretest with Caution: Event-Study Estimates after Testing for Parallel Trends},
+  journal = {American Economic Review: Insights},
+  year    = {2022},
+  volume  = {4},
+  number  = {3},
+  pages   = {305--322},
+  doi     = {10.1257/aeri.20210236}
+}
+
+% PREPRINT. Do not cite the SSRN/CESifo deposit (mangled author string). Distinct from the
+% authors' AEA P&P 2026 "When Should Pre-trends Be Parallel?" (10.1257/pandp.20261109).
+@misc{ghanem2022selection,
+  author        = {Dalia Ghanem and Pedro H. C. {Sant'Anna} and Kaspar W{\"u}thrich},
+  title         = {Selection and parallel trends},
+  year          = {2022},
+  note          = {arXiv:2203.09001; latest version July 2026},
+  eprint        = {2203.09001},
+  archiveprefix = {arXiv},
+  primaryclass  = {econ.EM},
+  doi           = {10.48550/arXiv.2203.09001}
+}
+
+% PREPRINT. The two-author covariates paper. The four-author "Time-Varying Covariates"
+% paper (arXiv:2202.02903) is a separate citation.
+@misc{caetano2024covariates,
+  author        = {Carolina Caetano and Brantly Callaway},
+  title         = {Difference-in-Differences when Parallel Trends Holds Conditional on Covariates},
+  year          = {2024},
+  note          = {arXiv:2406.15288; latest version June 2026},
+  eprint        = {2406.15288},
+  archiveprefix = {arXiv},
+  primaryclass  = {econ.EM},
+  doi           = {10.48550/arXiv.2406.15288}
+}
+
+% PREPRINT. No Crossref/OpenAlex/arXiv record; fields verified against the PDF title page.
+% R&R at Review of Economics and Statistics; the entry most likely to change.
+@techreport{harmon2022efficient,
+  author      = {Nikolaj A. Harmon},
+  title       = {Difference-in-Differences and Efficient Estimation of Treatment Effects},
+  institution = {University of Copenhagen},
+  year        = {2022},
+  note        = {Working paper; this version December 2024; R\&R, Review of Economics and Statistics},
+  url         = {https://web2.econ.ku.dk/nharmon/docs/harmon2022difference.pdf}
+}
+
+% PREPRINT
+@misc{chen2025efficient,
+  author        = {Xiaohong Chen and Pedro H. C. {Sant'Anna} and Haitian Xie},
+  title         = {Efficient Difference-in-Differences and Event Study Estimators},
+  year          = {2025},
+  note          = {arXiv:2506.17729},
+  eprint        = {2506.17729},
+  archiveprefix = {arXiv},
+  primaryclass  = {econ.EM},
+  doi           = {10.48550/arXiv.2506.17729}
+}
+
+% VoR
+@article{roth2023functional,
+  author  = {Jonathan Roth and Pedro H. C. {Sant'Anna}},
+  title   = {When Is Parallel Trends Sensitive to Functional Form?},
+  journal = {Econometrica},
+  year    = {2023},
+  volume  = {91},
+  number  = {2},
+  pages   = {737--747},
+  doi     = {10.3982/ECTA19402}
+}
+
+% VoR. Print year 2024 (online-first Dec 2023).
+@article{chen2024logs,
+  author  = {Jiafeng Chen and Jonathan Roth},
+  title   = {Logs with Zeros? Some Problems and Solutions},
+  journal = {The Quarterly Journal of Economics},
+  year    = {2024},
+  volume  = {139},
+  number  = {2},
+  pages   = {891--936},
+  doi     = {10.1093/qje/qjad054}
+}
+
+% VoR. Print year 2023 (advance access Oct 2022; resolvers stamp 2022).
+@article{abadie2023clustering,
+  author  = {Alberto Abadie and Susan Athey and Guido W. Imbens and Jeffrey M. Wooldridge},
+  title   = {When Should You Adjust Standard Errors for Clustering?},
+  journal = {The Quarterly Journal of Economics},
+  year    = {2023},
+  volume  = {138},
+  number  = {1},
+  pages   = {1--35},
+  doi     = {10.1093/qje/qjac038}
+}
+
+% PREPRINT. Not the did2s R Journal software paper. A revised version with Thakral, To,
+% and Yap circulates on the author's site and will likely become the published citation.
+@misc{gardner2022twostage,
+  author        = {John Gardner},
+  title         = {Two-stage differences in differences},
+  year          = {2022},
+  note          = {arXiv:2207.05943; revised version with Neil Thakral, Linh T{\^o}, and Luther Yap circulates},
+  eprint        = {2207.05943},
+  archiveprefix = {arXiv},
+  primaryclass  = {econ.EM},
+  doi           = {10.48550/arXiv.2207.05943}
+}
+
+% ============================ RDD =============================================
+% Canon (from reading notes) + primary papers, resolver-verified 2026-07-28.
+% All VoR; none preprint. Foundations Element: resolvers date it 2019, authors
+% self-cite 2020; we follow the resolvers.
+
+@article{cattaneo2022rdd,
+  author  = {Cattaneo, Matias D. and Titiunik, Roc{\'i}o},
+  title   = {Regression Discontinuity Designs},
+  journal = {Annual Review of Economics},
+  year    = {2022},
+  volume  = {14},
+  number  = {1},
+  pages   = {821--851},
+  doi     = {10.1146/annurev-economics-051520-021409}
+}
+
+@article{cattaneo2023guide,
+  author  = {Cattaneo, Matias D. and Keele, Luke and Titiunik, Roc{\'i}o},
+  title   = {A Guide to Regression Discontinuity Designs in Medical Applications},
+  journal = {Statistics in Medicine},
+  year    = {2023},
+  volume  = {42},
+  number  = {24},
+  pages   = {4484--4513},
+  doi     = {10.1002/sim.9861}
+}
+
+@article{calonico2014robust,
+  author  = {Calonico, Sebastian and Cattaneo, Matias D. and Titiunik, Roc{\'i}o},
+  title   = {Robust Nonparametric Confidence Intervals for Regression-Discontinuity Designs},
+  journal = {Econometrica},
+  year    = {2014},
+  volume  = {82},
+  number  = {6},
+  pages   = {2295--2326},
+  doi     = {10.3982/ECTA11757}
+}
+
+% Crossref truncates the third author to "Klaauw"; restored from the published byline.
+@article{hahn2001identification,
+  author  = {Hahn, Jinyong and Todd, Petra and {Van der Klaauw}, Wilbert},
+  title   = {Identification and Estimation of Treatment Effects with a Regression-Discontinuity Design},
+  journal = {Econometrica},
+  year    = {2001},
+  volume  = {69},
+  number  = {1},
+  pages   = {201--209},
+  doi     = {10.1111/1468-0262.00183}
+}
+
+@article{cattaneo2015randomization,
+  author  = {Cattaneo, Matias D. and Frandsen, Brigham R. and Titiunik, Roc{\'i}o},
+  title   = {Randomization Inference in the Regression Discontinuity Design: An Application to Party Advantages in the {U.S.} Senate},
+  journal = {Journal of Causal Inference},
+  year    = {2015},
+  volume  = {3},
+  number  = {1},
+  pages   = {1--24},
+  doi     = {10.1515/jci-2013-0010}
+}
+
+@article{cattaneo2020simple,
+  author  = {Cattaneo, Matias D. and Jansson, Michael and Ma, Xinwei},
+  title   = {Simple Local Polynomial Density Estimators},
+  journal = {Journal of the American Statistical Association},
+  year    = {2020},
+  volume  = {115},
+  number  = {531},
+  pages   = {1449--1455},
+  doi     = {10.1080/01621459.2019.1635480}
+}
+
+@article{mccrary2008manipulation,
+  author  = {McCrary, Justin},
+  title   = {Manipulation of the Running Variable in the Regression Discontinuity Design: A Density Test},
+  journal = {Journal of Econometrics},
+  year    = {2008},
+  volume  = {142},
+  number  = {2},
+  pages   = {698--714},
+  doi     = {10.1016/j.jeconom.2007.05.005}
+}
+
+@article{lee2008randomized,
+  author  = {Lee, David S.},
+  title   = {Randomized Experiments from Non-Random Selection in {U.S.} House Elections},
+  journal = {Journal of Econometrics},
+  year    = {2008},
+  volume  = {142},
+  number  = {2},
+  pages   = {675--697},
+  doi     = {10.1016/j.jeconom.2007.05.004}
+}
+
+@article{gelman2019polynomials,
+  author  = {Gelman, Andrew and Imbens, Guido},
+  title   = {Why High-Order Polynomials Should Not Be Used in Regression Discontinuity Designs},
+  journal = {Journal of Business \& Economic Statistics},
+  year    = {2019},
+  volume  = {37},
+  number  = {3},
+  pages   = {447--456},
+  doi     = {10.1080/07350015.2017.1366909}
+}
+
+@article{calonico2020bandwidth,
+  author  = {Calonico, Sebastian and Cattaneo, Matias D. and Farrell, Max H.},
+  title   = {Optimal Bandwidth Choice for Robust Bias-Corrected Inference in Regression Discontinuity Designs},
+  journal = {The Econometrics Journal},
+  year    = {2020},
+  volume  = {23},
+  number  = {2},
+  pages   = {192--210},
+  doi     = {10.1093/ectj/utz022}
+}
+
+@article{calonico2019covariates,
+  author  = {Calonico, Sebastian and Cattaneo, Matias D. and Farrell, Max H. and Titiunik, Roc{\'i}o},
+  title   = {Regression Discontinuity Designs Using Covariates},
+  journal = {The Review of Economics and Statistics},
+  year    = {2019},
+  volume  = {101},
+  number  = {3},
+  pages   = {442--451},
+  doi     = {10.1162/rest_a_00760}
+}
+
+@article{cattaneo2017comparing,
+  author  = {Cattaneo, Matias D. and Titiunik, Roc{\'i}o and Vazquez-Bare, Gonzalo},
+  title   = {Comparing Inference Approaches for {RD} Designs: A Reexamination of the Effect of {Head Start} on Child Mortality},
+  journal = {Journal of Policy Analysis and Management},
+  year    = {2017},
+  volume  = {36},
+  number  = {3},
+  pages   = {643--681},
+  doi     = {10.1002/pam.21985}
+}
+
+@article{cattaneo2019power,
+  author  = {Cattaneo, Matias D. and Titiunik, Roc{\'i}o and Vazquez-Bare, Gonzalo},
+  title   = {Power Calculations for Regression-Discontinuity Designs},
+  journal = {Stata Journal},
+  year    = {2019},
+  volume  = {19},
+  number  = {1},
+  pages   = {210--245},
+  doi     = {10.1177/1536867X19830919}
+}
+
+@article{card2015kink,
+  author  = {Card, David and Lee, David S. and Pei, Zhuan and Weber, Andrea},
+  title   = {Inference on Causal Effects in a Generalized Regression Kink Design},
+  journal = {Econometrica},
+  year    = {2015},
+  volume  = {83},
+  number  = {6},
+  pages   = {2453--2483},
+  doi     = {10.3982/ECTA11224}
+}
+
+@article{imbens2019optimized,
+  author  = {Imbens, Guido and Wager, Stefan},
+  title   = {Optimized Regression Discontinuity Designs},
+  journal = {The Review of Economics and Statistics},
+  year    = {2019},
+  volume  = {101},
+  number  = {2},
+  pages   = {264--278},
+  doi     = {10.1162/rest_a_00793}
+}
+
+@article{armstrong2020simple,
+  author  = {Armstrong, Timothy B. and Koles{\'a}r, Michal},
+  title   = {Simple and Honest Confidence Intervals in Nonparametric Regression},
+  journal = {Quantitative Economics},
+  year    = {2020},
+  volume  = {11},
+  number  = {1},
+  pages   = {1--39},
+  doi     = {10.3982/QE1199}
+}
+
+@article{armstrong2018optimal,
+  author  = {Armstrong, Timothy B. and Koles{\'a}r, Michal},
+  title   = {Optimal Inference in a Class of Regression Models},
+  journal = {Econometrica},
+  year    = {2018},
+  volume  = {86},
+  number  = {2},
+  pages   = {655--683},
+  doi     = {10.3982/ECTA14434}
+}
+
+@article{kolesar2018discrete,
+  author  = {Koles{\'a}r, Michal and Rothe, Christoph},
+  title   = {Inference in Regression Discontinuity Designs with a Discrete Running Variable},
+  journal = {American Economic Review},
+  year    = {2018},
+  volume  = {108},
+  number  = {8},
+  pages   = {2277--2304},
+  doi     = {10.1257/aer.20160945}
+}
+
+% Print-issue year 2022 (online-first 2021, which most citations use).
+@article{pei2022local,
+  author  = {Pei, Zhuan and Lee, David S. and Card, David and Weber, Andrea},
+  title   = {Local Polynomial Order in Regression Discontinuity Designs},
+  journal = {Journal of Business \& Economic Statistics},
+  year    = {2022},
+  volume  = {40},
+  number  = {3},
+  pages   = {1259--1267},
+  doi     = {10.1080/07350015.2021.1920961}
+}
+
+@book{cattaneo2019foundations,
+  author    = {Cattaneo, Matias D. and Idrobo, Nicol{\'a}s and Titiunik, Roc{\'i}o},
+  title     = {A Practical Introduction to Regression Discontinuity Designs: Foundations},
+  series    = {Elements in Quantitative and Computational Methods for the Social Sciences},
+  publisher = {Cambridge University Press},
+  year      = {2019},
+  doi       = {10.1017/9781108684606}
+}
+
+@book{cattaneo2024extensions,
+  author    = {Cattaneo, Matias D. and Idrobo, Nicol{\'a}s and Titiunik, Roc{\'i}o},
+  title     = {A Practical Introduction to Regression Discontinuity Designs: Extensions},
+  series    = {Elements in Quantitative and Computational Methods for the Social Sciences},
+  publisher = {Cambridge University Press},
+  year      = {2024},
+  doi       = {10.1017/9781009441896}
+}
+
+@article{ludwig2007head,
+  author  = {Ludwig, Jens and Miller, Douglas L.},
+  title   = {Does {Head Start} Improve Children's Life Chances? {E}vidence from a Regression Discontinuity Design},
+  journal = {The Quarterly Journal of Economics},
+  year    = {2007},
+  volume  = {122},
+  number  = {1},
+  pages   = {159--208},
+  doi     = {10.1162/qjec.122.1.159}
+}
+
+@article{calonico2015plots,
+  author  = {Calonico, Sebastian and Cattaneo, Matias D. and Titiunik, Roc{\'i}o},
+  title   = {Optimal Data-Driven Regression Discontinuity Plots},
+  journal = {Journal of the American Statistical Association},
+  year    = {2015},
+  volume  = {110},
+  number  = {512},
+  pages   = {1753--1769},
+  doi     = {10.1080/01621459.2015.1017578}
+}
+
+@article{hartman2021equivalence,
+  author  = {Hartman, Erin},
+  title   = {Equivalence Testing for Regression Discontinuity Designs},
+  journal = {Political Analysis},
+  year    = {2021},
+  volume  = {29},
+  number  = {4},
+  pages   = {505--521},
+  doi     = {10.1017/pan.2020.43}
+}
+
+% ---- iv ----
+% Canon (from reading notes) + primary papers, resolver-verified 2026-07-28.
+% One PREPRINT (jaeger2018shift); everything else VoR.
+
+% Crossref and OpenAlex omit the page range; 323--358 restored from Project Euclid.
+@article{imbens2014instrumental,
+  author  = {Imbens, Guido W.},
+  title   = {Instrumental Variables: An Econometrician's Perspective},
+  journal = {Statistical Science},
+  year    = {2014},
+  volume  = {29},
+  number  = {3},
+  pages   = {323--358},
+  doi     = {10.1214/14-STS480}
+}
+
+@article{keane2024practical,
+  author  = {Keane, Michael P. and Neal, Timothy},
+  title   = {A Practical Guide to Weak Instruments},
+  journal = {Annual Review of Economics},
+  year    = {2024},
+  volume  = {16},
+  number  = {1},
+  pages   = {185--212},
+  doi     = {10.1146/annurev-economics-092123-111021}
+}
+
+@article{borusyak2025practical,
+  author  = {Borusyak, Kirill and Hull, Peter and Jaravel, Xavier},
+  title   = {A Practical Guide to Shift-Share Instruments},
+  journal = {Journal of Economic Perspectives},
+  year    = {2025},
+  volume  = {39},
+  number  = {1},
+  pages   = {181--204},
+  doi     = {10.1257/jep.20231370}
+}
+
+@article{borusyak2023nonrandom,
+  author  = {Borusyak, Kirill and Hull, Peter},
+  title   = {Nonrandom Exposure to Exogenous Shocks},
+  journal = {Econometrica},
+  year    = {2023},
+  volume  = {91},
+  number  = {6},
+  pages   = {2155--2185},
+  doi     = {10.3982/ECTA19367}
+}
+
+% ---- IV primary papers, alphabetical by key ----
+
+@article{adao2019shift,
+  author  = {Ad{\~a}o, Rodrigo and Koles{\'a}r, Michal and Morales, Eduardo},
+  title   = {Shift-Share Designs: Theory and Inference},
+  journal = {The Quarterly Journal of Economics},
+  year    = {2019},
+  volume  = {134},
+  number  = {4},
+  pages   = {1949--2010},
+  doi     = {10.1093/qje/qjz025}
+}
+
+@article{anderson1949estimation,
+  author  = {Anderson, T. W. and Rubin, Herman},
+  title   = {Estimation of the Parameters of a Single Equation in a Complete System of Stochastic Equations},
+  journal = {The Annals of Mathematical Statistics},
+  year    = {1949},
+  volume  = {20},
+  number  = {1},
+  pages   = {46--63},
+  doi     = {10.1214/aoms/1177730090}
+}
+
+@article{andrews2019weak,
+  author  = {Andrews, Isaiah and Stock, James H. and Sun, Liyang},
+  title   = {Weak Instruments in Instrumental Variables Regression: Theory and Practice},
+  journal = {Annual Review of Economics},
+  year    = {2019},
+  volume  = {11},
+  number  = {1},
+  pages   = {727--753},
+  doi     = {10.1146/annurev-economics-080218-025643}
+}
+
+@article{angrist1991does,
+  author  = {Angrist, Joshua D. and Krueger, Alan B.},
+  title   = {Does Compulsory School Attendance Affect Schooling and Earnings?},
+  journal = {The Quarterly Journal of Economics},
+  year    = {1991},
+  volume  = {106},
+  number  = {4},
+  pages   = {979--1014},
+  doi     = {10.2307/2937954}
+}
+
+% Cited via the Taylor & Francis record; the JSTOR 10.2307 deposit is not in Crossref.
+@article{angrist1996identification,
+  author  = {Angrist, Joshua D. and Imbens, Guido W. and Rubin, Donald B.},
+  title   = {Identification of Causal Effects Using Instrumental Variables},
+  journal = {Journal of the American Statistical Association},
+  year    = {1996},
+  volume  = {91},
+  number  = {434},
+  pages   = {444--455},
+  doi     = {10.1080/01621459.1996.10476902}
+}
+
+% Crossref stores initials only; full names as on the published byline.
+@article{angrist1999jackknife,
+  author  = {Angrist, Joshua D. and Imbens, Guido W. and Krueger, Alan B.},
+  title   = {Jackknife instrumental variables estimation},
+  journal = {Journal of Applied Econometrics},
+  year    = {1999},
+  volume  = {14},
+  number  = {1},
+  pages   = {57--67},
+  doi     = {10.1002/(SICI)1099-1255(199901/02)14:1<57::AID-JAE501>3.0.CO;2-G}
+}
+
+% Article 105398; Crossref records the article number in the page field.
+@article{angrist2024one,
+  author  = {Angrist, Joshua and Koles{\'a}r, Michal},
+  title   = {One instrument to rule them all: The bias and coverage of just-{ID} {IV}},
+  journal = {Journal of Econometrics},
+  year    = {2024},
+  volume  = {240},
+  number  = {2},
+  pages   = {105398},
+  doi     = {10.1016/j.jeconom.2022.12.012}
+}
+
+@article{autor2013china,
+  author  = {Autor, David H. and Dorn, David and Hanson, Gordon H.},
+  title   = {The {China} Syndrome: Local Labor Market Effects of Import Competition in the {United States}},
+  journal = {American Economic Review},
+  year    = {2013},
+  volume  = {103},
+  number  = {6},
+  pages   = {2121--2168},
+  doi     = {10.1257/aer.103.6.2121}
+}
+
+@article{balke1997bounds,
+  author  = {Balke, Alexander and Pearl, Judea},
+  title   = {Bounds on Treatment Effects from Studies with Imperfect Compliance},
+  journal = {Journal of the American Statistical Association},
+  year    = {1997},
+  volume  = {92},
+  number  = {439},
+  pages   = {1171--1176},
+  doi     = {10.1080/01621459.1997.10474074}
+}
+
+% Crossref's publisher string is "W.E. Upjohn Institute", without "for Employment Research".
+@book{bartik1991who,
+  author    = {Bartik, Timothy J.},
+  title     = {Who Benefits from State and Local Economic Development Policies?},
+  publisher = {W.E. Upjohn Institute},
+  year      = {1991},
+  doi       = {10.17848/9780585223940}
+}
+
+% JSTOR deposit gives only the first page; range from Semantic Scholar.
+@article{bekker1994alternative,
+  author  = {Bekker, Paul A.},
+  title   = {Alternative Approximations to the Distributions of Instrumental Variable Estimators},
+  journal = {Econometrica},
+  year    = {1994},
+  volume  = {62},
+  number  = {3},
+  pages   = {657--681},
+  doi     = {10.2307/2951662}
+}
+
+% Print year 2022 (online-first 2021, which resolvers stamp).
+@article{borusyak2022quasi,
+  author  = {Borusyak, Kirill and Hull, Peter and Jaravel, Xavier},
+  title   = {Quasi-Experimental Shift-Share Research Designs},
+  journal = {Review of Economic Studies},
+  year    = {2022},
+  volume  = {89},
+  number  = {1},
+  pages   = {181--213},
+  doi     = {10.1093/restud/rdab030}
+}
+
+% Cited via the Taylor & Francis record; the JSTOR deposit misspells "Endogeneous".
+@article{bound1995problems,
+  author  = {Bound, John and Jaeger, David A. and Baker, Regina M.},
+  title   = {Problems with Instrumental Variables Estimation when the Correlation between the Instruments and the Endogenous Explanatory Variable is Weak},
+  journal = {Journal of the American Statistical Association},
+  year    = {1995},
+  volume  = {90},
+  number  = {430},
+  pages   = {443--450},
+  doi     = {10.1080/01621459.1995.10476536}
+}
+
+% The Ely Lecture (AEA Papers and Proceedings issue).
+@article{card2009immigration,
+  author  = {Card, David},
+  title   = {Immigration and Inequality},
+  journal = {American Economic Review},
+  year    = {2009},
+  volume  = {99},
+  number  = {2},
+  pages   = {1--21},
+  doi     = {10.1257/aer.99.2.1}
+}
+
+% Crossref stores initials only; full names from the published byline and the NBER deposit (w5052).
+@article{currie1996health,
+  author  = {Currie, Janet and Gruber, Jonathan},
+  title   = {Health Insurance Eligibility, Utilization of Medical Care, and Child Health},
+  journal = {The Quarterly Journal of Economics},
+  year    = {1996},
+  volume  = {111},
+  number  = {2},
+  pages   = {431--466},
+  doi     = {10.2307/2946684}
+}
+
+% JSTOR deposit gives only the first page; 1365--1388 from RePEc and Semantic Scholar.
+@article{dufour1997some,
+  author  = {Dufour, Jean-Marie},
+  title   = {Some Impossibility Theorems in Econometrics with Applications to Structural and Dynamic Models},
+  journal = {Econometrica},
+  year    = {1997},
+  volume  = {65},
+  number  = {6},
+  pages   = {1365--1388},
+  doi     = {10.2307/2171740}
+}
+
+@article{goldsmithpinkham2020bartik,
+  author  = {Goldsmith-Pinkham, Paul and Sorkin, Isaac and Swift, Henry},
+  title   = {{Bartik} Instruments: What, When, Why, and How},
+  journal = {American Economic Review},
+  year    = {2020},
+  volume  = {110},
+  number  = {8},
+  pages   = {2586--2624},
+  doi     = {10.1257/aer.20181047}
+}
+
+@article{hausman2012instrumental,
+  author  = {Hausman, Jerry A. and Newey, Whitney K. and Woutersen, Tiemen and Chao, John C. and Swanson, Norman R.},
+  title   = {Instrumental variable estimation with heteroskedasticity and many instruments},
+  journal = {Quantitative Economics},
+  year    = {2012},
+  volume  = {3},
+  number  = {2},
+  pages   = {211--255},
+  doi     = {10.3982/QE89}
+}
+
+% JSTOR deposit gives only the first page; range from RePEc.
+@article{imbens1994identification,
+  author  = {Imbens, Guido W. and Angrist, Joshua D.},
+  title   = {Identification and Estimation of Local Average Treatment Effects},
+  journal = {Econometrica},
+  year    = {1994},
+  volume  = {62},
+  number  = {2},
+  pages   = {467--475},
+  doi     = {10.2307/2951620}
+}
+
+% Crossref stores initials only; full names as on the published byline.
+@article{imbens1997estimating,
+  author  = {Imbens, Guido W. and Rubin, Donald B.},
+  title   = {Estimating Outcome Distributions for Compliers in Instrumental Variables Models},
+  journal = {Review of Economic Studies},
+  year    = {1997},
+  volume  = {64},
+  number  = {4},
+  pages   = {555--574},
+  doi     = {10.2307/2971731}
+}
+
+% PREPRINT. No journal version as of 2026-07-28; Crossref shows only the NBER and SSRN deposits.
+@techreport{jaeger2018shift,
+  author      = {Jaeger, David and Ruist, Joakim and Stuhler, Jan},
+  title       = {Shift-Share Instruments and the Impact of Immigration},
+  institution = {National Bureau of Economic Research},
+  type        = {Working Paper},
+  number      = {24285},
+  year        = {2018},
+  month       = {2},
+  doi         = {10.3386/w24285}
+}
+
+@article{keane2023instrument,
+  author  = {Keane, Michael and Neal, Timothy},
+  title   = {Instrument strength in {IV} estimation and inference: A guide to theory and practice},
+  journal = {Journal of Econometrics},
+  year    = {2023},
+  volume  = {235},
+  number  = {2},
+  pages   = {1625--1653},
+  doi     = {10.1016/j.jeconom.2022.12.009}
+}
+
+@article{kleibergen2005testing,
+  author  = {Kleibergen, Frank},
+  title   = {Testing Parameters in {GMM} Without Assuming that They Are Identified},
+  journal = {Econometrica},
+  year    = {2005},
+  volume  = {73},
+  number  = {4},
+  pages   = {1103--1123},
+  doi     = {10.1111/j.1468-0262.2005.00610.x}
+}
+
+@article{kolesar2015identification,
+  author  = {Koles{\'a}r, Michal and Chetty, Raj and Friedman, John and Glaeser, Edward and Imbens, Guido W.},
+  title   = {Identification and Inference With Many Invalid Instruments},
+  journal = {Journal of Business \& Economic Statistics},
+  year    = {2015},
+  volume  = {33},
+  number  = {4},
+  pages   = {474--484},
+  doi     = {10.1080/07350015.2014.978175}
+}
+
+@article{lee2022valid,
+  author  = {Lee, David S. and McCrary, Justin and Moreira, Marcelo J. and Porter, Jack},
+  title   = {Valid t-Ratio Inference for {IV}},
+  journal = {American Economic Review},
+  year    = {2022},
+  volume  = {112},
+  number  = {10},
+  pages   = {3260--3290},
+  doi     = {10.1257/aer.20211063}
+}
+
+@article{mogstad2021causal,
+  author  = {Mogstad, Magne and Torgovitsky, Alexander and Walters, Christopher R.},
+  title   = {The Causal Interpretation of Two-Stage Least Squares with Multiple Instrumental Variables},
+  journal = {American Economic Review},
+  year    = {2021},
+  volume  = {111},
+  number  = {11},
+  pages   = {3663--3698},
+  doi     = {10.1257/aer.20190221}
+}
+
+% The registered DOI carries Taylor & Francis's Technometrics stem (00401706); the
+% often-cited 10.1080/07350015.2013.806694 form does not resolve.
+@article{montielolea2013robust,
+  author  = {{Montiel Olea}, Jos{\'e} Luis and Pflueger, Carolin},
+  title   = {A Robust Test for Weak Instruments},
+  journal = {Journal of Business \& Economic Statistics},
+  year    = {2013},
+  volume  = {31},
+  number  = {3},
+  pages   = {358--369},
+  doi     = {10.1080/00401706.2013.806694}
+}
+
+@article{moreira2003conditional,
+  author  = {Moreira, Marcelo J.},
+  title   = {A Conditional Likelihood Ratio Test for Structural Models},
+  journal = {Econometrica},
+  year    = {2003},
+  volume  = {71},
+  number  = {4},
+  pages   = {1027--1048},
+  doi     = {10.1111/1468-0262.00438}
+}
+
+@article{moreira2009tests,
+  author  = {Moreira, Marcelo J.},
+  title   = {Tests with correct size when instruments can be arbitrarily weak},
+  journal = {Journal of Econometrics},
+  year    = {2009},
+  volume  = {152},
+  number  = {2},
+  pages   = {131--140},
+  doi     = {10.1016/j.jeconom.2009.01.012}
+}
+
+@article{moreira2019optimal,
+  author  = {Moreira, Humberto and Moreira, Marcelo J.},
+  title   = {Optimal two-sided tests for instrumental variables regression with heteroskedastic and autocorrelated errors},
+  journal = {Journal of Econometrics},
+  year    = {2019},
+  volume  = {213},
+  number  = {2},
+  pages   = {398--433},
+  doi     = {10.1016/j.jeconom.2019.04.038}
+}
+
+% JSTOR deposit gives only the first page; range from RePEc.
+@article{staiger1997instrumental,
+  author  = {Staiger, Douglas and Stock, James H.},
+  title   = {Instrumental Variables Regression with Weak Instruments},
+  journal = {Econometrica},
+  year    = {1997},
+  volume  = {65},
+  number  = {3},
+  pages   = {557--586},
+  doi     = {10.2307/2171753}
+}
+
+% Article 104112; no issue number.
+@article{young2022consistency,
+  author  = {Young, Alwyn},
+  title   = {Consistency without Inference: Instrumental Variables in Practical Application},
+  journal = {European Economic Review},
+  year    = {2022},
+  volume  = {147},
+  pages   = {104112},
+  doi     = {10.1016/j.euroecorev.2022.104112}
+}
+
+% ---- synthetic-control ----
+% Canon (from reading notes) + primary papers, resolver-verified 2026-07-28 against Crossref,
+% with OpenAlex / Semantic Scholar / JMLR used only to fill page ranges Crossref omits (noted
+% per entry). One PREPRINT (doudchenko2016balancing); everything else VoR. Print-issue year
+% rule applied: abadie2015comparative, liu2024practical, and klossner2018comparative all carry
+% their print year, not the online-first year resolvers stamp.
+
+@article{abadie2021using,
+  author  = {Abadie, Alberto},
+  title   = {Using Synthetic Controls: Feasibility, Data Requirements, and Methodological Aspects},
+  journal = {Journal of Economic Literature},
+  year    = {2021},
+  volume  = {59},
+  number  = {2},
+  pages   = {391--425},
+  doi     = {10.1257/jel.20191450}
+}
+
+% ---- Synthetic-control primary papers, alphabetical by key ----
+
+@article{abadie2003economic,
+  author  = {Abadie, Alberto and Gardeazabal, Javier},
+  title   = {The Economic Costs of Conflict: A Case Study of the {Basque Country}},
+  journal = {American Economic Review},
+  year    = {2003},
+  volume  = {93},
+  number  = {1},
+  pages   = {113--132},
+  doi     = {10.1257/000282803321455188}
+}
+
+@article{abadie2010synthetic,
+  author  = {Abadie, Alberto and Diamond, Alexis and Hainmueller, Jens},
+  title   = {Synthetic Control Methods for Comparative Case Studies: Estimating the Effect of {California}'s Tobacco Control Program},
+  journal = {Journal of the American Statistical Association},
+  year    = {2010},
+  volume  = {105},
+  number  = {490},
+  pages   = {493--505},
+  doi     = {10.1198/jasa.2009.ap08746}
+}
+
+% Print year 2015 (online-first April 2014, which resolvers stamp as the issued date).
+@article{abadie2015comparative,
+  author  = {Abadie, Alberto and Diamond, Alexis and Hainmueller, Jens},
+  title   = {Comparative Politics and the Synthetic Control Method},
+  journal = {American Journal of Political Science},
+  year    = {2015},
+  volume  = {59},
+  number  = {2},
+  pages   = {495--510},
+  doi     = {10.1111/ajps.12116}
+}
+
+% VoR. Supersedes the 2019 working paper; the JASA synthetic-control special section (116(536)).
+@article{abadie2021penalized,
+  author  = {Abadie, Alberto and {L'Hour}, J{\'e}r{\'e}my},
+  title   = {A Penalized Synthetic Control Estimator for Disaggregated Data},
+  journal = {Journal of the American Statistical Association},
+  year    = {2021},
+  volume  = {116},
+  number  = {536},
+  pages   = {1817--1834},
+  doi     = {10.1080/01621459.2021.1971535}
+}
+
+% JMLR has no Crossref DOI for this paper; volume, article number, and pages taken from the
+% JMLR v19 landing page (19(22):1-51). The 10.5555 stem in OpenAlex is an ACM DL mirror.
+@article{amjad2018robust,
+  author  = {Amjad, Muhammad and Shah, Devavrat and Shen, Dennis},
+  title   = {Robust Synthetic Control},
+  journal = {Journal of Machine Learning Research},
+  year    = {2018},
+  volume  = {19},
+  number  = {22},
+  pages   = {1--51},
+  url     = {https://www.jmlr.org/papers/v19/17-777.html}
+}
+
+% VoR. Supersedes NBER w25532 (2019), which is the working paper most citations still use.
+@article{arkhangelsky2021synthetic,
+  author  = {Arkhangelsky, Dmitry and Athey, Susan and Hirshberg, David A. and Imbens, Guido W. and Wager, Stefan},
+  title   = {Synthetic Difference-in-Differences},
+  journal = {American Economic Review},
+  year    = {2021},
+  volume  = {111},
+  number  = {12},
+  pages   = {4088--4118},
+  doi     = {10.1257/aer.20190159}
+}
+
+@article{athey2017state,
+  author  = {Athey, Susan and Imbens, Guido W.},
+  title   = {The State of Applied Econometrics: Causality and Policy Evaluation},
+  journal = {Journal of Economic Perspectives},
+  year    = {2017},
+  volume  = {31},
+  number  = {2},
+  pages   = {3--32},
+  doi     = {10.1257/jep.31.2.3}
+}
+
+% VoR. Supersedes NBER w25132 (2018).
+@article{athey2021matrix,
+  author  = {Athey, Susan and Bayati, Mohsen and Doudchenko, Nikolay and Imbens, Guido and Khosravi, Khashayar},
+  title   = {Matrix Completion Methods for Causal Panel Data Models},
+  journal = {Journal of the American Statistical Association},
+  year    = {2021},
+  volume  = {116},
+  number  = {536},
+  pages   = {1716--1730},
+  doi     = {10.1080/01621459.2021.1891924}
+}
+
+% VoR. Supersedes NBER w28885 and the SSRN deposit (10.2139/ssrn.3861414).
+@article{benmichael2021augmented,
+  author  = {Ben-Michael, Eli and Feller, Avi and Rothstein, Jesse},
+  title   = {The Augmented Synthetic Control Method},
+  journal = {Journal of the American Statistical Association},
+  year    = {2021},
+  volume  = {116},
+  number  = {536},
+  pages   = {1789--1803},
+  doi     = {10.1080/01621459.2021.1929245}
+}
+
+% Crossref and OpenAlex omit the page range; 247--274 from Semantic Scholar (Project Euclid issue).
+@article{brodersen2015inferring,
+  author  = {Brodersen, Kay H. and Gallusser, Fabian and Koehler, Jim and Remy, Nicolas and Scott, Steven L.},
+  title   = {Inferring causal impact using {Bayesian} structural time-series models},
+  journal = {The Annals of Applied Statistics},
+  year    = {2015},
+  volume  = {9},
+  number  = {1},
+  pages   = {247--274},
+  doi     = {10.1214/14-AOAS788}
+}
+
+% Crossref drops the accent in the last author's given name; Roc{\'i}o restored from the byline.
+@article{cattaneo2021prediction,
+  author  = {Cattaneo, Matias D. and Feng, Yingjie and Titiunik, Roc{\'i}o},
+  title   = {Prediction Intervals for Synthetic Control Methods},
+  journal = {Journal of the American Statistical Association},
+  year    = {2021},
+  volume  = {116},
+  number  = {536},
+  pages   = {1865--1880},
+  doi     = {10.1080/01621459.2021.1979561}
+}
+
+% VoR. Supersedes the cemmap working paper (10.1920/wp.cem.2017.6217), whose deposit also
+% truncates the third author to "Yu Zhu"; the published byline is Yinchu Zhu.
+@article{chernozhukov2021exact,
+  author  = {Chernozhukov, Victor and W{\"u}thrich, Kaspar and Zhu, Yinchu},
+  title   = {An Exact and Robust Conformal Inference Method for Counterfactual and Synthetic Controls},
+  journal = {Journal of the American Statistical Association},
+  year    = {2021},
+  volume  = {116},
+  number  = {536},
+  pages   = {1849--1864},
+  doi     = {10.1080/01621459.2021.1920957}
+}
+
+% PREPRINT. No journal version as of 2026-07-28; Crossref and OpenAlex show only the NBER
+% deposit and an arXiv preprint (arXiv:1610.07748).
+@techreport{doudchenko2016balancing,
+  author      = {Doudchenko, Nikolay and Imbens, Guido W.},
+  title       = {Balancing, Regression, Difference-in-Differences and Synthetic Control Methods: A Synthesis},
+  institution = {National Bureau of Economic Research},
+  type        = {Working Paper},
+  number      = {22791},
+  year        = {2016},
+  month       = {10},
+  doi         = {10.3386/w22791}
+}
+
+% Crossref registers the DOI lowercase (10.3982/qe1596); the uppercase form used here is the
+% publisher's canonical string and resolves identically.
+@article{ferman2021synthetic,
+  author  = {Ferman, Bruno and Pinto, Cristine},
+  title   = {Synthetic controls with imperfect pretreatment fit},
+  journal = {Quantitative Economics},
+  year    = {2021},
+  volume  = {12},
+  number  = {4},
+  pages   = {1197--1221},
+  doi     = {10.3982/QE1596}
+}
+
+% Article 20160026; De Gruyter assigns no page range and Crossref stores the article number
+% in its own field rather than in "page".
+@article{firpo2018synthetic,
+  author  = {Firpo, Sergio and Possebom, Vitor},
+  title   = {Synthetic Control Method: Inference, Sensitivity Analysis and Confidence Sets},
+  journal = {Journal of Causal Inference},
+  year    = {2018},
+  volume  = {6},
+  number  = {2},
+  pages   = {20160026},
+  doi     = {10.1515/jci-2016-0026}
+}
+
+% Title corrected: the paper is about "Social Programs: The Case of Manpower Training", not
+% "Training Programs". The JSTOR deposits at 10.2307/2290060--2290062 are the comments and
+% the rejoinder, not the article.
+@article{heckman1989choosing,
+  author  = {Heckman, James J. and Hotz, V. Joseph},
+  title   = {Choosing among Alternative Nonexperimental Methods for Estimating the Impact of Social Programs: The Case of Manpower Training},
+  journal = {Journal of the American Statistical Association},
+  year    = {1989},
+  volume  = {84},
+  number  = {408},
+  pages   = {862--874},
+  doi     = {10.1080/01621459.1989.10478848}
+}
+
+% Article 11; no page range. Print issue December 2018 (online-first May 2018).
+@article{klossner2018comparative,
+  author  = {Kl{\"o}{\ss}ner, Stefan and Kaul, Ashok and Pfeifer, Gregor and Schieler, Manuel},
+  title   = {Comparative politics and the synthetic control method revisited: a note on {Abadie} et al. (2015)},
+  journal = {Swiss Journal of Economics and Statistics},
+  year    = {2018},
+  volume  = {154},
+  number  = {1},
+  pages   = {11},
+  doi     = {10.1186/s41937-017-0004-9}
+}
+
+% VoR. Print year 2024 (online-first August 2022, which resolvers stamp). Supersedes the
+% SSRN working paper (10.2139/ssrn.3555463).
+@article{liu2024practical,
+  author  = {Liu, Licheng and Wang, Ye and Xu, Yiqing},
+  title   = {A Practical Guide to Counterfactual Estimators for Causal Inference with Time-Series Cross-Sectional Data},
+  journal = {American Journal of Political Science},
+  year    = {2024},
+  volume  = {68},
+  number  = {1},
+  pages   = {160--176},
+  doi     = {10.1111/ajps.12723}
+}
+
+@article{xu2017generalized,
+  author  = {Xu, Yiqing},
+  title   = {Generalized Synthetic Control Method: Causal Inference with Interactive Fixed Effects Models},
+  journal = {Political Analysis},
+  year    = {2017},
+  volume  = {25},
+  number  = {1},
+  pages   = {57--76},
+  doi     = {10.1017/pan.2016.2}
+}
+
+% ---- field-experiment ----
+% Canon (from reading notes) + primary papers, resolver-verified 2026-07-28 against Crossref,
+% with OpenAlex, Project Euclid, and IMS arXiv journal-refs used only to fill fields Crossref
+% omits (noted per entry). No PREPRINTs: semenova2025generalized is published as "Generalized Lee
+% bounds" (Journal of Econometrics 251, 2025). Print-issue year rule applied: guo2023generalized,
+% cohen2024noharm, ye2023toward, and young2019channeling carry their print year, not the
+% online-first year resolvers stamp. Also cited by this area but already defined above (not
+% duplicated here): abadie2023clustering, imbens1994identification, angrist1996identification,
+% balke1997bounds, imbens1997estimating, lee2008randomized.
+
+% Crossref's chapter record carries no authors, editors, or volume; authors restored from
+% OpenAlex. Pages 73--140 are from Crossref itself; everything Crossref omits stays omitted.
+@incollection{athey2017econometrics,
+  author    = {Athey, Susan and Imbens, Guido W.},
+  title     = {The Econometrics of Randomized Experiments},
+  booktitle = {Handbook of Economic Field Experiments},
+  publisher = {Elsevier},
+  year      = {2017},
+  pages     = {73--140},
+  doi       = {10.1016/bs.hefe.2016.10.003}
+}
+
+% Crossref and OpenAlex omit the page range; 237--249 from the Project Euclid landing page.
+@article{freedman2008logistic,
+  author  = {Freedman, David A.},
+  title   = {Randomization Does Not Justify Logistic Regression},
+  journal = {Statistical Science},
+  year    = {2008},
+  volume  = {23},
+  number  = {2},
+  pages   = {237--249},
+  doi     = {10.1214/08-STS262}
+}
+
+% Crossref and OpenAlex omit the page range; 295--318 from the IMS journal-ref on
+% arXiv:1208.2301, matching the Project Euclid landing page.
+@article{lin2013agnostic,
+  author  = {Lin, Winston},
+  title   = {Agnostic notes on regression adjustments to experimental data: Reexamining {Freedman}'s critique},
+  journal = {The Annals of Applied Statistics},
+  year    = {2013},
+  volume  = {7},
+  number  = {1},
+  pages   = {295--318},
+  doi     = {10.1214/12-AOAS583}
+}
+
+% Print year 2023 (online-first July 2021, which resolvers stamp).
+@article{guo2023generalized,
+  author  = {Guo, Kevin and Basse, Guillaume},
+  title   = {The Generalized {Oaxaca-Blinder} Estimator},
+  journal = {Journal of the American Statistical Association},
+  year    = {2023},
+  volume  = {118},
+  number  = {541},
+  pages   = {524--536},
+  doi     = {10.1080/01621459.2021.1941053}
+}
+
+@article{lee2009training,
+  author  = {Lee, David S.},
+  title   = {Training, Wages, and Sample Selection: Estimating Sharp Bounds on Treatment Effects},
+  journal = {Review of Economic Studies},
+  year    = {2009},
+  volume  = {76},
+  number  = {3},
+  pages   = {1071--1102},
+  doi     = {10.1111/j.1467-937X.2009.00536.x}
+}
+
+% ---- Field-experiment primary papers, alphabetical by key ----
+
+@article{athey2016recursive,
+  author  = {Athey, Susan and Imbens, Guido},
+  title   = {Recursive partitioning for heterogeneous causal effects},
+  journal = {Proceedings of the National Academy of Sciences},
+  year    = {2016},
+  volume  = {113},
+  number  = {27},
+  pages   = {7353--7360},
+  doi     = {10.1073/pnas.1510489113}
+}
+
+% Crossref's title embeds italic markup around the p; stripped.
+@article{athey2018exact,
+  author  = {Athey, Susan and Eckles, Dean and Imbens, Guido W.},
+  title   = {Exact p-Values for Network Interference},
+  journal = {Journal of the American Statistical Association},
+  year    = {2018},
+  volume  = {113},
+  number  = {521},
+  pages   = {230--240},
+  doi     = {10.1080/01621459.2016.1241178}
+}
+
+@article{bai2022optimality,
+  author  = {Bai, Yuehao},
+  title   = {Optimality of Matched-Pair Designs in Randomized Controlled Trials},
+  journal = {American Economic Review},
+  year    = {2022},
+  volume  = {112},
+  number  = {12},
+  pages   = {3911--3940},
+  doi     = {10.1257/aer.20201856}
+}
+
+% Print year 2024 (advance access June 2023, which resolvers stamp). Biometrika bylines
+% carry initials, as does Crossref; full names per OpenAlex are Peter Cohen and Colin B.
+% Fogarty.
+@article{cohen2024noharm,
+  author  = {Cohen, P. L. and Fogarty, C. B.},
+  title   = {No-harm calibration for generalized {Oaxaca-Blinder} estimators},
+  journal = {Biometrika},
+  year    = {2024},
+  volume  = {111},
+  number  = {1},
+  pages   = {331--338},
+  doi     = {10.1093/biomet/asad036}
+}
+
+% Crossref's deposit lowercases "Have" and appends a footnote asterisk; title as on the
+% published byline.
+@article{crepon2013labor,
+  author  = {Cr{\'e}pon, Bruno and Duflo, Esther and Gurgand, Marc and Rathelot, Roland and Zamora, Philippe},
+  title   = {Do Labor Market Policies Have Displacement Effects? Evidence from a Clustered Randomized Experiment},
+  journal = {The Quarterly Journal of Economics},
+  year    = {2013},
+  volume  = {128},
+  number  = {2},
+  pages   = {531--580},
+  doi     = {10.1093/qje/qjt001}
+}
+
+% No Crossref record for the 1935 Oliver and Boyd edition; sparse entry by design.
+@book{fisher1935design,
+  author    = {Fisher, Ronald A.},
+  title     = {The Design of Experiments},
+  publisher = {Oliver and Boyd},
+  year      = {1935}
+}
+
+@article{freedman2008regression,
+  author  = {Freedman, David A.},
+  title   = {On regression adjustments to experimental data},
+  journal = {Advances in Applied Mathematics},
+  year    = {2008},
+  volume  = {40},
+  number  = {2},
+  pages   = {180--193},
+  doi     = {10.1016/j.aam.2006.12.003}
+}
+
+% Cited via the Taylor & Francis record; the comments and rejoinder in the same issue
+% have separate JSTOR deposits.
+@article{horowitz2000nonparametric,
+  author  = {Horowitz, Joel L. and Manski, Charles F.},
+  title   = {Nonparametric Analysis of Randomized Experiments with Missing Covariate and Outcome Data},
+  journal = {Journal of the American Statistical Association},
+  year    = {2000},
+  volume  = {95},
+  number  = {449},
+  pages   = {77--84},
+  doi     = {10.1080/01621459.2000.10473902}
+}
+
+@article{hudgens2008toward,
+  author  = {Hudgens, Michael G. and Halloran, M. Elizabeth},
+  title   = {Toward Causal Inference With Interference},
+  journal = {Journal of the American Statistical Association},
+  year    = {2008},
+  volume  = {103},
+  number  = {482},
+  pages   = {832--842},
+  doi     = {10.1198/016214508000000292}
+}
+
+@article{imbens2004confidence,
+  author  = {Imbens, Guido W. and Manski, Charles F.},
+  title   = {Confidence Intervals for Partially Identified Parameters},
+  journal = {Econometrica},
+  year    = {2004},
+  volume  = {72},
+  number  = {6},
+  pages   = {1845--1857},
+  doi     = {10.1111/j.1468-0262.2004.00555.x}
+}
+
+% Subtitle "An Introduction" from the Crossref record (registered as a monograph).
+@book{imbens2015causal,
+  author    = {Imbens, Guido W. and Rubin, Donald B.},
+  title     = {Causal Inference for Statistics, Social, and Biomedical Sciences: An Introduction},
+  publisher = {Cambridge University Press},
+  year      = {2015},
+  doi       = {10.1017/CBO9781139025751}
+}
+
+@article{imbens2016robust,
+  author  = {Imbens, Guido W. and Koles{\'a}r, Michal},
+  title   = {Robust Standard Errors in Small Samples: Some Practical Advice},
+  journal = {Review of Economics and Statistics},
+  year    = {2016},
+  volume  = {98},
+  number  = {4},
+  pages   = {701--712},
+  doi     = {10.1162/REST_a_00552}
+}
+
+@article{list2019multiple,
+  author  = {List, John A. and Shaikh, Azeem M. and Xu, Yang},
+  title   = {Multiple hypothesis testing in experimental economics},
+  journal = {Experimental Economics},
+  year    = {2019},
+  volume  = {22},
+  number  = {4},
+  pages   = {773--793},
+  doi     = {10.1007/s10683-018-09597-5}
+}
+
+% The Dabrowska--Speed translation of Neyman's 1923 Polish original; Crossref credits the
+% translators as coauthors and we follow it. Crossref omits the page range; 465--472 from
+% the Project Euclid landing page.
+@article{neyman1990application,
+  author  = {Splawa-Neyman, Jerzy and Dabrowska, D. M. and Speed, T. P.},
+  title   = {On the Application of Probability Theory to Agricultural Experiments. Essay on Principles. Section 9},
+  journal = {Statistical Science},
+  year    = {1990},
+  volume  = {5},
+  number  = {4},
+  pages   = {465--472},
+  doi     = {10.1214/ss/1177012031}
+}
+
+% Article 13; De Gruyter assigns no page range (article number from OpenAlex; Crossref
+% records neither pages nor a print date for this online-only issue).
+@article{rosenblum2010simple,
+  author  = {Rosenblum, Michael and van der Laan, Mark J.},
+  title   = {Simple, Efficient Estimators of Treatment Effects in Randomized Trials Using Generalized Linear Models to Leverage Baseline Variables},
+  journal = {The International Journal of Biostatistics},
+  year    = {2010},
+  volume  = {6},
+  number  = {1},
+  pages   = {13},
+  doi     = {10.2202/1557-4679.1138}
+}
+
+% VoR. Published as "Generalized Lee bounds"; supersedes the "Better Lee Bounds" arXiv
+% preprint (arXiv:2008.12720, since retitled to match). Article 106055; no issue number.
+@article{semenova2025generalized,
+  author  = {Semenova, Vira},
+  title   = {Generalized {Lee} bounds},
+  journal = {Journal of Econometrics},
+  year    = {2025},
+  volume  = {251},
+  pages   = {106055},
+  doi     = {10.1016/j.jeconom.2025.106055}
+}
+
+@article{tauchmann2014lee,
+  author  = {Tauchmann, Harald},
+  title   = {{Lee} (2009) Treatment-Effect Bounds for Nonrandom Sample Selection},
+  journal = {Stata Journal},
+  year    = {2014},
+  volume  = {14},
+  number  = {4},
+  pages   = {884--894},
+  doi     = {10.1177/1536867X1401400411}
+}
+
+@article{wager2018estimation,
+  author  = {Wager, Stefan and Athey, Susan},
+  title   = {Estimation and Inference of Heterogeneous Treatment Effects using Random Forests},
+  journal = {Journal of the American Statistical Association},
+  year    = {2018},
+  volume  = {113},
+  number  = {523},
+  pages   = {1228--1242},
+  doi     = {10.1080/01621459.2017.1319839}
+}
+
+% Print year 2023 (online-first March 2022, which resolvers stamp).
+@article{ye2023toward,
+  author  = {Ye, Ting and Shao, Jun and Yi, Yanyao and Zhao, Qingyuan},
+  title   = {Toward Better Practice of Covariate Adjustment in Analyzing Randomized Clinical Trials},
+  journal = {Journal of the American Statistical Association},
+  year    = {2023},
+  volume  = {118},
+  number  = {544},
+  pages   = {2370--2382},
+  doi     = {10.1080/01621459.2022.2049278}
+}
+
+% Print year 2019 (online-first November 2018). Crossref's title carries a stray trailing
+% asterisk (footnote marker); removed.
+@article{young2019channeling,
+  author  = {Young, Alwyn},
+  title   = {Channeling {Fisher}: Randomization Tests and the Statistical Insignificance of Seemingly Significant Experimental Results},
+  journal = {The Quarterly Journal of Economics},
+  year    = {2019},
+  volume  = {134},
+  number  = {2},
+  pages   = {557--598},
+  doi     = {10.1093/qje/qjy029}
+}
+
+% ---- causal-design (router) ----
+% Canon + observables-branch primary papers, resolver-verified 2026-07-28 against Crossref,
+% with Project Euclid / RePEc / OpenAlex used only where Crossref omits fields (noted per
+% entry). No PREPRINTs: every entry has a version of record. Print-issue year rule applied
+% throughout.
+
+% Crossref-verified 2026-07-28 (the Annual Reviews landing page sits behind Cloudflare and
+% blocks non-browser fetches). Crossref dates the VoR to the 2024 volume (11(1), April 2024).
+@article{imbens2024causal,
+  author  = {Imbens, Guido W.},
+  title   = {Causal Inference in the Social Sciences},
+  journal = {Annual Review of Statistics and Its Application},
+  year    = {2024},
+  volume  = {11},
+  number  = {1},
+  pages   = {123--152},
+  doi     = {10.1146/annurev-statistics-033121-114601}
+}
+
+% Trade-press piece; no DOI and no journal companion, the web page is the citable object.
+% URL live 2026-07-28 (HTTP 200); title, byline, and datePublished 2024-11-20 from the
+% page's own metadata.
+@misc{li2024quasiexperimental,
+  author       = {Li, Kathleen T. and Luo, Lan and Pattabhiramaiah, Adithya},
+  title        = {Causal Inference with Quasi-Experimental Data},
+  year         = {2024},
+  howpublished = {Marketing News, American Marketing Association, November 20, 2024},
+  url          = {https://www.ama.org/marketing-news/causal-inference-with-quasi-experimental-data/}
+}
+
+% Crossref-verified 2026-07-28.
+@article{hirano2003efficient,
+  author  = {Hirano, Keisuke and Imbens, Guido W. and Ridder, Geert},
+  title   = {Efficient Estimation of Average Treatment Effects Using the Estimated Propensity Score},
+  journal = {Econometrica},
+  year    = {2003},
+  volume  = {71},
+  number  = {4},
+  pages   = {1161--1189},
+  doi     = {10.1111/1468-0262.00442}
+}
+
+% Crossref-verified 2026-07-28. Print year 2018 (online-first Nov 2017, which resolvers stamp).
+@article{li2018balancing,
+  author  = {Li, Fan and Morgan, Kari Lock and Zaslavsky, Alan M.},
+  title   = {Balancing Covariates via Propensity Score Weighting},
+  journal = {Journal of the American Statistical Association},
+  year    = {2018},
+  volume  = {113},
+  number  = {521},
+  pages   = {390--400},
+  doi     = {10.1080/01621459.2016.1260466}
+}
+
+% Biometrika bylines carry initials, as does Crossref; kept as published.
+@article{crump2009dealing,
+  author  = {Crump, R. K. and Hotz, V. J. and Imbens, G. W. and Mitnik, O. A.},
+  title   = {Dealing with limited overlap in estimation of average treatment effects},
+  journal = {Biometrika},
+  year    = {2009},
+  volume  = {96},
+  number  = {1},
+  pages   = {187--199},
+  doi     = {10.1093/biomet/asn055}
+}
+
+% Crossref-verified 2026-07-28. Pages 962--973 per the article record; a 2008 Biometrics
+% correction exists (10.1111/j.1541-0420.2008.01025.x).
+@article{bang2005doubly,
+  author  = {Bang, Heejung and Robins, James M.},
+  title   = {Doubly Robust Estimation in Missing Data and Causal Inference Models},
+  journal = {Biometrics},
+  year    = {2005},
+  volume  = {61},
+  number  = {4},
+  pages   = {962--973},
+  doi     = {10.1111/j.1541-0420.2005.00377.x}
+}
+
+% Pages C1--C68; the issue uses the journal's C-prefixed pagination.
+@article{chernozhukov2018double,
+  author  = {Chernozhukov, Victor and Chetverikov, Denis and Demirer, Mert and Duflo, Esther and Hansen, Christian and Newey, Whitney and Robins, James},
+  title   = {Double/debiased machine learning for treatment and structural parameters},
+  journal = {The Econometrics Journal},
+  year    = {2018},
+  volume  = {21},
+  number  = {1},
+  pages   = {C1--C68},
+  doi     = {10.1111/ectj.12097}
+}
+
+% Crossref-verified 2026-07-28. Crossref registers the DOI lowercase (10.3982/ecta15732);
+% the uppercase form used here is the publisher's canonical string and resolves identically.
+@article{athey2021policy,
+  author  = {Athey, Susan and Wager, Stefan},
+  title   = {Policy Learning with Observational Data},
+  journal = {Econometrica},
+  year    = {2021},
+  volume  = {89},
+  number  = {1},
+  pages   = {133--161},
+  doi     = {10.3982/ECTA15732}
+}
+
+% Crossref-verified 2026-07-28; Crossref omits the page range, 1912--1947 from the Project
+% Euclid landing page. Full title carries the social-network application clause.
+@article{aronow2017estimating,
+  author  = {Aronow, Peter M. and Samii, Cyrus},
+  title   = {Estimating average causal effects under general interference, with application to a social network experiment},
+  journal = {The Annals of Applied Statistics},
+  year    = {2017},
+  volume  = {11},
+  number  = {4},
+  pages   = {1912--1947},
+  doi     = {10.1214/16-AOAS1005}
+}
+
+% VoR (Statistical Science 38(3)), Crossref-verified 2026-07-28; pages 458--476 from the
+% Project Euclid landing page since Crossref omits them. The JRSS-B 2026 "Multiple
+% randomization designs" paper (10.1093/jrsssb/qkaf073) is a separate follow-up.
+@article{bajari2023experimental,
+  author  = {Bajari, Patrick and Burdick, Brian and Imbens, Guido W. and Masoero, Lorenzo and McQueen, James and Richardson, Thomas S. and Rosen, Ido M.},
+  title   = {Experimental Design in Marketplaces},
+  journal = {Statistical Science},
+  year    = {2023},
+  volume  = {38},
+  number  = {3},
+  pages   = {458--476},
+  doi     = {10.1214/23-STS883}
+}
+
+% Crossref-verified 2026-07-28. The EC'20 one-page abstract (10.1145/3391403.3399507) is a
+% separate record with only three authors; this is the Management Science VoR.
+@article{johari2022experimental,
+  author  = {Johari, Ramesh and Li, Hannah and Liskovich, Inessa and Weintraub, Gabriel Y.},
+  title   = {Experimental Design in Two-Sided Platforms: An Analysis of Bias},
+  journal = {Management Science},
+  year    = {2022},
+  volume  = {68},
+  number  = {10},
+  pages   = {7069--7089},
+  doi     = {10.1287/mnsc.2021.4247}
+}
+
+% VoR, Crossref-verified 2026-07-28. Published: supersedes NBER w26463 (2019), which most
+% citations still use. Print issue July 2026 (ReStud 93(4)); advance access Sep 2025, which
+% resolvers stamp.
+@article{athey2026surrogate,
+  author  = {Athey, Susan and Chetty, Raj and Imbens, Guido W. and Kang, Hyunseung},
+  title   = {The Surrogate Index: Combining Short-Term Proxies to Estimate Long-Term Treatment Effects More Rapidly and Precisely},
+  journal = {Review of Economic Studies},
+  year    = {2026},
+  volume  = {93},
+  number  = {4},
+  pages   = {2284--2312},
+  doi     = {10.1093/restud/rdaf087}
+}
+
+% No Crossref record (JSTOR-era AER Papers and Proceedings); fields verified 2026-07-28
+% against RePEc/IDEAS citation metadata. JSTOR stable 2006592 blocks non-browser fetches.
+@article{manski1990nonparametric,
+  author  = {Manski, Charles F.},
+  title   = {Nonparametric Bounds on Treatment Effects},
+  journal = {American Economic Review},
+  year    = {1990},
+  volume  = {80},
+  number  = {2},
+  pages   = {319--323}
+}
+
+% Crossref-verified 2026-07-28. Crossref and OpenAlex both store initials only (P. R. /
+% D. B.); kept as stored. Historical journal name restored (Crossref normalizes the
+% container to the current OUP title).
+@article{rosenbaum1983assessing,
+  author  = {Rosenbaum, P. R. and Rubin, D. B.},
+  title   = {Assessing Sensitivity to an Unobserved Binary Covariate in an Observational Study with Binary Outcome},
+  journal = {Journal of the Royal Statistical Society: Series B (Methodological)},
+  year    = {1983},
+  volume  = {45},
+  number  = {2},
+  pages   = {212--218},
+  doi     = {10.1111/j.2517-6161.1983.tb01242.x}
+}
+
+% Crossref-verified 2026-07-28. AEA Papers and Proceedings issue (93(2)).
+@article{imbens2003sensitivity,
+  author  = {Imbens, Guido W.},
+  title   = {Sensitivity to Exogeneity Assumptions in Program Evaluation},
+  journal = {American Economic Review},
+  year    = {2003},
+  volume  = {93},
+  number  = {2},
+  pages   = {126--132},
+  doi     = {10.1257/000282803321946921}
+}
+
+% Crossref-verified 2026-07-28. Print year 2019 (online-first June 2017, which resolvers stamp).
+@article{oster2019unobservable,
+  author  = {Oster, Emily},
+  title   = {Unobservable Selection and Coefficient Stability: Theory and Evidence},
+  journal = {Journal of Business \& Economic Statistics},
+  year    = {2019},
+  volume  = {37},
+  number  = {2},
+  pages   = {187--204},
+  doi     = {10.1080/07350015.2016.1227711}
+}
+
+% Crossref-verified 2026-07-28. Print year 2020 (online-first Dec 2019, which resolvers stamp).
+@article{cinelli2020making,
+  author  = {Cinelli, Carlos and Hazlett, Chad},
+  title   = {Making Sense of Sensitivity: Extending Omitted Variable Bias},
+  journal = {Journal of the Royal Statistical Society: Series B (Statistical Methodology)},
+  year    = {2020},
+  volume  = {82},
+  number  = {1},
+  pages   = {39--67},
+  doi     = {10.1111/rssb.12348}
+}
+
+% Crossref book record + Springer landing page verified 2026-07-28 (Edition Number 2,
+% Springer Series in Statistics). The 1995 first edition is 10.1007/978-1-4757-2443-1.
+@book{rosenbaum2002observational,
+  author    = {Rosenbaum, Paul R.},
+  title     = {Observational Studies},
+  edition   = {2},
+  series    = {Springer Series in Statistics},
+  publisher = {Springer},
+  year      = {2002},
+  doi       = {10.1007/978-1-4757-3692-2}
+}
+
+% Crossref-verified 2026-07-28. Print year 2012 (online-first Jan 2011). Crossref stores the
+% title in all caps and splits the author names oddly ("H. / Steve Ching"); title case and
+% byline names restored via OpenAlex raw author names.
+@article{hsiao2012panel,
+  author  = {Hsiao, Cheng and Ching, H. Steve and Wan, Shui Ki},
+  title   = {A Panel Data Approach for Program Evaluation: Measuring the Benefits of Political and Economic Integration of {Hong Kong} with {Mainland China}},
+  journal = {Journal of Applied Econometrics},
+  year    = {2012},
+  volume  = {27},
+  number  = {5},
+  pages   = {705--740},
+  doi     = {10.1002/jae.1230}
+}
+
+% Crossref-verified 2026-07-28. Print year 2020 (online-first Dec 2019, which resolvers stamp).
+@article{li2020inference,
+  author  = {Li, Kathleen T.},
+  title   = {Statistical Inference for Average Treatment Effects Estimated by Synthetic Control Methods},
+  journal = {Journal of the American Statistical Association},
+  year    = {2020},
+  volume  = {115},
+  number  = {532},
+  pages   = {2068--2083},
+  doi     = {10.1080/01621459.2019.1686986}
+}
+
+% Crossref-verified 2026-07-28. Supersedes the SSRN deposit (10.2139/ssrn.4137460).
+@article{li2023augmented,
+  author  = {Li, Kathleen T. and Van den Bulte, Christophe},
+  title   = {Augmented Difference-in-Differences},
+  journal = {Marketing Science},
+  year    = {2023},
+  volume  = {42},
+  number  = {4},
+  pages   = {746--767},
+  doi     = {10.1287/mksc.2022.1406}
+}
+
+% Crossref-verified 2026-07-28. Marketing Science 43(2), not a 2022 issue; supersedes the
+% SSRN deposit "A Novel Forward Difference-in-Differences Method" (10.2139/ssrn.4213705).
+@article{li2024forward,
+  author  = {Li, Kathleen T.},
+  title   = {Frontiers: A Simple Forward Difference-in-Differences Method},
+  journal = {Marketing Science},
+  year    = {2024},
+  volume  = {43},
+  number  = {2},
+  pages   = {267--279},
+  doi     = {10.1287/mksc.2022.0212}
+}
+
+% Crossref-verified 2026-07-28. Venue is JMR (60(3), print June 2023; online-first Feb 2023),
+% not Marketing Science. Supersedes the SSRN deposit (10.2139/ssrn.4122311).
+@article{li2023statistical,
+  author  = {Li, Kathleen T. and Sonnier, Garrett P.},
+  title   = {Statistical Inference for the Factor Model Approach to Estimate Causal Effects in Quasi-Experimental Settings},
+  journal = {Journal of Marketing Research},
+  year    = {2023},
+  volume  = {60},
+  number  = {3},
+  pages   = {449--472},
+  doi     = {10.1177/00222437221137533}
+}
+
+% Crossref-verified 2026-07-29.
+@article{imai2010general,
+  author  = {Imai, Kosuke and Keele, Luke and Tingley, Dustin},
+  title   = {A General Approach to Causal Mediation Analysis},
+  journal = {Psychological Methods},
+  year    = {2010},
+  volume  = {15},
+  number  = {4},
+  pages   = {309--334},
+  doi     = {10.1037/a0020761}
+}
+
+% Crossref-verified 2026-07-29. Title confirmed exact as sketched.
+@article{pieters2017meaningful,
+  author  = {Pieters, Rik},
+  title   = {Meaningful Mediation Analysis: Plausible Causal Inference and Informative Communication},
+  journal = {Journal of Consumer Research},
+  year    = {2017},
+  volume  = {44},
+  number  = {3},
+  pages   = {692--716},
+  doi     = {10.1093/jcr/ucx081}
+}
+
+% Crossref-verified 2026-07-29. Print year 2023 (online-first 2022, which the DOI string reflects).
+@article{mackinnon2023cluster,
+  author  = {MacKinnon, James G. and Nielsen, Morten {\O}rregaard and Webb, Matthew D.},
+  title   = {Cluster-Robust Inference: A Guide to Empirical Practice},
+  journal = {Journal of Econometrics},
+  year    = {2023},
+  volume  = {232},
+  number  = {2},
+  pages   = {272--299},
+  doi     = {10.1016/j.jeconom.2022.04.001}
+}
+
+% Crossref-verified 2026-07-29. Journal version; supersedes NBER w23568 (titled "...Treatment Effects").
+@article{mogstad2018using,
+  author  = {Mogstad, Magne and Santos, Andres and Torgovitsky, Alexander},
+  title   = {Using Instrumental Variables for Inference About Policy Relevant Treatment Parameters},
+  journal = {Econometrica},
+  year    = {2018},
+  volume  = {86},
+  number  = {5},
+  pages   = {1589--1619},
+  doi     = {10.3982/ecta15463}
+}
+
+% Crossref-verified 2026-07-29. Software companion to mogstad2018using (the ivmte R package).
+@article{shea2023ivmte,
+  author  = {Shea, Joshua and Torgovitsky, Alexander},
+  title   = {{ivmte}: An {R} Package for Extrapolating Instrumental Variable Estimates Away From Compliers},
+  journal = {Observational Studies},
+  year    = {2023},
+  volume  = {9},
+  number  = {2},
+  pages   = {1--42},
+  doi     = {10.1353/obs.2023.0016}
+}

--- a/skills/causal-design/references/details.md
+++ b/skills/causal-design/references/details.md
@@ -1,0 +1,132 @@
+# Causal-design lookup details
+
+Heavy reference content the SKILL.md points into. Current as of 2026-07-28.
+
+## The sensitivity ladder, in full (Imbens 2024)
+
+Three graded options when unconfoundedness carries the identification; report at least one,
+chosen by how much structure you are willing to impose.
+
+- Manski bounds: drop unconfoundedness entirely and bound the estimand by the logically
+  possible outcome ranges. With a binary outcome the bounds have width one and always
+  include zero, so they are honest but usually uninformative; their value is stating what
+  the data alone can say.
+- Calibrated confounder models: posit an unobserved binary confounder, parameterize its
+  association with assignment and with outcomes via log odds ratios, and trace the
+  estimate over a plausible range (rosenbaum1983assessing). Imbens (2003) calibrates the
+  range against the strongest observed covariate, which is the move reviewers accept. The
+  modern reporting standards descend from this: Oster's coefficient-stability delta
+  (oster2019unobservable; note it assumes proportional selection and R-squared targets,
+  state both), Cinelli-Hazlett robustness values (cinelli2020making; sensemakr gives the
+  minimal reporting table: RV, partial R2 of the treatment, bounds against 1x/2x/3x the
+  benchmark covariate), plus Masten-Poirier and Chernozhukov et al. long-story bounds as
+  further options.
+- Rosenbaum design sensitivity (rosenbaum2002observational): bound only the odds of
+  assignment (the Gamma parameter), leave the outcome association unrestricted; matched
+  designs report the Gamma at which significance is lost.
+
+Failure semantics: an estimate that flips sign or loses significance under mild calibrated
+confounding indicts the design; do not respond by switching estimators. M-bias from
+conditioning on colliders is possible in principle but has produced few clear empirical
+mistakes in economics (Imbens); the descendant rule catches the common error.
+
+## Selection-on-observables facts worth citing
+
+- Doubly robust = consistent if EITHER the outcome model or the propensity model is
+  consistent; tolerates slow (ML-rate) convergence of both nuisances (Imbens 2024, on
+  bang2005doubly and the DML literature).
+- Fixed-number-of-matches matching is never fully efficient, and with many covariates its
+  bias does not vanish asymptotically (Abadie-Imbens 2006, via Imbens 2024);
+  bias-corrected matching with a growing number of matches restores the efficiency bound.
+- Weighting by the true propensity score is inefficient relative to the estimated one
+  (hirano2003efficient); use the estimated score even in simulations.
+- Overlap: the Crump et al. variance-minimizing trimming rule, commonly approximated by
+  dropping units with estimated scores outside [0.1, 0.9] (crump2009dealing); overlap
+  weights e(x)(1-e(x)) shift the estimand to the population with genuine treatment
+  ambiguity (li2018balancing), often the policy-relevant one in targeting applications.
+- PSM in marketing: used "for decades," now "called into question due to the technique's
+  sensitivity to parametric assumptions" (AMA, citing Athey-Imbens); field replacements
+  are AIPW, double ML, causal forests.
+- Adaptive experiments: naive sample means are biased under adaptive assignment because
+  adaptivity truncates the losing arms' samples early (Imbens 2024). The family has NO
+  analysis route for bandit-collected data; the adaptive-reweighting literature is outside
+  the canon. Practical exits: a final non-adaptive confirmatory phase, or restricting
+  analysis to a uniform-assignment holdout.
+- Surrogate index (athey2026surrogate): estimate the relation of long-run outcome to
+  surrogates in observational data, apply it to experimental surrogate movements; valid
+  only when all causal paths from treatment to the long-run outcome pass through the
+  measured surrogates, which is the assumption to argue and the limitation to state. The
+  family ships no estimation template; Athey, Chetty, Imbens, and Kang's own empirical
+  implementation is the recipe, and the deliverable stops at the validity argument.
+
+## SDID inference by data shape (pointer)
+
+The authoritative statement lives in synthetic-control's details, absorbed there from the
+AMA piece with "permutation" mapped to the placebo estimator.
+
+## The AMA exemplar table (method -> published marketing application)
+
+Use these to argue a method is accepted practice in marketing journals.
+
+| Method | Application |
+|---|---|
+| DiD | app monetization free-to-paid (Cao, Chintagunta, Li 2023 JM); nudges on purchases and returns (Ghose et al. 2024) |
+| Factor models / gsynth | physician payment disclosure and prescribing (Guo, Sriram, Manchanda 2020 MktSci); newspaper paywalls (Pattabhiramaiah, Sriram, Manchanda 2019 MktSci); advertising and earned word of mouth (Lovett, Peres, Xu 2019) |
+| Synthetic DiD | TV advertising and online sales (Lambrecht, Tucker, Zhang 2024); soda taxes and marketing conduct (Keller, Guyts, Grewal 2024) |
+| Matrix completion | misinformation and the brand premium (Bronnenberg, Dube, Sanders 2020) |
+| AIPW | advertising measurement at Facebook (Gordon et al. 2019 MktSci) |
+| Causal forest | restaurant survival from consumer photos (Zhang, Luo 2023); digital-engagement spillovers on print subscriptions (Pattabhiramaiah, Overby, Xu 2022); targeted campaigns (Ellickson, Kar, Reeder 2023) |
+| Augmented DiD | Li and Van den Bulte 2023 (MktSci) |
+| Forward DiD | Li 2024 (MktSci Frontiers) |
+
+These are the AMA piece's citations, not bib entries of this family; pull the full
+references from the piece when one is needed in a paper.
+
+## Interference routing (pointer)
+
+Designs, estimators, and diagnostics live in field-experiment.
+
+- Clustered interference: two-stage randomization over clusters (hudgens2008toward,
+  crepon2013labor).
+- Network interference: exposure mappings (aronow2017estimating) with exact tests of the
+  sharp null (athey2018exact).
+- Marketplaces and two-sided platforms: multiple randomization designs over buyer-seller
+  pairs (bajari2023experimental, johari2022experimental).
+- The 61-million-person Facebook voting experiment (Bond et al. 2012) is the scale anchor
+  for network experiments; cite from Imbens 2024.
+
+## Marketing vocabulary glossary (AMA; write for reviewers in these terms)
+
+- Design rigor vs statistical rigor: randomization buys the former; quasi-experimental
+  methods compensate with the latter.
+- Clean controls: comparison units never treated (or not-yet-treated) during the
+  estimation window; staggered designs must justify them.
+- False precision / false imprecision: CIs too narrow / too wide from an inference
+  procedure the data shape does not support (the Li-Sonnier gsynth bootstrap result).
+- ATT-first: marketing quasi-experiments default to the effect on the treated, matching
+  what the panel estimators identify.
+- Parallel trends "is a statement about the treatment counterfactual": only its
+  pretreatment shadow is testable, by visual inspection plus statistical tests.
+- SUTVA decomposed for marketers: no interference (a state law must not move control-state
+  outcomes) and no hidden treatment versions; justified by "logical argumentation based on
+  institutional knowledge."
+
+## Package index (verified against docs/source 2026-07-28; the observables branch only, method skills carry their own)
+
+| Tool | Version | Role | Traps |
+|---|---|---|---|
+| grf | 2.6.1 | causal_forest + average_treatment_effect (AIPW default, TMLE binary-only option); best_linear_projection (HC3); rank_average_treatment_effect; policy scores | treatment argument is W; clusters= at FIT time is what makes ATE SEs cluster-robust; target.sample="overlap" = Li-Morgan-Zaslavsky ATO, the documented poor-overlap fallback; RATE priorities need a held-out forest; hist(cf$W.hat) is the documented overlap check (pinned also in field-experiment's details; update the two pins together on refresh) |
+| policytree | 1.2.4 | double_robust_scores(forest) -> policy_tree(X, Gamma, depth = 2) | Gamma columns = actions in order (1 control, 2 treated); predict returns the column index, not 0/1; exact search exponential in depth |
+| sensemakr | 0.1.6 | Cinelli-Hazlett sensitivity: robustness values, benchmark bounds, ovb_minimal_reporting (latex/html) | treatment looked up by coefficient name, so factor treatments FAIL (undocumented, in source): code treatment numeric 0/1; kd defaults to 1, pass kd = 1:3 for the standard table; lm objects (fixest method on GitHub) |
+| WeightIt | 1.7.0 | balancing weights, estimand = "ATO" for overlap weights (method = "glm") | ATO not available for every method (check ?method_<name>); downstream is lm_weightit/glm_weightit + marginaleffects::avg_comparisons (M-estimation SEs account for estimated weights); plain lm + vcovCL treats weights as fixed; keep.mparts=TRUE default enables the M-estimation SEs |
+| marginaleffects | 0.32.0 | g-computation/contrasts on weightit fits (native support) | no grf support; use grf's own estimators for forests (pinned also in field-experiment's details; update the two pins together on refresh) |
+| DoubleML | 1.0.2 | explicit double/debiased ML when nuisance-learner control is wanted (mlr3) | heavier setup; the grf route covers the default DR case |
+| MatchIt | 4.7.2 | matching as preprocessing when a matched design is wanted | same author ecosystem as WeightIt; matching never fully efficient (Imbens), prefer DR estimation after |
+| estimatr | 1.0.6 | lm_robust with HC/CR SEs (shared with field-experiment) | design-based defaults; already the family's experiment workhorse (pinned also in field-experiment's details; update the two pins together on refresh) |
+
+Docs: grf-labs.github.io/grf, grf-labs.github.io/policytree, carloscinelli.com/sensemakr,
+ngreifer.github.io/WeightIt, marginaleffects.com.
+
+Clustered-SE incantation on any plain lm: lmtest::coeftest(fit, vcov =
+sandwich::vcovCL(fit, cluster = ~ id)) with cluster as a formula (multiway: ~ firm + year);
+default type HC1 for lm objects.

--- a/skills/causal-design/scripts/unconfoundedness_template.R
+++ b/skills/causal-design/scripts/unconfoundedness_template.R
@@ -1,0 +1,109 @@
+# Selection-on-observables template (the branch causal-design owns). Every call verified
+# against package documentation and source on 2026-07-28 (grf 2.6.1, policytree 1.2.4,
+# sensemakr 0.1.6, WeightIt 1.7.0, marginaleffects 0.32.0). Adapt and run section by
+# section.
+#
+# API traps verified against docs/source:
+#   - sensemakr looks the treatment up by COEFFICIENT NAME: a factor treatment fails with
+#     "Variables not found in model" (undocumented; source check_covariates). Code the
+#     treatment as numeric 0/1. kd defaults to 1; pass kd = 1:3 explicitly for the
+#     standard 1x/2x/3x benchmark table.
+#   - WeightIt: estimand = "ATO" is valid for method = "glm" (binary and multi-category)
+#     but NOT for every method; re-check ?method_<name> if you swap methods. The
+#     recommended downstream is now lm_weightit()/glm_weightit() (M-estimation SEs that
+#     account for the weights being ESTIMATED) + marginaleffects::avg_comparisons();
+#     plain lm + vcovCL treats weights as fixed.
+#   - policytree double_robust_scores returns N x d with columns = actions IN ORDER:
+#     column 1 = control, column 2 = treated; predict() returns that column index
+#     (1 = assign control, 2 = assign treated), not a 0/1 treatment.
+#   - grf: cluster-robust ATE standard errors come from passing clusters= AT FIT TIME
+#     (DR scores are aggregated by cluster downstream); there is no cluster argument in
+#     average_treatment_effect(). rank_average_treatment_effect() priorities must come
+#     from a forest trained on a held-out split, or the RATE is spuriously inflated.
+
+library(grf)             # 2.6.1
+library(policytree)      # 1.2.4
+library(sensemakr)       # 0.1.6
+library(WeightIt)        # 1.7.0
+library(marginaleffects) # 0.32.0
+# Package index with versions, links, and traps in references/details.md.
+
+## df: one row per unit. y outcome; d treatment CODED NUMERIC 0/1; x1..xK PRETREATMENT
+## covariates; cl cluster id at the level treatment was ASSIGNED (drop clusters= below if
+## assignment was at the unit level; clustering is a design property, abadie2023clustering).
+## The conditioning set contains only non-descendants of treatment and outcome, justified
+## by temporal precedence. "Using variables causally affected by the treatment or outcome
+## is the most common mistake" (Imbens 2024) -- audit the covariate list before running.
+
+X <- as.matrix(df[, c("x1", "x2", "x3")])
+
+## ---- 1. Overlap FIRST (violations move the estimand, not just the estimator) ----------
+cf <- causal_forest(X, df$y, df$d,
+                    num.trees = 2000,          # grf default, pinned for reproducibility
+                    clusters  = df$cl,         # cluster-robust SEs propagate from here
+                    seed      = 42)
+hist(cf$W.hat, xlim = c(0, 1))                 # grf's documented overlap check: nothing
+                                               # near 0 or 1
+mean(cf$W.hat < 0.10 | cf$W.hat > 0.90)        # share outside the Crump rule of thumb
+# Poor overlap, two exits, both re-declare WHO the estimate is about:
+#  (a) trim to W.hat in [0.10, 0.90] (crump2009dealing approximation of the
+#      variance-minimizing rule), refit, and report the retained population;
+#  (b) target.sample = "overlap" below (Li-Morgan-Zaslavsky ATO): no division by
+#      estimated propensities, weights concentrate on units that could get either arm.
+
+## ---- 2. Doubly robust average effects (AIPW is the default method) --------------------
+average_treatment_effect(cf, target.sample = "all")      # ATE;  returns c(estimate, std.err)
+average_treatment_effect(cf, target.sample = "treated")  # ATT (marketing default framing)
+average_treatment_effect(cf, target.sample = "overlap")  # ATO under poor overlap
+# Nuisances are orthogonalized automatically (Y.hat, W.hat by internal regression
+# forests); this is the doubly robust default of the skill (bang2005doubly; Imbens 2024).
+# Wanting explicit nuisance-learner control instead: DoubleML (R, 1.0.2) on mlr3.
+
+## ---- 3. Heterogeneity: describe CATEs vs decide who to treat (different goals) --------
+tau <- predict(cf, estimate.variance = TRUE)   # $predictions = OOB CATEs;
+                                               # sqrt($variance.estimates) = SEs
+best_linear_projection(cf, A = X[, c("x1", "x2")])   # doubly robust CATE projection,
+                                                     # HC3 SEs; the reportable summary
+# Targeting evidence needs the split discipline (priorities independent of evaluation).
+# Equal halves keep both the priority and evaluation forests adequately powered; any
+# held-out split satisfies the grf requirement:
+tr <- sample(nrow(X), nrow(X) / 2)
+cf_tr <- causal_forest(X[tr, ],  df$y[tr],  df$d[tr],  seed = 42)
+cf_ev <- causal_forest(X[-tr, ], df$y[-tr], df$d[-tr], seed = 42)
+rank_average_treatment_effect(cf_ev,
+                              priorities = predict(cf_tr, X[-tr, ])$predictions)
+# Deciding WHO to treat is policy learning (athey2021policy), not a CATE map:
+Gamma <- double_robust_scores(cf)              # N x 2: col 1 = control, col 2 = treated
+pt <- policy_tree(X, Gamma, depth = 2)         # depth 2 default: trades interpretability
+predict(pt, X)                                 # against fit; deepen only if the evaluated
+                                               # policy value clearly improves (search is
+                                               # exponential in depth). 1=control, 2=treat
+
+## ---- 4. Overlap weights with weight-aware inference (the ATO route) -------------------
+w <- weightit(d ~ x1 + x2 + x3, data = df, method = "glm", estimand = "ATO")
+fit <- lm_weightit(y ~ d * (x1 + x2 + x3), data = df, weightit = w)
+avg_comparisons(fit, variables = "d", wts = w$weights)
+# vcov = "asympt" M-estimation SEs account for the weights being estimated (the docs'
+# recommended pipeline). Fixed-weight fallback, clustered:
+#   f2 <- lm(y ~ d, data = df, weights = w$weights)
+#   lmtest::coeftest(f2, vcov = sandwich::vcovCL(f2, cluster = ~ cl))
+
+## ---- 5. Sensitivity analysis (MANDATORY: unconfoundedness is untestable) ---------------
+ols <- lm(y ~ d + x1 + x2 + x3, data = df)     # d numeric 0/1 (the sensemakr trap)
+sens <- sensemakr(model = ols, treatment = "d",
+                  benchmark_covariates = "x1",  # the strongest observed confounder,
+                  kd = 1:3)                     # calibration in the Imbens (2003) spirit
+summary(sens); plot(sens)
+ovb_minimal_reporting(sens, format = "latex")  # the Cinelli-Hazlett reporting table
+# Read the verdict on the DESIGN: an estimate that flips under a confounder 1-3x as
+# strong as the best observed covariate indicts the identification, not the estimator.
+# Ladder alternatives in references/details.md: Manski bounds (assumption-free),
+# oster2019unobservable (state its proportional-selection and R2-target assumptions),
+# rosenbaum2002observational design sensitivity for matched designs.
+
+## ---- Session ---------------------------------------------------------------------------
+# Pin: grf 2.6.1 (seed set; honesty on by default), policytree 1.2.4, sensemakr 0.1.6,
+# WeightIt 1.7.0 (keep.mparts default TRUE is what makes lm_weightit's M-estimation SEs
+# possible), marginaleffects 0.32.0 (WeightIt supported natively; grf is NOT, use grf's
+# own estimators for forest effects).
+sessionInfo()

--- a/skills/did/SKILL.md
+++ b/skills/did/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: did
+description: Design, estimate, validate, and write up a difference-in-differences analysis of a natural experiment, using the post-2018 heterogeneity-robust toolkit with an explicit statement of which parallel-trends assumption is imposed. Produces advice with citations, R estimation and diagnostics code, and a drafted methods paragraph. TRIGGER on "difference-in-differences", "diff-in-diff", "DiD", "TWFE", "two-way fixed effects", "event study", "staggered adoption", "parallel trends", "pre-trends", "Callaway-Sant'Anna", "HonestDiD", "triple differences", or any panel/repeated-cross-section setting where some units become treated over time (policy rollout, staggered feature launch, state law changes). For a single treated unit or when pre-trends visibly fail, see the synthetic-control handoff inside. Design triage across methods belongs to causal-design.
+---
+
+# Difference-in-differences
+
+An opinionated DiD workflow grounded in a read canon (references/canon.md, current as of
+2026-07-29). The deliverable is threefold: the specification decision with the citation that
+justifies it, the estimation and diagnostics code in R (Stata on request), and a methods
+paragraph with citations placed and the limitation stated in first person at the point of the
+choice. Where the literature is unsettled the skill names a default and the condition that moves
+you off it, and where the canon genuinely disagrees it says so instead of faking consensus.
+
+Refresh path: this literature moved fast in 2018-2024 and is still moving. To update, run the
+litreview skill on "difference-in-differences" since the canon date and fold results into
+references/canon.md as flagged addenda.
+
+## Triage: three questions before anything else
+
+From Roth, Sant'Anna, Bilinski, and Poe (2023), the most condensed decision object in the
+literature:
+
+1. **Is everyone treated at the same time?** Yes: TWFE is fine, static or dynamic; nothing new
+   is needed. No (staggered): default to a heterogeneity-robust estimator; TWFE only if you will
+   defend effect homogeneity.
+2. **Are you sure about parallel trends?** Justify levels vs logs (PT is functional-form
+   dependent and generally cannot hold in both). If PT is plausible only conditional on
+   covariates, use regression adjustment, IPW, or doubly robust, never bare TWFE-with-controls.
+   Always pair the event study with a Rambachan-Roth sensitivity analysis, a universal mandate
+   this skill family hardens beyond the canon's best-practice advice because the analysis is
+   cheap and the pretest is low-powered.
+3. **Do you have many treated and untreated clusters?** Yes: cluster at the level at which
+   treatment is independently assigned. No: pick a few-clusters method by which homogeneity
+   assumption you believe (references/details.md has the map), or fall back to a cluster-level
+   Fisher randomization test. Before picking, run the MacKinnon, Nielsen, and Webb (2023)
+   battery (CV1, CV3 jackknife, and a restricted wild cluster bootstrap side by side):
+   agreement means stop, disagreement means escalate to the map.
+
+Two exits from DiD entirely, both routed to the synthetic-control skill: only one or a handful
+of treated units, or selection on lagged outcomes with autocorrelated errors, where DiD is
+inconsistent even as pre-periods grow while SC is consistent (Arkhangelsky-Hirshberg, via the
+panel survey of Arkhangelsky and Imbens 2024). Synthetic DiD also lives there. Few treated
+aggregate UNITS with failed pretrends exit to synthetic-control; few treated CLUSTERS of micro
+units with plausible parallel trends stay here on the few-clusters inference map
+(references/details.md). When parallel trends fails and the synthetic-control exit is also
+infeasible (no credible donors, short pre-period), decline the design and route back to
+causal-design; a failed gate is a verdict. If treatment timing is quasi-random, DiD is valid
+but inefficient; use the efficient random-timing estimators (R package staggered,
+Roth-Sant'Anna).
+
+## Estimand before estimator
+
+Weights define the target parameter, not the specification (Baker et al. 2026). An unweighted
+ATT answers "effect on the average treated county"; a population-weighted ATT answers "effect on
+the average treated person." In the Baker et al. Medicaid 2x2 these are +0.1 and -2.6 deaths per
+100,000: different questions, not a robustness check of each other. In marketing panels where
+units differ enormously in size (DMAs, stores, channels), decide by the business or policy
+question and, if you report both, report them as different estimands.
+
+Write the target in potential-outcomes notation before touching code: which ATT(g,t) cells, and
+which aggregation (event-time, calendar-time, overall; cohort-share or population weights).
+
+## The parallel-trends menu and the estimator it implies
+
+State explicitly which PT assumption you impose (Baker et al. 2026 make this a requirement).
+Three variants under staggered adoption, with the estimator crosswalk:
+
+| PT variant | Comparison group | Pre-trends restricted? | Estimators | R |
+|---|---|---|---|---|
+| PT-Nev | never-treated | no | Callaway-Sant'Anna (never), Sun-Abraham | `did::att_gt(control_group="nevertreated")`, `fixest::sunab()` |
+| PT-NYT | not-yet-treated | no | Callaway-Sant'Anna (NYT), dCDH instantaneous | `did::att_gt(control_group="notyettreated")` |
+| PT-all | all groups, all periods | yes (testable, and baked in) | BJS/Gardner/LWX imputation, Wooldridge ETWFE | `didimputation`, `did2s`, `etwfe` |
+
+Default: **Callaway-Sant'Anna with not-yet-treated controls**, Baker et al.'s own choice for
+their application. Move to never-treated when the not-yet-treateds' timing plausibly responded
+to recent outcomes; move to imputation (PT-all) when you will defend parallel pre-trends over
+the whole panel and errors are near-serially-uncorrelated, where it buys real efficiency
+(Roth et al. 2023). If Y(0) is close to a random walk, the CS last-pre-period baseline is the
+efficient choice and imputation's pre-period averaging buys nothing (Harmon's caveat: averaging
+is not guaranteed more precise). If PT is implausible for one specific cohort, drop that cohort
+rather than average over it.
+
+"Never-treated" operationally means "not treated by the end of the sample." If all units are
+eventually treated, drop periods from when the last cohort adopts and use that cohort as the
+comparison, and drop units treated in the first period.
+
+## The TWFE question, stated honestly
+
+The canon disagrees, and the skill's position is a default with named dissent:
+
+- Baker et al. (2026): TWFE under staggered adoption has "well-understood, potentially serious,
+  and easily remedied problems, and we do not recommend using it."
+- Arkhangelsky and Imbens (2024): "we recommend against the current routine use of the standard
+  TWFE estimator or related estimators," though under block assignment TWFE still estimates the
+  ATT, and they think negative-weight concerns "have perhaps been exaggerated."
+- Abadie, Angrist, Frandsen, and Pischke (2025): the pathologies "are unlikely to derail DD or
+  event-study designs in practice"; in the divorce data BJS and TWFE match. Their prescription
+  is TWFE event studies with BJS as a check.
+
+Default here: estimate the robust estimator as the headline number and report TWFE alongside it.
+Agreement is affirmative evidence the simple model suffices (AAFP); divergence means
+heterogeneity is doing real work and the robust estimate stands. The only way to know TWFE would
+have been fine is to run the robust estimator anyway, at which point you report it (Baker et
+al.). Run the building-block heterogeneity scan (2x2 DiDs by cohort, gap, and time since
+adoption, Arkhangelsky-Imbens) rather than trusting any single robust estimator blindly.
+
+## Event-study mechanics
+
+Hard rules, mostly from Abadie, Angrist, Frandsen, and Pischke (2025):
+
+- Feasible horizons: with panel end T and cohorts c(s), longest lag q = T - min c(s), longest
+  lead m = max c(s) - 1. Here s indexes treatment cohorts and c(s) is cohort s's adoption
+  period. The formulas assume periods renumbered 1..T, so calendar years must be reindexed
+  first.
+- Always omit event time -1. With never-treated units that single normalization identifies
+  everything. Without them, a second lead or lag must be omitted, the linear component of the
+  effect path is unidentified, and different second choices rotate the whole path around -1.
+  Choose deliberately, never let the software's default drop decide, and show the path under at
+  least two normalizations before interpreting dynamics.
+- Bin leads and lags beyond the horizon where only a few units identify the coefficient (AAFP
+  use +/-15 with 41 periods). Clustered SEs fail at long horizons through leverage: a lone late
+  adopter can identify the longest leads, and coverage collapses.
+- Report simultaneous sup-t uniform bands, computed separately for leads and lags, not only
+  pointwise bands (recipe in references/details.md; the did package produces them by multiplier
+  bootstrap). Never use a clustered joint F over many leads.
+- Under staggered timing, build the event study from a robust estimator, never from dynamic
+  TWFE: cross-lag contamination means TWFE lead coefficients can be nonzero under valid PT and
+  zero under violations (Sun-Abraham, via Roth et al. 2023).
+- Check composition: cohorts entering and leaving event times can manufacture dynamics. Use the
+  balanced-in-event-time aggregation or a fixed cohort set when in doubt.
+
+## Pre-trends and honest sensitivity
+
+Pre-trend tests are underpowered: in simulations calibrated to three top journals, linear
+violations detected only 50% of the time produce bias as large as the estimated effect and a
+spurious significant effect about half the time (Roth 2022). Quote from Roth et al. (2023): "the
+lack of a significant pre-trend does not necessarily imply the validity of the parallel trends
+assumption." Also the converse (Kahn-Lang and Lang's bar mitzvah example): parallel pre-trends
+do not imply parallel post-trends.
+
+The canon splits on pretesting itself. Roth (2022) shows conditioning on passing adds selection
+bias; AAFP's cost-benefit analysis concludes "the bias-mitigation benefits of pretesting are
+likely to outweigh the risks" and prescribes a sup-t joint test of the leads. Default here: run
+the sup-t pretest and report it, but never let a pass substitute for the sensitivity analysis,
+and report the test's power against economically relevant violations (R package pretrends).
+
+Mandatory companion to every event study: Rambachan-Roth honest inference (HonestDiD), in one
+or both of its restrictions, a universality that is this family's own hardening of the canon's
+best-practice endorsement (cheap to run, against a low-powered pretest). Relative magnitudes
+bounds post-treatment violations by M-bar times
+the largest pre-treatment violation; use it when the worry is shocks like those already seen
+pre-treatment. Smoothness bounds deviations from a linear extrapolation of the pre-trend by M;
+use it when the worry is a smoothly evolving confound. Report the identified set, the robust CI,
+and the breakdown value at which the conclusion dies, then read it economically: robustness to
+M-bar = 2 is strong in a calm period and weak if treatment coincided with a shock larger than
+anything pre-treatment. Worked template numbers (Baker et al.): largest one-period pre-trend 4,
+identified set -2.6 +/- 4 = [-6.6, 1.4], robust CI [-11.1, 5.1].
+
+## Covariates
+
+Never bare TWFE-with-controls: even in the 2x2 it identifies the ATT only under constant effects
+across covariate strata, weights strata non-convexly, and adds three misspecification bias terms
+(Caetano-Callaway, via Baker et al. 2026). Choose covariates from theory (determinants of
+untreated trends or of selection), check they are unaffected by treatment (a time-varying
+covariate is fine only if its whole path is unaffected), then use:
+
+- **Doubly robust (default)**: `did::att_gt(est_method="dr")`, Sant'Anna-Zhao. Consistent if
+  either the outcome-change model or the propensity model is right.
+- Regression adjustment when overlap is weak (extrapolates the outcome model; say so).
+- IPW when you understand selection better than outcome dynamics; noisy as control propensity
+  scores approach 1. The did/DRDID packages trim above 0.995 by default; keep the trim and plot
+  the propensity distributions by group first.
+
+Conditioning on lagged outcomes changes the identifying assumption from PT to unconfoundedness.
+The two are non-nested; matching on lagged outcomes can create mean-reversion bias when groups
+differ in levels but genuinely trend in parallel (Daw-Hatfield, via Roth et al. 2023). When they
+disagree, the bracketing result bounds the truth: under unconfoundedness with treated-group
+pre-treatment dominance, TWFE underestimates and lagged-outcome adjustment overestimates
+(Arkhangelsky-Imbens 2024). Report both and say which selection story you believe.
+
+## Functional form
+
+Parallel trends in logs precludes parallel trends in levels. Choose the transformation on
+substantive grounds and own it: "DD identification strategies are inherently
+transformation-dependent" (AAFP 2025). Run the Roth-Sant'Anna falsification test of
+insensitivity to functional form when the choice is contestable. Apparent
+transformation-robustness achieved through rich time-varying controls usually means the controls,
+not the fixed effects, are identifying the effect, which is regression conditioning rather than
+DiD, and some such controls are bad controls. For revenue, spend, and engagement outcomes the
+zeros problem is endemic; log(1+y) conclusions are unit-dependent (Chen-Roth), so prefer levels,
+Poisson, or an extensive/intensive margin split.
+
+## Inference
+
+Cluster at the level at which treatment is independently assigned (state policies: state). This
+is the design-based rule (Rambachan-Roth, the DiD instance of Abadie-Athey-Imbens-Wooldridge),
+and it also answers "what is the superpopulation" when the sample is the population. With few
+treated clusters, no method is assumption-free: the map in references/details.md lists each
+option with the homogeneity assumption it needs, which is the selection criterion (Roth et al.
+2023). The honest fallbacks are folding the cluster shock into the HonestDiD violation bound, or
+a cluster-level Fisher randomization test, exact under the sharp null when timing is as good as
+random.
+
+## Beyond the absorbing binary treatment
+
+- Treatments that turn on and off (promotions, price changes): dCDH estimators require
+  no-carryover; for advertising and pricing that assumption is usually wrong, so check it and
+  prefer the intertemporal extension (`DIDmultiplegt`/`did_multiplegt_dyn`).
+- Continuous treatment intensity: ATT(d|d) is identified under standard PT, but causal-response
+  parameters need strong PT across doses (Callaway, Goodman-Bacon, Sant'Anna).
+- Exposure designs (baseline exposure share times a national change): the linear-interaction
+  coefficient is an average marginal effect, roughly kappa + 2 phi E[M], not E[tau_s]; add the
+  squared-exposure interaction when heterogeneity is plausible and report both (AAFP 2025).
+- Triple differences: not simply the difference of two DiDs once covariates or staggered NYT
+  comparisons enter (Ortiz-Villavicencio and Sant'Anna, via Baker et al.).
+- Repeated cross-sections (brand trackers, surveys): fine without covariates; with covariates,
+  test compositional stability (Sant'Anna-Xu Hausman-type check) before pooling.
+
+## Diagnostics battery
+
+Report with every DiD analysis, in roughly this order:
+
+1. Raw group-mean time-series plot (the anatomy plot; it contains every number the estimator
+   uses) and the ATT(g,t) matrix in calendar and event time.
+2. Event study from the robust estimator with sup-t bands, binned horizons, deliberate
+   normalization.
+3. Sup-t joint pretest of the leads, plus its power against a relevant violation (pretrends).
+4. HonestDiD identified set, robust CI, breakdown M-bar, economic reading.
+5. Covariate balance as normalized differences, levels and pre-period changes; flag |nd| > 0.25
+   (0.1 if the covariate is known to matter). A change-imbalance reads as a PT violation only if
+   the covariate is strictly exogenous.
+6. Propensity overlap plot when covariates enter.
+7. TWFE alongside the robust estimator; if they diverge, Goodman-Bacon decomposition
+   (bacondecomp) and dCDH negative-weight diagnostics (TwoWayFEWeights) to show why.
+8. Building-block heterogeneity scan by cohort, gap, and time since adoption.
+9. Composition checks: balanced event time, fixed cohort set.
+10. Functional-form check when the transformation is contestable.
+
+## R implementation
+
+The complete runnable pipeline is scripts/did_template.R: estimation, both HonestDiD
+restrictions with the official adapter included verbatim, pretest power, TWFE and Sun-Abraham
+cross-checks, divergence diagnostics, imputation, the efficient random-timing estimator, and
+balance. Every call signature in it was verified against the package source on 2026-07-28
+(versions pinned in the script). The core, with the two settings that are easy to get wrong:
+
+```r
+library(did)
+atts <- att_gt(yname = "y", tname = "period", idname = "unit",
+               gname = "first_treated",         # 0 = never-treated (did's convention)
+               xformla = NULL,                   # or ~ x1 + x2 for conditional PT
+               control_group = "notyettreated",  # states the PT variant you impose
+               est_method = "dr", clustervars = "cluster",
+               base_period = "universal",        # REQUIRED for the honest_did chain
+               data = df)
+es <- aggte(atts, type = "dynamic", min_e = -15, max_e = 15, cband = TRUE)
+```
+
+Cross-package traps the script handles explicitly: never-treated is coded 0 in did and
+didimputation, Inf in staggered, and any out-of-range value in fixest::sunab, so one recycled
+cohort variable silently misclassifies units; aggte's default type is "group", so event studies
+need type = "dynamic"; pretrends installs from GitHub only. Package links live in
+references/details.md.
+
+Stata equivalents on request: csdid, did_imputation, eventstudyinteract, jwdid, honestdid,
+boottest for wild bootstrap. The Baker et al. AEA replication package
+(aeaweb.org/articles/materials/25430, 25431) is a full R and Stata template.
+
+## Methods paragraph template
+
+Adapt, keeping the first-person limitation at the point of the choice:
+
+> Treatment is staggered and effects are plausibly heterogeneous, so static and dynamic two-way
+> fixed effects estimands can place negative weights on some group-time effects (Roth,
+> Sant'Anna, Bilinski, and Poe 2023; Goodman-Bacon 2021). Following the forward-engineering
+> approach of Baker, Callaway, Cunningham, Goodman-Bacon, and Sant'Anna (2026), I define the
+> target as [unit/person-weighted] group-time ATTs and their event-study aggregation, impose
+> parallel trends with respect to [not-yet-treated] units [conditional on X], and estimate with
+> the doubly robust procedure of Callaway and Sant'Anna (2021), reporting uniform confidence
+> bands. I assess sensitivity to parallel-trends violations following Rambachan and Roth (2023):
+> bounding post-treatment violations by the largest pre-treatment trend difference ([value])
+> gives an identified set of [set] and a robust confidence interval of [CI]; the conclusion
+> survives violations up to M-bar = [breakdown]. A limitation of this design is [the specific
+> PT variant imposed / the few treated clusters / the transformation choice], which costs
+> [what it costs]; I address it by [sensitivity/fallback]. Standard errors are clustered at the
+> [level], the level at which treatment is independently assigned (Roth et al. 2023).
+
+Every claim in the paragraph must trace to a canon entry; references/canon.md maps claims to
+papers and BibTeX keys in the shared causal-design/references/causal.bib. Verify any primary
+paper cited beyond the canon with bibcheck before submission.
+
+## Handoffs
+
+- causal-design: design triage before this skill; shared inference material.
+- synthetic-control: few treated units, long pre-period, selection on lagged outcomes, failed
+  pretests ("sidesteps collinearity concerns while allowing for divergent nonlinear trends",
+  AAFP citing Abadie 2021). Synthetic DiD is that skill's bridge topic, not this one's.
+- field-experiment: when rollout timing was actually randomized, randomization-based tools
+  apply; the staggered estimator itself is documented here (R package staggered, Roth-Sant'Anna).
+- iv: share-balance pre-trend scrutiny for shift-share exposure designs lands here; the
+  parallel-trends toolkit applies to share balance.
+- rdd: policy-date designs masquerading as RD in time arrive here when many units switch at a
+  date; treat the date as an event study, not a cutoff.
+- preregister: pre-specifying a DiD analysis of a known upcoming natural experiment.

--- a/skills/did/references/canon.md
+++ b/skills/did/references/canon.md
@@ -1,0 +1,148 @@
+# DiD canon
+
+Current as of 2026-07-29. These sources are hand-picked; nothing enters this file without
+explicit human approval. BibTeX keys point into ../../causal-design/references/causal.bib.
+Refresh: litreview on the method since the date above, results proposed as flagged addenda.
+
+## Roth, Sant'Anna, Bilinski, and Poe (2023)
+
+Journal of Econometrics 235(2): 2218-2244. Key: `roth2023whats`.
+
+- Role: synthesis and default workflow; the triage checklist.
+- Settles: TWFE failure modes under staggered adoption (negative weights, forbidden comparisons,
+  event-study contamination); the CS-vs-imputation baseline tradeoff; pre-trend tests are
+  underpowered with quantified stakes (Roth 2022 numbers); conditional PT wants RA/IPW/DR, never
+  bare controls; cluster where treatment is independently assigned; the few-clusters map keyed
+  to homogeneity assumptions.
+- Binds when: any staggered design; any pre-trends discussion; any few-clusters problem.
+- Implement: the package table (did/csdid, did2s, didimputation, DIDmultiplegt, fixest::sunab,
+  HonestDiD, pretrends, bacondecomp, TwoWayFEWeights, staggered).
+- Quote: "The lack of a significant pre-trend does not necessarily imply the validity of the
+  parallel trends assumption."
+
+## Baker, Callaway, Cunningham, Goodman-Bacon, and Sant'Anna (2026)
+
+Journal of Economic Literature 64(2): 498-557. Key: `baker2026did`.
+
+- Role: the build-order guide; forward engineering from estimand to estimator; worked Medicaid
+  application with public R and Stata replication code (AEA materials 25430, 25431).
+- Settles: weights define the estimand (unit vs person average, +0.1 vs -2.6); the three formal
+  staggered PT variants (Nev, NYT, all) and the estimator-to-assumption crosswalk; TWFE with
+  covariates fails even in the 2x2 (Caetano-Callaway); DR default with 0.995 propensity
+  trimming; balanced-event-time aggregation; repeated-cross-section composition rules
+  (Sant'Anna-Xu); the DDD warning (Ortiz-Villavicencio-Sant'Anna); worked HonestDiD arithmetic.
+- Binds when: setting up any DiD analysis; choosing the PT variant; covariates enter; the panel
+  is unbalanced or a repeated cross-section.
+- Implement: did::att_gt + aggte as the core stack; est_method="dr"; etwfe/jwdid for Wooldridge;
+  the estimator-to-assumption crosswalk is the paper's core practical content.
+- Quote: TWFE has "well-understood, potentially serious, and easily remedied problems, and we do
+  not recommend using it"; researchers must "clearly state the specific parallel trends
+  assumption they are actually imposing."
+
+## Arkhangelsky and Imbens (2024)
+
+The Econometrics Journal 27(3): C1-C61. Key: `arkhangelsky2024causal`.
+
+- Role: the unifying survey and the boundary document with synthetic-control; the taxonomy the
+  causal-design router uses.
+- Settles: three-axis classification (data type, frame shape, assignment mechanism); DiD, SC,
+  unconfoundedness, and matrix completion as one optimization problem under different
+  restrictions; under selection on lagged outcomes with autocorrelated errors DiD is
+  inconsistent while SC is consistent (the routing result, due to Arkhangelsky-Hirshberg and
+  relayed by this survey); the TWFE-vs-lagged-outcome bracketing; negative-weight concerns
+  "have perhaps been exaggerated" (the named dissent from the clean/forbidden framing);
+  backdated placebo tests can backfire under selection on past shocks.
+- Binds when: choosing between did and synthetic-control; block vs staggered assignment; deciding
+  whether the additive model itself is the weak point.
+- Implement: names no software; the standard mapping (did, fixest::sunab, DIDmultiplegt,
+  didimputation, synthdid, gsynth, fect, MCPanel) is ours, from package docs.
+- Quote: "we recommend against the current routine use of the standard TWFE estimator or related
+  estimators," paired with the block-assignment exception.
+
+## Abadie, Angrist, Frandsen, and Pischke (2025)
+
+NBER WP 34550; chapter of Metrics Remastered, Princeton UP 2026. Key: `abadie2025harvesting`.
+
+- Role: the counterweight; specification mechanics the guides skip; the pro-pretesting position.
+- Settles: lead/lag arithmetic (q = T - min c(s), m = max c(s) - 1); the second-normalization
+  requirement without never-treated units and the path-rotation demonstration; leverage failure
+  of clustered SEs at long horizons, fixed by binning and sup-t bands; the pretesting
+  cost-benefit rule (screening pays when |delta_s|/(2-theta) < delta at calibrated power);
+  exposure-design estimands (average marginal effect, not E[tau_s]); "DD identification
+  strategies are inherently transformation-dependent"; BJS-vs-TWFE agreement in the divorce data
+  as the empirical bottom line.
+- Binds when: writing any event-study specification; no never-treated units; long panels; deciding
+  whether to pretest; exposure designs; the logs-vs-levels choice.
+- Implement: Stata boottest (the only package it names); the sup-t four-step recipe is
+  implementable from the covariance matrix directly (details.md).
+- Quote: heterogeneity concerns "are unlikely to derail DD or event-study designs in practice";
+  "Better to choose these reference points deliberately than to let regression software make
+  hidden—and potentially misleading—choices for you." (the em dashes are the paper's own,
+  verified against NBER WP 34550 p. 2; verbatim quotes keep source punctuation)
+
+## MacKinnon, Nielsen, and Webb (2023)
+
+Journal of Econometrics 232(2): 272-299. Key: `mackinnon2023cluster`.
+
+- Role: execution companion to the Roth et al. few-clusters map; the routine cluster-inference
+  battery, its diagnostics, and the failure signatures.
+- Settles: there is no safe G ("In very favorable cases, inference based on CV1 and the t(G-1)
+  distribution can be fairly reliable when G = 20, but in unfavorable ones it can be unreliable
+  even when G = 200 or more"; score heterogeneity, cluster-size variation, and leverage decide);
+  CV3, the cluster jackknife, is the most reliable CRVE and runs with t(G-1) as first line,
+  cheap even for huge samples; cluster at the assignment level or coarser, largest-SE rule of
+  thumb, and picking the level by test is pre-testing; cluster FEs do not remove intra-cluster
+  dependence outside pure random effects; few treated clusters is a distinct failure ("the CV1
+  standard error of this coefficient can easily be too small by a factor of five or more" at
+  G1 = 1, and CV3 helps but still fails when G1 is very small) while WCR fails the other way
+  (under-rejection, bimodal bootstrap distribution as the tell, ordinary WR bootstrap as the
+  rescue); RI-t over RI-beta under cluster-size heterogeneity; the five concern zones (G <= 12;
+  G1 <= 6 or G - G1 <= 6; seriously unbalanced sizes; atypical treated clusters; leverage
+  concentration); reporting G, cluster sizes, leverage, partial leverage, and effective
+  clusters is part of the method.
+- Binds when: any clustered inference on a CRVE; choosing the clustering level; any of the five
+  concern zones fires; before reaching for the few-clusters map.
+- Implement: Stata boottest, summclust, edfreg, randcmd (the paper's own stack); in R,
+  fwildclusterboot 0.14.3 and summclust 0.7.0 (both archived from CRAN, r-universe builds),
+  clubSandwich CR2/Satterthwaite, sandwich vcovBS jackknife (details.md package index and
+  did_template.R section 10); no R package implements RI-t, hand-roll it.
+- Scope limits: IV with clustered data explicitly out of scope (theory and simulations
+  insufficient; the iv skill must not cite it for clustered-IV fixes); two-way clustering
+  theory still developing; model-based inference only, with the design-based AAIW branch set
+  aside; Donald-Lang is the one map row the guide does not discuss.
+- Quote: "it is therefore absolutely essential to report the number of clusters, G, whenever
+  inference is based on a CRVE. This is even more important than reporting N."
+
+## Named disagreements the skill carries
+
+- TWFE in practice: Baker et al. and Arkhangelsky-Imbens against routine use; AAFP find it
+  adequate with a BJS check. Default: robust headline, TWFE alongside.
+- Pretesting: Roth (2022) caution vs AAFP pro-pretest cost-benefit. Default: sup-t pretest plus
+  power report, never a substitute for HonestDiD.
+- What follows from robust-estimator agreement: AAFP keep TWFE as workhorse; A-I move to
+  factor/SC/SDID because the additive model is the weak point. Presented as live.
+
+## Excluded
+
+- de Chaisemartin and D'Haultfoeuille, "Credible Answers to Hard Questions" (SSRN 4487202,
+  384pp): dropped from canon by human decision 2026-07-28. Their coverage here rests on their
+  published papers as relayed by the surveys, plus the public companion ecosystem:
+  github.com/Credible-Answers (did_multiplegt_dyn and relatives), SSC cc_xd_didtextbook,
+  anzonyquispe.github.io/did_book solutions in Stata, R, and Python.
+
+## Primary papers cited through the surveys
+
+Cite the survey for the synthesis; cite the primary paper for a specific theorem. All entries
+below are resolver-verified in causal.bib (2026-07-28); the ones marked preprint there get
+re-checked with bibcheck at manuscript time. Keys: `goodmanbacon2021timing` (decomposition);
+`callaway2021multiple` (ATT(g,t)); `sun2021dynamic` (contamination, interaction-weighted);
+`dechaisemartin2020twoway` (negative weights); `dechaisemartin2026intertemporal` (intertemporal;
+published ReStat 108(4) on 2026-07-17, superseding NBER w29873); `borusyak2024revisiting`
+(imputation, efficiency); `wooldridge2025mundlak` (ETWFE, supersedes the 2021 SSRN WP);
+`santanna2020doubly` (doubly robust); `rambachan2023credible` (honest inference);
+`roth2022pretest` (pretest power); `ghanem2022selection` (selection mechanisms; preprint);
+`caetano2024covariates` (covariate TWFE; preprint; the four-author time-varying-covariates paper
+is separate); `harmon2022efficient` (pre-period averaging precision; unpublished WP, R&R
+ReStat); `chen2025efficient` (efficient combination; preprint); `roth2023functional`
+(functional form); `chen2024logs` (zeros and logs); `abadie2023clustering` (clustering);
+`gardner2022twostage` (two-stage; preprint, revised co-authored version circulates).

--- a/skills/did/references/details.md
+++ b/skills/did/references/details.md
@@ -1,0 +1,157 @@
+# DiD lookup details
+
+Heavy reference content the SKILL.md points into. Current as of 2026-07-29.
+
+## Package index (verified 2026-07-28)
+
+| Package | Where | Version seen | Role |
+|---|---|---|---|
+| did | CRAN; bcallaway11.github.io/did | 2.5.1 | Callaway-Sant'Anna att_gt/aggte |
+| HonestDiD | CRAN; github.com/asheshrambachan/HonestDiD | 0.2.8 | Rambachan-Roth, both restrictions; README ships the aggte adapter |
+| didimputation | CRAN; github.com/kylebutts/didimputation | 0.5.1 | BJS imputation |
+| did2s | CRAN | | Gardner two-stage |
+| fixest | CRAN; lrberge.github.io/fixest | 0.14.2 | sunab (Sun-Abraham), TWFE (pinned also in iv's details; update the two pins together on refresh) |
+| pretrends | GitHub ONLY: github.com/jonathandroth/pretrends | master | pretest power, slope_for_power |
+| staggered | CRAN; github.com/jonathandroth/staggered | 1.2.2 | efficient random-timing estimators |
+| TwoWayFEWeights | CRAN; github.com/Credible-Answers/twowayfeweights | 2.1.0 | dCDH negative-weight diagnostics |
+| bacondecomp | CRAN; github.com/evanjflack/bacondecomp | 0.1.1 | Goodman-Bacon decomposition |
+| etwfe | CRAN | | Wooldridge extended TWFE |
+| DIDmultiplegt / did_multiplegt_dyn | CRAN/SSC; github.com/Credible-Answers | | dCDH intertemporal, on/off treatments |
+| summclust | ARCHIVED from CRAN 2025-11-02; install from s3alfisc.r-universe.dev | 0.7.0 | CV3 cluster-jackknife vcov, leverage, partial leverage, leave-one-cluster-out betas |
+| fwildclusterboot | ARCHIVED from CRAN 2024-05-29; install from s3alfisc.r-universe.dev | 0.14.3 | boottest wild cluster bootstrap: WCR/WCU, Rademacher/Webb weights, MNW "33" variants |
+| clubSandwich | CRAN | 0.7.0 | CR2 vcovCR + Satterthwaite coef_test, the CRAN-resident cross-check |
+| sandwich | CRAN | | vcovBS(type = "jackknife"), a CRAN-resident CV3 route for linear models, no leverage diagnostics |
+
+Never-treated coding by package: did and didimputation use 0 (didimputation also accepts NA);
+staggered uses Inf; sunab treats any cohort value outside the observed periods as never-treated
+(the fixest example data uses 10000). Recode per package; never recycle blindly.
+
+Cluster-inference rows verified 2026-07-29. Install the archived pair with
+install.packages(c("summclust", "fwildclusterboot"), repos = "https://s3alfisc.r-universe.dev").
+boottest's fixest method takes feols objects only and disallows weights with fixed effects.
+
+## Few-clusters map (choose by the homogeneity you believe)
+
+Map from Roth et al. (2023) Section 5 (`roth2023whats`); execution order, thresholds, and
+failure signatures from MacKinnon, Nielsen, and Webb (2023, `mackinnon2023cluster`; MNW in
+the rows). Each method with the assumption that is its price:
+
+| Method | Needs | Works when |
+|---|---|---|
+| CV3 cluster jackknife with t(G-1) | across-cluster independence only | the default first line at any G, not a few-clusters specialist; sometimes under-rejects; still fails with very few treated clusters |
+| CR2 with Satterthwaite dof | a working model for the dof (identity or random-effects variance); the Imbens-Kolesar variant fails with absorbed cluster FEs | confirmation tool, not first line; the dof can fall far below G-1 |
+| Donald-Lang | homoskedastic Gaussian cluster shocks | few treated and few untreated (the one row MNW do not discuss) |
+| Conley-Taber | treated clusters share controls' error distribution (fails under heterogeneous effects or unequal sizes) | many controls, few treated; RI-beta-like, so under cluster-size heterogeneity prefer RI-t (MacKinnon-Webb 2020b) |
+| Ferman-Pinto | heteroskedasticity only from observables (size); the restriction is exactly why it can work with one treated cluster (MNW p. 287) | Conley-Taber setting plus size variation |
+| Hagemann permutation | bound on maximal relative heterogeneity; no cluster-specific trend heterogeneity in Y(0); G1 >= 4 and G - G1 >= 4 | few clusters both sides |
+| Cluster wild bootstrap (WCR) | homogeneity conditions that fail with cluster-and-time FEs or heterogeneous effects (Canay-Santos-Shaikh) | not a general fix. With few treated it under-rejects (every other method over-rejects); a bimodal bootstrap distribution is the tell; use Webb 6-point weights plus enumeration when 2^G is small; the rescue is the ordinary wild restricted (WR, observation-level weights) bootstrap |
+| Long-T methods (Canay-Romano-Shaikh, Ibragimov-Mueller, conformal) | limited time-series dependence, PT over many periods; CRS needs treated and control observations inside every cluster (merge clusters, pay power); IM infeasible when treatment is cluster-invariant | T genuinely large |
+| Fallback A | none beyond honesty | treat the cluster shock as a PT violation inside HonestDiD |
+| Fallback B: cluster-level Fisher randomization test | timing as good as random; exact under the sharp null | arbitrary heterogeneity allowed; a null is informative |
+
+## Few-clusters battery (MacKinnon, Nielsen, and Webb 2023)
+
+Run before reaching for the map; the map is the escalation path when the battery disagrees.
+Condensed from `mackinnon2023cluster` Section 9:
+
+1. List plausible clustering levels; decide by the assignment-level rule and the largest-SE
+   rule (score-variance tests and placebo regressions optional; picking the level by test is
+   pre-testing).
+2. Report G and the cluster-size distribution for every plausible level.
+3. Report leverage, partial leverage, influence, and the effective number of clusters for the
+   key specification.
+4. Run CV3 (cluster jackknife) and at least one WCR bootstrap alongside CV1, for tests and
+   intervals, as a matter of course. Agreement means finite-sample problems are probably not
+   severe. Disagreement means try more variants and the map.
+5. With few or atypical treated (or control) clusters, even CV3 and WCR are unreliable; verify
+   with randomization inference (RI-t degrades less than RI-beta under cluster-size
+   heterogeneity).
+
+Concern zones, verbatim thresholds (p. 290): "few but balanced clusters (say, G <= 12)";
+"balanced but few treated (or few control) clusters (say G1 <= 6 or G - G1 <= 6)"; "seriously
+unbalanced cluster sizes (even when G is quite large)"; "treated clusters that are unusually
+large or small"; "any sort of heterogeneity that causes a few clusters to have high leverage".
+Three of the five can fire at large G. Reporting is part of the method: "it is therefore
+absolutely essential to report the number of clusters, G, whenever inference is based on a
+CRVE. This is even more important than reporting N." G and the leverage diagnostics go in the
+paper alongside N.
+
+## Sup-t uniform band recipe (AAFP 2025, four steps)
+
+1. Estimate the leads (or lags), save coefficients and their full covariance matrix.
+2. Simulate many draws from N(0, Sigma-hat).
+3. For each draw take the maximum absolute t-statistic across coefficients.
+4. The 1-alpha quantile of that distribution is the critical value; band = estimate +/- cv * se.
+
+Compute separately for leads and lags. Expect true size above nominal with clustered SEs (0.146
+at nominal 5% in AAFP's calibrated design). Wild-bootstrap variant (null imposed, Rademacher
+weights, 999 reps, bootstrap the max-t via Stata boottest): near-nominal size 0.049, power only
+0.31; use when a false rejection is costlier than a miss.
+
+## Pretesting cost-benefit (AAFP 2025)
+
+Unconditional bias delta * theta vs screened bias delta_s * P[divergent | pass]. Screening
+reduces bias when |delta_s| (1-pi) / ((1-pi) theta + (1-alpha)(1-theta)) < delta; at power 0.5
+and nominal size, screening pays when |delta_s| / (2 - theta) < delta. Caveat carried with it:
+screened BJS can be more biased than screened regression under linear divergent trends, because
+BJS baselines on the whole pre-period average (short lags worst).
+
+## Covariate balance: normalized differences
+
+(X-bar_T - X-bar_C) / sqrt((S_T^2 + S_C^2)/2), reported for baseline levels and for pre-period
+changes, weighted and unweighted (Imbens-Rubin via Baker et al.). Flags: |nd| > 0.25
+problematic, 0.1 already worrisome for a covariate known to matter. A Delta-X balance check is
+literally a 2x2 DiD with X as the outcome, so a change-imbalance indicates a PT violation only
+if X is strictly exogenous; if treatment can move X, the imbalance may be a treatment effect.
+
+## RA / IPW / DR mechanics (Baker et al. 2026)
+
+- RA: fit E[dY | X, D=0] on controls, average predictions over treated-unit X. Survives weak
+  overlap by extrapolation; credibility rests on that extrapolation.
+- IPW: reweight control trends by p(X)/(1-p(X)) so the control covariate distribution matches
+  the treated. Noisy as control p(X) approaches 1; trim at 0.995 (package default), keep the
+  trim, use bias correction (Ma-Sasaki-Wang) if trimming more aggressively.
+- DR: combine; consistent if either model is right, efficient if both are (Sant'Anna-Zhao).
+- Event studies: long differences Y_t - Y_{g-1}; propensity model period-invariant, outcome
+  model per-period. Staggered: group-time propensity P(G=g | X, in g or not-yet-treated at t).
+- BJS and dCDH take covariates only in levels, so they do not implement conditional PT proper;
+  Wooldridge ETWFE with interactions does.
+
+## Exposure-design estimand (AAFP 2025)
+
+With tau_s = kappa + phi M_s, the linear-interaction regression estimates approximately the
+average marginal effect kappa + 2 phi E[M_s], twice as sensitive to exposure as the
+random-coefficient average E[tau_s] = kappa + phi E[M_s]. Nunn-Qian numbers: pooled OLS 0.81,
+weighted average of tau_s about 0.55, computed AME about 0.75 (matching OLS). Which target is
+right depends on whether tau_s rising with M_s is itself causal. When heterogeneity is
+plausible, add the exposure-squared interaction and report both.
+
+## Minimal teaching counterexamples (AAFP 2025)
+
+- Dynamic heterogeneity: two states, true effects 1 on impact and 4 thereafter; static DD
+  returns -0.5 because already-treated units serve as controls.
+- Cross-sectional heterogeneity: constant per-state effects of 1 and 4 produce an event-study
+  tau_1 = -2 through the implicit cross-state extrapolation.
+
+## Repeated cross-sections and unbalanced panels (Baker et al. 2026)
+
+Unconditional DiD needs only group-time means: repeated cross-sections and unbalanced panels are
+fine with the estimand reinterpreted (ATT among units sampled post). With covariates: if the
+joint distribution of (D, X) is time-invariant, pool across periods for precision; if
+composition may change, do not pool, target ATT(2 | sampled in 2), and run the Sant'Anna-Xu
+Hausman-type comparison. Staggered warning: the Sun-Abraham regression with unit FEs on
+unbalanced data no longer equals the CS estimator; replace unit FEs with group dummies.
+
+## Estimator-to-assumption crosswalk (code level)
+
+- did::att_gt(control_group="nevertreated") imposes PT-GT-Nev.
+- did::att_gt(control_group="notyettreated") imposes PT-GT-NYT (Baker et al.'s preference).
+- etwfe / jwdid, did2s, didimputation, and any pre-period-averaging estimator impose PT-GT-all
+  (parallel pre-trends become a testable overidentifying restriction, and are baked in).
+- fixest::sunab equals CS-never numerically on balanced panels; on unbalanced panels the
+  equivalence fails (see above).
+- lpdid (local projections DiD) is equivalent to the CS-NYT plug-in (Dube-Girardi-Jorda-Taylor).
+- Stacked regression (clean-controls stacks) appears in marketing practice and in the AMA
+  Marketing News routing source (Li, Luo, and Pattabhiramaiah 2024; 'AMA' hereafter); its
+  implicit variance weights are a known problem (Baker et al.), so prefer Callaway-Sant'Anna
+  or Sun-Abraham unless the stack weights are examined and reported.

--- a/skills/did/scripts/did_template.R
+++ b/skills/did/scripts/did_template.R
@@ -1,0 +1,254 @@
+# DiD analysis template. Runnable end to end; every call signature verified against the
+# package source/README on 2026-07-28 (versions noted per section). Adapt the column names
+# in the CONFIG block and run section by section.
+#
+# Data expectations: long panel with one row per unit-period.
+#   unit          unit id
+#   period        integer time (consecutive)
+#   first_treated integer cohort = first treated period, coded 0 for never-treated
+#                 (the did/didimputation convention; sections recode where a package
+#                 differs: staggered wants Inf, fixest::sunab wants any out-of-range value.
+#                 Recycling one coding across packages silently misclassifies units.)
+#   y             outcome
+#   cluster       level at which treatment is independently assigned
+#   treat         derived below (section 5): post-adoption indicator, 1 from first_treated
+#                 on for treated units, 0 always for never-treated (first_treated == 0)
+
+## ---- CONFIG ----------------------------------------------------------------
+YNAME <- "y"; TNAME <- "period"; IDNAME <- "unit"; GNAME <- "first_treated"
+CLUSTER <- "cluster"
+XFORMLA <- NULL              # e.g. ~ x1 + x2 for conditional PT; NULL = unconditional
+df <- your_data              # replace
+
+## ---- 0. Packages -----------------------------------------------------------
+# CRAN: did (2.5.x), HonestDiD (0.2.8), didimputation (0.5.x), TwoWayFEWeights (2.1.x),
+#       bacondecomp (0.1.1), fixest, staggered (1.2.x)
+# GitHub only (not on CRAN): pretrends -> devtools::install_github("jonathandroth/pretrends")
+library(did); library(HonestDiD); library(fixest)
+
+## ---- 1. Group-time ATTs (Callaway-Sant'Anna) -------------------------------
+# base_period = "universal" is REQUIRED for the honest_did sensitivity chain below
+# (the helper hard-errors otherwise). control_group states the PT variant you impose:
+# "notyettreated" = PT-NYT (default here), "nevertreated" = PT-Nev.
+atts <- att_gt(
+  yname = YNAME, tname = TNAME, idname = IDNAME, gname = GNAME,
+  xformla = XFORMLA, data = df,
+  control_group = "notyettreated",
+  est_method = "dr",                 # "dr" | "ipw" | "reg"
+  clustervars = CLUSTER,
+  base_period = "universal"
+)
+summary(atts)
+
+## ---- 2. Aggregations -------------------------------------------------------
+# aggte's default type is "group"; event studies need type = "dynamic" explicitly.
+# cband = TRUE gives simultaneous (uniform) bands via multiplier bootstrap.
+# +/-15 is AAFP's window for a 41-period panel; set min_e/max_e from your own q and m.
+es  <- aggte(atts, type = "dynamic", min_e = -15, max_e = 15, cband = TRUE)
+att <- aggte(atts, type = "group")
+ggdid(es)
+# Composition check: balanced-in-event-time aggregation (units observed over the window)
+# balance_e = 5 is a placeholder; set it to the horizon you report.
+es_bal <- aggte(atts, type = "dynamic", balance_e = 5, cband = TRUE)
+
+## ---- 3. Honest sensitivity (Rambachan-Roth) --------------------------------
+# Run for every event study: this family's own hardening of the canon's best-practice
+# endorsement (did/SKILL.md).
+# helper source verbatim from the HonestDiD README (github.com/asheshrambachan/HonestDiD,
+# "staggered timing" section, fetched 2026-07-28). Requires consecutive event times with
+# -1 as the reference period.
+honest_did <- function(...) UseMethod("honest_did")
+
+honest_did.AGGTEobj <- function(es,
+                                e          = 0,
+                                type       = c("smoothness", "relative_magnitude"),
+                                gridPoints = 100,
+                                ...) {
+  type <- match.arg(type)
+  if (es$type != "dynamic") stop("need to pass in an event study")
+  if (es$DIDparams$base_period != "universal") stop("Use a universal base period for honest_did")
+  es_inf_func <- es$inf.function$dynamic.inf.func.e
+  n <- nrow(es_inf_func)
+  V <- t(es_inf_func) %*% es_inf_func / n / n
+  referencePeriod <- -1
+  consecutivePre  <- !all(diff(es$egt[es$egt <= referencePeriod]) == 1)
+  consecutivePost <- !all(diff(es$egt[es$egt >= referencePeriod]) == 1)
+  if (consecutivePre | consecutivePost) {
+    stop("honest_did expects a time vector with consecutive time periods;\nplease re-code your event study and interpret the results accordingly.")
+  }
+  hasReference <- any(es$egt == referencePeriod)
+  if (hasReference) {
+    referencePeriodIndex <- which(es$egt == referencePeriod)
+    V    <- V[-referencePeriodIndex, -referencePeriodIndex]
+    beta <- es$att.egt[-referencePeriodIndex]
+  } else {
+    beta <- es$att.egt
+  }
+  nperiods <- nrow(V)
+  npre     <- sum(1 * (es$egt < referencePeriod))
+  npost    <- nperiods - npre
+  if (!hasReference & (min(c(npost, npre)) <= 0)) {
+    stop(paste0(if (npost <= 0) "not enough post-periods" else "not enough pre-periods",
+                " (check your time vector; note honest_did takes -1 as the reference period)"))
+  }
+  baseVec1 <- basisVector(index = (e + 1), size = npost)
+  orig_ci  <- constructOriginalCS(betahat = beta, sigma = V,
+                                  numPrePeriods = npre, numPostPeriods = npost,
+                                  l_vec = baseVec1)
+  if (type == "relative_magnitude") {
+    robust_ci <- createSensitivityResults_relativeMagnitudes(
+      betahat = beta, sigma = V, numPrePeriods = npre, numPostPeriods = npost,
+      l_vec = baseVec1, gridPoints = gridPoints, ...)
+  } else if (type == "smoothness") {
+    robust_ci <- createSensitivityResults(
+      betahat = beta, sigma = V, numPrePeriods = npre, numPostPeriods = npost,
+      l_vec = baseVec1, ...)
+  }
+  list(robust_ci = robust_ci, orig_ci = orig_ci, type = type)
+}
+
+# 3a. Relative magnitudes: post violations bounded by Mbar x the largest pre violation.
+#     Report the breakdown Mbar at which the conclusion dies, and read it economically.
+#     Widen Mbarvec until the breakdown Mbar sits inside the grid; a capped grid cannot
+#     locate the breakdown this skill requires reporting.
+hd_rm <- honest_did(es, e = 0, type = "relative_magnitude",
+                    Mbarvec = seq(0.5, 3, by = 0.5))
+createSensitivityPlot_relativeMagnitudes(hd_rm$robust_ci, hd_rm$orig_ci)
+
+# 3b. Smoothness: violations bounded by M deviations from a linear extrapolation of the
+#     pre-trend. Binds when the worry is a smoothly evolving confound (secular trend);
+#     relative magnitudes binds when the worry is shocks like those seen pre-treatment.
+hd_sm <- honest_did(es, e = 0, type = "smoothness",
+                    Mvec = seq(0, 0.05, by = 0.01))   # scale M to your outcome units
+createSensitivityPlot(hd_sm$robust_ci, hd_sm$orig_ci)
+
+## ---- 4. Pre-test power (pretrends, GitHub) ---------------------------------
+# Power of the pre-test against a violation you consider economically relevant.
+# beta/sigma extracted from the event study the same way honest_did does.
+library(pretrends)
+inf  <- es$inf.function$dynamic.inf.func.e
+Vall <- t(inf) %*% inf / nrow(inf) / nrow(inf)
+keep <- es$egt != -1
+sigma_es <- Vall[keep, keep]; beta_es <- es$att.egt[keep]; tVec <- es$egt[keep]
+slope50 <- slope_for_power(sigma = sigma_es, targetPower = 0.5,
+                           tVec = tVec, referencePeriod = -1)
+pt <- pretrends(betahat = beta_es, sigma = sigma_es, tVec = tVec,
+                referencePeriod = -1,
+                deltatrue = slope50 * (tVec - (-1)))
+pt$df_power       # power, Bayes factor, likelihood ratio
+pt$event_plot_pretest
+
+## ---- 5. TWFE alongside, and Sun-Abraham cross-check ------------------------
+# Post-treatment indicator for the TWFE, bacon, and twowayfeweights calls. Never-treated
+# units (first_treated == 0) must stay 0: without the != 0 guard, period >= 0 would mark
+# them treated everywhere, the same cohort-recoding trap flagged for sunab below.
+df$treat <- as.integer(df$first_treated != 0 & df$period >= df$first_treated)
+twfe <- feols(as.formula(paste(YNAME, "~ treat |", IDNAME, "+", TNAME)),
+              data = df, cluster = df[[CLUSTER]])
+# sunab treats any cohort value outside the observed periods as never-treated;
+# recode 0 -> 10000 (do NOT feed the did-style 0, it would read as an early cohort).
+df$first_treated_sunab <- ifelse(df[[GNAME]] == 0, 10000, df[[GNAME]])
+sa <- feols(as.formula(paste(YNAME, "~ sunab(first_treated_sunab,", TNAME, ") |",
+                             IDNAME, "+", TNAME)),
+            data = df, cluster = df[[CLUSTER]])
+
+## ---- 6. Divergence diagnostics (run when TWFE and CS disagree) -------------
+library(bacondecomp)
+bd <- bacon(as.formula(paste(YNAME, "~ treat")), data = df,
+            id_var = IDNAME, time_var = TNAME)   # weights on each 2x2, incl. forbidden
+library(TwoWayFEWeights)
+tw <- twowayfeweights(df, YNAME, IDNAME, TNAME, "treat", type = "feTR",
+                      summary_measures = TRUE)   # negative weights, sign-reversal stats
+
+## ---- 7. Imputation estimator (PT-all upgrade) ------------------------------
+# Only when you will defend parallel pre-trends over the whole panel.
+# didimputation codes never-treated as 0 or NA (same as did).
+# pretrends = -5:-1 is a placeholder; match your panel.
+library(didimputation)
+imp <- did_imputation(data = df, yname = YNAME, gname = GNAME,
+                      tname = TNAME, idname = IDNAME,
+                      horizon = TRUE, pretrends = -5:-1)
+
+## ---- 8. Quasi-random timing (efficient estimator) --------------------------
+# staggered codes never-treated as g = Inf.
+# eventTime = 0:10 is a placeholder; match your panel.
+library(staggered)
+df$g_inf <- ifelse(df[[GNAME]] == 0, Inf, df[[GNAME]])
+st <- staggered(df = df, i = IDNAME, t = TNAME, g = "g_inf", y = YNAME,
+                estimand = "eventstudy", eventTime = 0:10)
+
+## ---- 9. Covariate balance: normalized differences --------------------------
+norm_diff <- function(x, treated) {
+  (mean(x[treated]) - mean(x[!treated])) /
+    sqrt((var(x[treated]) + var(x[!treated])) / 2)
+}
+# Report for baseline levels and pre-period changes; flag |nd| > 0.25 (0.1 if the
+# covariate is known to matter). A change-imbalance reads as a PT violation only if
+# the covariate is strictly exogenous.
+
+## ---- 10. Few clusters / few treated (MacKinnon-Nielsen-Webb) ----------------
+# Signatures in this section verified 2026-07-29. summclust (0.7.0) and
+# fwildclusterboot (0.14.3) are ARCHIVED from CRAN; install from r-universe:
+#   install.packages(c("summclust", "fwildclusterboot"),
+#                    repos = "https://s3alfisc.r-universe.dev")
+# CRAN-resident fallbacks: clubSandwich (CR2 + Satterthwaite, 10c below) and sandwich's
+# vcovBS(type = "jackknife"), the CV3-type estimator for linear models, without the
+# leverage diagnostics.
+
+# 10a. CV3 (cluster jackknife) with leverage diagnostics on the TWFE fit from section 5.
+# Report G, the cluster-size distribution, leverage, partial leverage, and the effective
+# number of clusters alongside N, always.
+library(summclust)
+sc <- summclust(twfe, cluster = CLUSTER, params = "treat", type = "CRV3")
+summary(sc)   # CV3 vcov with t(G-1); leverage_g, partial_leverage, beta_jack
+plot(sc)
+# If some leave-one-cluster-out estimate in beta_jack cannot be computed (the only
+# treated cluster was deleted), do not believe the original estimates.
+
+# 10b. Restricted wild cluster bootstrap (WCR: impose_null = TRUE). boottest's fixest
+# method takes feols objects only and disallows weights combined with fixed effects.
+# Use type = "webb" (6-point weights) when G is small: only 2^G Rademacher draws exist
+# (G = 12 gives 4,096), and boottest enumerates them all when B > 2^G. Pick B so
+# alpha * (B + 1) is an integer (9999 or 99999).
+library(fwildclusterboot)
+wcr <- boottest(twfe, param = "treat", B = 9999, clustid = CLUSTER,
+                type = "rademacher", impose_null = TRUE, bootstrap_type = "fnw11")
+wcr           # p-value and CI to set beside the CV1 and CV3 answers
+# Plot the bootstrap t-statistic distribution: bimodality is the few-treated failure
+# signature (WCR then under-rejects while every CRVE over-rejects).
+# Cross-check with the "33" variant (CV3 statistic, jackknife-transformed bootstrap
+# scores); it over-rejects less as regressors multiply and cluster sizes diverge.
+wcr33 <- boottest(twfe, param = "treat", B = 9999, clustid = CLUSTER,
+                  type = "rademacher", impose_null = TRUE, bootstrap_type = "33")
+# The same calls run on the Sun-Abraham fit (sa, section 5) with the sunab coefficient
+# name as param, for event-study leads and lags.
+
+# 10c. CRAN cross-check: CR2 with Satterthwaite dof (clubSandwich 0.7.0). The dof can
+# fall far below G-1; the Imbens-Kolesar variant is inapplicable once cluster FEs are
+# absorbed.
+library(clubSandwich)
+vc2 <- vcovCR(twfe, cluster = df[[CLUSTER]], type = "CR2")
+coef_test(twfe, vcov = vc2, test = "Satterthwaite")
+
+# 10d. Few treated (or control) clusters: CV1/CV2 standard errors can be too small by a
+# factor of five or more at G1 = 1; CV3 over-rejects less but still fails when G1 is
+# very small; WCR fails the other way (under-rejection, essentially zero at G1 = 1).
+# Rescues, in order: the ordinary wild restricted (WR, observation-level weights)
+# bootstrap; randomization inference; the synthetic-control handoff for one or very few
+# treated. No R package implements MacKinnon-Webb RI-t; hand-roll it (about 20 lines):
+#   1. enumerate the C(G, G1) assignments of which clusters are treated, or draw
+#      B = 99999 re-randomizations without replacement when enumeration is infeasible
+#      (B picked so alpha * (B + 1) is an integer, the same rule as in 10b);
+#   2. re-estimate and compute the cluster-robust t statistic under each assignment;
+#   3. the p-value counts the actual assignment among those at least as extreme (the
+#      P*_2 convention).
+# RI needs timing as good as random and treated clusters not systematically different.
+# Under cluster-size heterogeneity RI-t degrades less than RI-beta, so RI-t is the
+# default.
+
+## ---- Session ---------------------------------------------------------------
+# Pin versions in the replication package: did >= 2.5, HonestDiD 0.2.8. did 2.5
+# defaults faster_mode = TRUE and aggte's default type is "group", both changed
+# from the 2.1.x tutorials. summclust 0.7.0 and fwildclusterboot 0.14.3 come from
+# r-universe, not CRAN; record the repo in the replication package.
+sessionInfo()

--- a/skills/field-experiment/SKILL.md
+++ b/skills/field-experiment/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: field-experiment
+description: Design, analyze, and write up randomized experiments (field experiments, A/B tests, RCTs), covering stratified and clustered designs, randomization inference, covariate adjustment done right, noncompliance, attrition and gated outcomes, treatment-effect heterogeneity, and interference. Produces advice with citations, R estimation and diagnostics code, and a drafted methods paragraph. TRIGGER on "A/B test", "randomized experiment", "RCT", "field experiment", "holdout", "lift test", "randomization inference", "stratified randomization", "cluster randomized", "geo experiment", "power analysis", "MDE", "encouragement design", "noncompliance", "ITT", "attrition", "Lee bounds", "CUPED", "variance reduction", "uplift", "heterogeneous treatment effects", "causal forest" (experimental heterogeneity; observational causal forests belong to causal-design), "interference", "spillover", "SUTVA". Pre-registration documents belong to the preregister skill; design triage across methods belongs to causal-design.
+---
+
+# Field experiments
+
+An opinionated experimental workflow grounded in a read canon (references/canon.md, current as
+of 2026-07-28): the Athey-Imbens handbook chapter as the spine (randomization-based inference
+first), Freedman's logistic-regression critique and Lin's repair for covariate adjustment,
+Guo-Basse's generalization to nonlinear outcomes, and Lee's bounds for attrition and gated
+outcomes. The deliverable is the design or analysis decision with the citation that justifies
+it, the estimation and diagnostics code in R, and a methods paragraph with the limitation
+stated in first person at the point of the choice.
+
+Refresh path: run the litreview skill on the method since the canon date and fold results into
+references/canon.md as flagged addenda.
+
+## Design first: decisions that cannot be fixed ex post
+
+- Stratify at design time instead of adjusting at analysis time. Ex ante stratification with
+  equal treatment fractions weakly dominates complete randomization in expected squared error,
+  even in small samples and even when the stratifier is useless; ex post regression adjustment
+  can hurt when covariates are unpredictive. Stratify as finely as possible subject to at
+  least two treated and two control units per stratum.
+- The family's default is fine stratification with at least two treated and two control per
+  stratum, not pairs: within-pair variances are not estimable (Athey-Imbens) and the
+  pair-level variance is conservative for the sample ATE. Pairing remains a defensible
+  design under later matched-pair work (Bai 2022). A study that pairs should cite that
+  literature and must analyze as paired.
+- Re-randomization is implicit stratification and is analyzable only if the acceptance rule
+  was written down before drawing. No written rule means p-values are only interpretable as
+  conservative. Prefer building balance into strata.
+- Clustered assignment: choose the estimand before the estimator. The cluster-average effect
+  and the unit-average effect differ whenever effects covary with cluster size, and with
+  very unequal clusters the unit-weighted estimand can be nearly unlearnable while the
+  cluster-average stays precise. Cluster-level analysis is the primary, most transparent
+  specification; report both estimands when cluster sizes vary a lot. Geo experiments and
+  store-level rollouts are exactly this case (average-store vs average-customer effect).
+- Power before the experiment, with the closed-form minimum-N formula (worked example and
+  algebra in references/details.md; a treated share of one half is optimal under
+  homoskedasticity). For stratified and clustered designs, simulate the design instead
+  (DeclareDesign). Ex-post power from observed effects is not a diagnostic anywhere in this
+  family of skills.
+
+Adaptive and bandit experiments are out of scope here and unrouted in the family: no canon
+source covers adaptive inference. The caution stands regardless: naive sample means are biased
+under adaptive assignment, because the arm that looked worse early gets its sample truncated
+(the caution and its citation live in causal-design). The practical exits are a final
+non-adaptive confirmatory phase or restricting analysis to a uniform-assignment holdout.
+Beyond those two, this family declines.
+
+## Analysis defaults
+
+- Report a randomization-inference p-value and the Neyman difference in means with its
+  conservative variance side by side. The Fisher exact test uses the difference in means by
+  default, mean ranks under heavy tails or many zeros, and an omnibus quadratic form for
+  multiple outcomes, all inside the same randomization distribution.
+- Analyze as randomized: stratified designs get within-stratum differences averaged with
+  stratum weights, paired designs the across-pair variance, clustered designs the
+  cluster-level machinery or Liang-Zeger with small-sample correction (CR2). Ignoring a
+  paired design roughly doubled the standard error in the canon's worked example.
+- HC2 is the default variance everywhere (it reproduces the Neyman estimator exactly for a
+  binary treatment); with a rare treatment arm Eicker-Huber-White (EHW, i.e. HC0) is
+  anti-conservative, so use HC2 with Behrens-Fisher/Satterthwaite degrees of freedom.
+  Small-cell pricing and email tests live in exactly this regime.
+- One caveat carried honestly: exact tests of the sharp null are exact, but inverting
+  Fisher-Pitman permutation tests into CIs for the ATE can undercover under heterogeneous
+  effects with unbalanced designs. Test sharp nulls by permutation; interval-estimate the ATE
+  with Neyman/HC2 machinery.
+- Continuous monitoring and optional stopping are not covered by the canon. The design-time
+  answer is a stopping rule fixed in the preregistration (the preregister skill's field). If
+  the platform peeked at interim results, fixed-sample p-values are invalid, and this family
+  has no always-valid inference route to offer.
+
+## Covariate adjustment, the settled version
+
+- The unadjusted difference in means comes first in every table. It is the hands-above-the-
+  table number, visibly not the product of a specification search.
+- If adjusting with OLS: demeaned covariates, full treatment-by-covariate interactions, HC2.
+  That estimator cannot hurt asymptotic precision relative to the difference in means (Lin
+  2013); both conditions are load-bearing, and uncentered interactions lose the guarantee
+  entirely. With near-equal arms the uninteracted legacy specification is asymptotically
+  harmless; with a 90/10 holdout the interactions are what protect you. estimatr::lm_lin is
+  the reference implementation.
+- Choose covariates for outcome prediction, fixed before outcomes are seen. A pre-period
+  measure of the outcome is the one covariate reliably worth having (this is what CUPED-style
+  industry variance reduction adjusts for; same estimator family).
+- Binary outcomes: the logit coefficient on treatment is inconsistent for the marginal effect
+  even under a true model, because the odds ratio is noncollapsible (Freedman 2008). Never
+  report exp(beta) from a covariate-adjusted logit as the lift, and never compare odds ratios
+  across specifications or samples with different covariates. Primary analysis is the
+  difference in proportions with HC2, which is the linear probability model in saturated
+  form: under randomization its coefficient IS the marginal effect, read directly off the
+  table, and lm_lin on a binary outcome is the covariate-adjusted LPM with the same
+  guarantee (the classic LPM objections have no force here; details.md). For precision,
+  standardize an interacted logistic working model to the marginal risk difference, which is
+  the average marginal effect, never the marginal effect at the mean. With multiple arms,
+  OLS on arm dummies reads out each contrast directly; multi-arm logit coefficients stay
+  conditional.
+- Nonlinear outcomes generally (Guo-Basse 2023): impute each arm's missing potential outcomes
+  from separate per-arm fits and average. Routing by outcome type: binary to logistic
+  imputation, counts to Poisson (45 percent shorter intervals than linear adjustment in their
+  worked example), skewed-positive (revenue) to log-OLS with second-stage-OLS recalibration,
+  otherwise Lin. Canonical links calibrate automatically; anything else gets recalibrated.
+  Three pre-trust checks: no separation (fitted values near 0/1), per-arm R2 not both near 1,
+  model flexibility small relative to arm sizes. There is NO universal never-worse guarantee
+  for nonlinear imputation; platforms that want one use linear imputation or no-harm
+  calibration. Never report a log-scale coefficient as the level-scale effect.
+
+## Noncompliance
+
+ITT is the only analysis randomization alone justifies; report it always, and it is the
+headline when assignment is the policy lever. The LATE (ITT over first stage) adds exclusion
+and monotonicity, which randomization does not deliver; argue them with the iv skill's
+discipline (exclusion by compliance type, monotonicity by instrument direction). As-treated
+and per-protocol comparisons are uninterpretable mixtures, ruled out entirely: exposed-vs-
+unexposed comparisons in ad experiments are this error. Report compliance shares, Balke-Pearl
+bounds when exclusion is doubtful, and, before generalizing beyond compliers, the two
+Bertanha-Imbens comparability tests (always-takers vs treated compliers, never-takers vs
+untreated compliers). Ghost ads and PSA holdouts are one-sided noncompliance: ITT is lift on
+assignment, LATE is lift on exposure.
+
+## Attrition and gated outcomes (the Lee block)
+
+Any outcome observed only conditional on a post-treatment event (spend given retention,
+satisfaction given response, wages given employment, order value given purchase) triggers
+this block. Conditioning on the gate is conditioning on a post-treatment variable, and a
+perfect experiment identifies nothing about the gated outcome without more assumptions.
+
+1. Compute the differential observation rate between arms first.
+2. Near zero: run the monotonicity balance test (baseline covariates balanced within the
+   selected subsample). If it passes, report the selected-sample difference labeled as the
+   effect for the always-observed stratum; the untrimmed estimate is the efficient choice
+   there.
+3. Otherwise Lee bounds are the primary analysis: trim the higher-observation arm's outcome
+   distribution by the excess share p0 = (s_T - s_C)/s_T from the top for the lower bound and
+   the bottom for the upper bound; sharp under randomization plus monotone selection, no
+   exclusion restriction and no bounded support needed. Report the Imbens-Manski interval
+   (the effect is the target, and it is narrower than set coverage). Tighten with cells built
+   from predicted-outcome quintiles on baseline covariates.
+4. Every bounds writeup carries one signed-selection sentence: who the marginal observed
+   units are and therefore which end of the interval is credible (a retention intervention
+   keeping marginal low-spenders biases the survivor comparison down, so the upper end is the
+   credible one).
+5. Horowitz-Manski worst-case bounds appear once as the assumption-free outer benchmark
+   (Lee's were 1/14th their width in Job Corps). Heckman-style corrections only with a
+   credible excluded instrument for selection, which field experiments rarely have.
+
+Monotonicity failure (imbalance among the selected despite equal rates) means two-way flows,
+and the bounds themselves are compromised; there is no within-model fix.
+
+## Heterogeneity and multiple testing
+
+- Pre-specified subgroups: stratified analysis plus a multiple-testing correction that
+  exploits correlation across tests (List-Shaikh-Xu bootstrap; Romano-Wolf stepdown), not
+  Bonferroni. Multiple outcomes: omnibus statistic or corrected p-values; uncorrected
+  per-outcome stars are the failure mode.
+- Data-driven heterogeneity requires honesty: any CI you will report needs sample splitting
+  (one sample picks the partition, an independent one estimates). Coverage survives high
+  dimension; MSE does not. Honest trees for interpretable subgroups, causal forests for the
+  CATE surface with pointwise inference, plus the rank-average-treatment-effect test for
+  detectable heterogeneity; this is also the uplift-modeling stack.
+- The constant-effect test (series regression of both arms' conditional means) tells you
+  whether a single ATE is an incomplete summary; rejection routes to the toolkit above.
+- Quantile effects are differences of marginal quantiles, never quantiles of unit-level
+  differences (unidentified). The bootstrap fails at mass points (30 percent zeros made a
+  bootstrap SE of exactly 0 in the canon's example); pair QTE estimates with an exact test
+  using the QTE as the statistic.
+
+## Interference
+
+When units interact, SUTVA fails and the simple ATE misstates the policy effect. Contained
+interactions: randomize at the group level (markets, stores). Direct-vs-indirect effects:
+two-stage saturation designs (randomize treated fractions across groups, then units within);
+if within-market treatment-control differences vary with the market-level treated share,
+displacement is present, the marketplace-cannibalization check. One general network: exact
+randomization tests with focal, buffer, and auxiliary units, since there is no coherent
+large-network asymptotic. Platform experiments should default to market-level clustering
+when cannibalization or budget spillover is plausible. Marketplace and two-sided settings:
+multiple randomization designs assign treatment to buyer-seller pairs (Bajari et al. 2023;
+Johari et al. 2022 analyzes the bias of one-sided designs).
+
+## Diagnostics battery
+
+1. Covariate balance table with exact p-values, run even on clean randomizations (the Lalonde
+   benchmark hides an imbalance at p = 0.002); post-attrition imbalance means the analyzed
+   sample is no longer the randomized sample, which routes to the Lee block.
+2. Adjusted vs unadjusted side by side: adjustment should barely move the point estimate and
+   shrink the SE by roughly 1 - R2. A large movement signals compromised randomization,
+   attrition, or specification problems, and is never a precision story.
+3. Design-consistent variance check: the design-aware variance should be weakly smaller than
+   the complete-randomization one; larger means the analysis mis-specifies the design.
+4. Both cluster estimands when cluster sizes vary; the gap between them is itself evidence
+   that effects covary with cluster size.
+5. Zero-effect coverage simulation before reporting: hold outcomes fixed, re-randomize, check
+   empirical coverage of every planned estimator-variance pair. Minutes of compute; catches
+   small-sample and skewness failures.
+6. Leading-term bias estimate for regression adjustment (sample-moment formula); a value that
+   is a nontrivial fraction of the SE means drop the adjustment or coarsen covariates.
+7. Compliance and attrition accounting: first-stage table (equals the compliance-share
+   table), differential response rate, and the Lee machinery when it is nonzero.
+
+## R implementation
+
+The complete runnable pipeline is scripts/experiment_template.R (assignment, RI + Neyman
+analysis, lm_lin and nonlinear imputation, noncompliance, Lee bounds, heterogeneity, power),
+with every call verified against package documentation. The core:
+
+```r
+library(randomizr); library(estimatr)
+Z <- block_ra(blocks = strata, prob = 0.5)          # design: stratified assignment
+difference_in_means(y ~ z, blocks = strata, data = df)   # analyze as randomized
+lm_lin(y ~ z, covariates = ~ pre_y + x1, data = df)      # Lin adjustment, HC2 default
+# binary outcome, marginal risk difference via standardization:
+fit <- glm(y ~ z * (pre_y + x1), family = binomial, data = df)
+marginaleffects::avg_comparisons(fit, variables = "z")
+```
+
+Package index with versions, links, and traps in references/details.md.
+
+## Methods paragraph template
+
+> We randomized [units] to [arms] within strata of [X] with equal treatment fractions, and we
+> analyze the experiment as randomized: we report randomization-inference p-values alongside
+> the difference in means with HC2 standard errors [and Behrens-Fisher degrees of freedom,
+> given arm sizes of N_t and N_c] (Athey and Imbens 2017). The unadjusted estimate comes
+> first; for precision we adjust with the fully interacted, demeaned-covariate regression of
+> Lin (2013) [/ for our binary outcome, we standardize an interacted logistic working model to
+> the marginal risk difference, since the logit coefficient targets a noncollapsible
+> conditional estimand (Freedman 2008; Guo and Basse 2023)]. [Noncompliance: we report
+> intention-to-treat effects and the complier average effect, with exclusion argued by
+> compliance type.] [Gated outcome: because [outcome] is observed only given [gate] and
+> assignment moves [gate] rates by [x] points, we report Lee (2009) bounds with the
+> Imbens-Manski interval; the marginal observed units are [who], so the [end] of the interval
+> is the credible one. This estimand covers the always-observed stratum, a limitation of the
+> data and not the design, and I do not extrapolate to units whose observation status
+> responds to treatment.]
+
+Every claim traces to references/canon.md; keys live in causal-design/references/causal.bib.
+
+## Handoffs
+
+- preregister: the pre-analysis plan document itself; this skill supplies what to
+  pre-specify (strata, covariates, estimators, subgroups, gates).
+- iv: exclusion and monotonicity discipline for LATE claims; weak-instrument inference when
+  the first stage is thin.
+- causal-design: whether to experiment at all; clustering questions shared across designs.
+- did / synthetic-control: staggered rollouts and geo designs analyzed observationally when
+  randomization was infeasible or broken.

--- a/skills/field-experiment/references/canon.md
+++ b/skills/field-experiment/references/canon.md
@@ -1,0 +1,142 @@
+# Field-experiment canon
+
+Current as of 2026-07-28. Athey-Imbens and Freedman are hand-picked; Lin, Guo-Basse, and Lee
+are human-approved addenda (2026-07-28) filling the covariate-adjustment and attrition gaps.
+BibTeX keys point into ../../causal-design/references/causal.bib. Refresh: litreview on the
+method since the date above, results proposed as flagged addenda.
+
+## Athey and Imbens (2017)
+
+Handbook of Economic Field Experiments. Key: `athey2017econometrics`. Read: arXiv 1607.00698
+(the published chapter is paywalled; contents match).
+
+- Role: the spine; randomization-based inference put ahead of the regression paradigm, and
+  the design and analysis rules that follow.
+- Settles: Fisher exact tests and Neyman conservative variance as the default pair; the
+  Neyman variance drops an unidentifiable term, so CIs are conservative; HC2 equals the
+  Neyman estimator for binary treatment, EHW is anti-conservative with rare arms
+  (Behrens-Fisher dof fix); stratify ex ante (weakly dominates complete randomization even
+  small-sample), strata to 2+2, do not pair, re-randomization needs a pre-specified
+  acceptance rule; clustered designs have two estimands and cluster-level analysis is
+  primary; ITT plus LATE and never as-treated or per-protocol; honest sample splitting for
+  data-driven heterogeneity (coverage survives, MSE pays); QTEs are marginal-quantile
+  differences and the bootstrap fails at mass points; interference handled by cluster
+  randomization, saturation designs, or network-exact tests with focal/buffer units.
+- Binds when: designing any experiment; every analysis choice; the noncompliance and
+  interference blocks.
+- Implement: names no software; the randomizr/estimatr/ri2/grf mapping is ours, in
+  references/details.md.
+- Quote: Freedman's "Experiments should be analyzed as experiments, not as observational
+  studies," quoted in the chapter's introduction (attribute to Freedman 2006, not the
+  chapter).
+
+## Freedman (2008)
+
+Statistical Science 23(2): 237-249. Key: `freedman2008logistic`.
+
+- Role: the estimand discipline for binary outcomes; why covariate-adjusted logit
+  coefficients are not treatment effects.
+- Settles: under the randomization model the logit treatment coefficient is inconsistent for
+  the marginal differential log odds, and the failure is noncollapsibility, not confounding
+  (conditional odds multiplier strictly exceeds the pooled one whenever a prognostic
+  covariate varies); robust SEs fix nothing about the estimand; the plug-in (standardization)
+  estimator is consistent thanks to the canonical-link calibration property, and the
+  ITT rate comparison is always available; probit plug-ins are not calibrated;
+  "cross-tabulation before regression."
+- Binds when: any binary-outcome experiment (the modal marketing experiment); comparing
+  odds ratios across specifications, segments, or platforms (banned).
+- Implement: glm + marginaleffects::avg_comparisons (our mapping); the four-line per-arm
+  imputation pattern in scripts/experiment_template.R.
+- Quote: "randomization does not justify the model, so the usual estimators can be
+  inconsistent" (abstract). The "almost anything can happen" line belongs to the OLS
+  companion paper (`freedman2008regression`), not this one; cite each Freedman to its own
+  paper.
+
+## Lin (2013)
+
+Annals of Applied Statistics 7(1). Key: `lin2013agnostic`. Approved addendum.
+
+- Role: closes Freedman's OLS critique; the covariate-adjustment default.
+- Settles: OLS with demeaned covariates and full treatment interactions cannot hurt
+  asymptotic precision and is weakly more efficient than uninteracted adjustment; the
+  sandwich variance is consistent or asymptotically conservative under the Neyman model;
+  equal arms make the legacy specification benign, imbalanced arms are where interactions
+  protect; adjustment bias is order 1/n with an estimable leading term; covariates chosen
+  for prediction, the lagged outcome being the one that reliably matters; the zero-effect
+  coverage simulation and leading-term bias estimate as pre-reporting checks; Fisher-Pitman
+  CI inversion can undercover the ATE under heterogeneity (temper the RI-first stance to
+  sharp nulls).
+- Binds when: any OLS adjustment; every holdout design with unbalanced arms.
+- Implement: estimatr::lm_lin (named for the paper), HC2 default, HC3/Welch small-sample.
+- Quote: "In large samples, the essential problem is omission of treatment x covariate
+  interactions, not the linear model."
+
+## Guo and Basse (2023)
+
+JASA 118(541): 524-536. Key: `guo2023generalized`. Approved addendum. Read: arXiv v1
+(JASA text unverified in detail).
+
+- Role: design-based covariate adjustment beyond OLS; the imputation reading that unifies
+  Lin and Freedman's plug-in.
+- Settles: Lin's estimator is the linear Oaxaca-Blinder imputation estimator, and centering
+  is what makes one interacted regression equal two per-arm fits; prediction unbiasedness
+  (canonical-link calibration) plus stability gives consistency with no correct-model
+  assumption; the CI replaces Neyman arm variances with per-arm MSEs and shortens exactly
+  in proportion to fit gains (Poisson imputation 45 percent shorter than Lin on counts);
+  recalibration (second-stage OLS) makes any fit usable; NO universal noninferiority
+  theorem (linear and isotonic have it, logistic unresolved; no-harm calibration restores
+  it); estimand is the sample ATE, and they decline the g-formula superpopulation reading.
+- Binds when: nonlinear outcomes (binary, counts, skewed revenue); platform default
+  pipelines that must never lose to the difference in means.
+- Implement: the paper's own four-line R snippet (in the template verbatim); RobinCar for
+  covariate-adaptive designs.
+- Quote: the noninferiority disclaimer, "the price of generality."
+
+## Lee (2009)
+
+Review of Economic Studies 76(3): 1071-1102. Key: `lee2009training`. Approved addendum.
+Read: NBER WP 11721 (numbers quoted are the WP's).
+
+- Role: attrition and gated outcomes; sharp bounds without exclusion restrictions.
+- Settles: conditioning on a post-treatment gate breaks randomization for the gated outcome;
+  under monotone selection the excess observation share p0 is point-identified and trimming
+  the excess arm gives sharp bounds for the always-observed stratum; no exclusion
+  restriction or bounded support needed (vs Heckman and Horowitz-Manski respectively);
+  covariate cells tighten (predicted-outcome quintiles, 13 percent in Job Corps);
+  Imbens-Manski interval as the default; p0 near zero plus selected-sample balance makes
+  the untrimmed estimate valid and efficient; monotonicity is testable at p0 near zero and
+  its failure compromises the bounds themselves; selection monotonicity mirrors compliance
+  monotonicity (always-observed mirrors always-takers).
+- Binds when: any gated outcome (spend given retention, NPS given response, order value
+  given purchase); differential attrition of any kind.
+- Implement: Stata leebounds (Tauchmann) is the standard; R is hand-rolled or the Semenova
+  GitHub package (state verified in references/details.md); the template hand-rolls with a
+  bootstrap.
+- Quote: "Even a randomized experiment cannot guarantee that treatment and control
+  individuals will be comparable conditional on being employed."
+
+## Named disputes and caveats the skill carries
+
+1. Pairing: the canon says never pair (prefer strata of four); later matched-pair theory
+   (Bai 2022) disagrees. Default: strata of at least 2+2 when designing; analyze existing
+   paired designs as paired; cite both when it matters.
+2. RI confidence intervals: exact tests of sharp nulls are exact, but Fisher-Pitman
+   inversion can undercover the ATE under heterogeneity with unbalanced arms (Lin, citing
+   Gail). The skill tests by permutation and interval-estimates by Neyman/HC2.
+3. Nonlinear imputation has no universal never-worse guarantee; the earlier reading that
+   Guo-Basse prove one is wrong (their explicit disclaimer). Linear or no-harm-calibrated
+   imputation when a guarantee is required.
+
+## Primary papers cited through the canon
+
+Resolver-verified entries in causal.bib (field-experiment block): Neyman 1923/1990 and
+Fisher 1935 (foundations); Imbens-Rubin 2015 (the long-form source); Freedman 2008
+Adv. Appl. Math. (OLS critique); Imbens-Kolesar 2016 (small-sample robust SEs); Young 2019
+(Channeling Fisher); Athey-Imbens 2016 and Wager-Athey 2018 (honest trees, causal forests);
+List-Shaikh-Xu 2019 (multiple testing); Hudgens-Halloran 2008, Athey-Eckles-Imbens 2018,
+Crepon et al. 2013 (interference); Imbens-Manski 2004 and Horowitz-Manski 2000 (bounds and
+intervals); Rosenblum-van der Laan 2010 and Ye et al. 2023 (standardization robustness);
+Cohen-Fogarty 2024 (no-harm calibration); Bai 2022 (matched pairs); Tauchmann 2014
+(leebounds); Semenova 2025 (generalized Lee bounds, the published "Better Lee Bounds", now
+J. Econometrics 251); plus reused iv-block entries imbens1994identification,
+angrist1996identification, balke1997bounds and the shared abadie2023clustering.

--- a/skills/field-experiment/references/details.md
+++ b/skills/field-experiment/references/details.md
@@ -1,0 +1,207 @@
+# Field-experiment lookup details
+
+Heavy reference content the SKILL.md points into. Current as of 2026-07-28.
+
+## Variance algebra
+
+- Neyman: V-hat = s2_c/N_c + s2_t/N_t, upward biased for the randomization variance because
+  the unit-level effect variance S2_tc/N is unidentifiable and dropped; unbiased if effects
+  are constant or the estimand is the super-population ATE.
+- HC2 on Y ~ W with binary W reproduces the Neyman estimator exactly; HC0/EHW differs by the
+  degrees-of-freedom treatment and is anti-conservative with a rare arm (N_t = 4, N_c = 54:
+  EHW 0.1215 vs Neyman 0.1400). Behrens-Fisher/Satterthwaite dof (Imbens-Kolesar) is the fix.
+- Stratified: tau-hat = sum_g (N_g/N) tau-hat_g, V-hat = sum_g (N_g/N)^2 V-hat_g; the
+  complete-randomization variance is valid but conservative.
+- Paired: use the across-pair variance of pair differences (conservative for the sample ATE,
+  right for the super-population one). Ignoring pairing roughly doubles the SE in the
+  Children's Television Workshop example (4.6 vs 7.8).
+- Clustered: for the cluster-average estimand, difference in means on cluster means
+  (equivalently unit-level WLS with weights 1/N_g); for the unit-average estimand,
+  unweighted unit OLS with Liang-Zeger CR (CR2 small-sample correction and Satterthwaite
+  dof), or cluster-level WLS with weights N_g. One mega-cluster can make the unit-weighted
+  estimand essentially unlearnable.
+- Clustered sampling with unit-level randomization is a different problem: Neyman for the
+  sample ATE, clustered SEs only for the population ATE (abadie2023clustering).
+
+## Power
+
+Minimum N = (Phi^-1(beta) + Phi^-1(1 - alpha/2))^2 / ((tau^2/sigma^2) gamma (1 - gamma)),
+gamma the treated share (1/2 optimal under homoskedasticity). Worked example: sigma = 6,
+tau = 1, alpha = .05, power = .8 gives N = 1130; tau = 2 gives N = 282. Base R power.t.test
+matches up to the t-vs-normal refinement; stratified and clustered designs by simulation
+(DeclareDesign) or PowerUpR closed forms for cluster designs.
+
+## Lin algebra and checks
+
+- Efficiency: the interacted estimator's gain over uninteracted is
+  ((2p_A - 1)^2 / (n p_A (1 - p_A))) times the variance of the covariate-explained part of
+  the treatment effect; zero at equal arms or equal slopes. Variance gain over unadjusted is
+  the 1 - R2 factor.
+- For uninteracted adjustment to hurt with one covariate, more than three quarters of
+  subjects must sit in one arm, or the covariate must covary more with the effect than with
+  the outcome level. With more than two arms, pooled adjustment can hurt even balanced;
+  separate per-arm regressions keep the guarantee.
+- Bias is order 1/n; leading term is a covariance of outcomes with squared demeaned
+  covariates, estimable by plug-in (ALO example: -0.0002 against SE 0.146). Report it when
+  arms are small and covariates skewed.
+- Zero-effect coverage simulation: hold outcomes fixed, assume no effect, re-randomize many
+  times, compute empirical coverage for every planned estimator-variance pair. A coverage
+  benchmark, not a permutation test.
+- Sandwich sweep: HC0-HC3 agreed (94.4-95.1 percent coverage) in Lin's 250k-replication
+  check; HC0 degrades first with leverage; the Guo-Basse Fatalities footnote has HC0
+  undercovering for Lin's estimator, a concrete HC2-by-default argument.
+- Poststratification is lm_lin with partition indicators; then the estimator is exactly
+  unbiased over the randomization distribution.
+
+## Noncollapsibility and standardization (binary outcomes)
+
+- Section 9 inequality: with subject-level odds multiplier lambda > 1 and any variation in
+  baseline risks, the pooled multiplier lies strictly between 1 and lambda. So
+  |beta-hat| > |marginal Delta| whenever the covariate is prognostic; the gap is predicted,
+  not evidence of bias.
+- The calibration mechanism: logit score equations force arm-average fitted probabilities to
+  equal arm-average outcomes; that plus randomization's covariate balance makes the plug-in
+  consistent. Probit lacks it (small but nonzero asymptotic bias).
+- Freedman's simulation anchors: n = 5000 coefficient bias 0.195 (truth 0.939); swapping the
+  covariate drove the coefficient to about 3 against truth near 1.
+- Standardization recipe: fit y ~ w * covariates with family = binomial; average predictions
+  with w set to 1 and to 0 over ALL units; report the risk-difference (or the log odds of
+  the averaged probabilities, Freedman's Delta-tilde). marginaleffects::avg_comparisons is
+  the packaged route; the design-based interval is the Guo-Basse residual t-interval.
+- Guo-Basse conditions: prediction unbiasedness + stability -> consistency; + entropy
+  condition -> asymptotic normality; CI = tau-hat +/- t * sqrt(MSE_1/n_1 + MSE_0/n_0),
+  conservative, exact under the sharp null with the same model class per arm. Degenerate
+  when both arms' R2 near 1. Isotonic imputation needed ~600 units per arm for near-nominal
+  coverage.
+
+## The LPM case, stated plainly: binary outcomes only (house framing)
+
+Scope: everything in this section is specific to binary outcomes, the only setting where an
+LPM-versus-logit choice exists. The difference in means is unbiased for the ATE under
+randomization for any outcome type; what is binary-specific is reading that coefficient as a
+probability-scale marginal effect and the noncollapsibility trap in the logit alternative.
+For counts and skewed-positive outcomes the analogous contrast is OLS versus Poisson or
+log-scale models, and the same three-tier logic applies through the Guo-Basse routing
+(nonlinear coefficients are never read; nonlinear models serve only as imputation engines).
+
+- Choosing the LPM over a logit is declining to assume a functional form, not assuming a
+  linear one: OLS of the binary outcome on the treatment dummy is the linear probability
+  model in saturated form and equals the difference in proportions, so under randomization
+  the coefficient is unbiased for the risk difference (the ATE) with no functional-form
+  assumption doing any work, while the logit imposes a shape whose coefficient still needs
+  AME post-processing before it is interpretable. The LPM is the nonparametric estimator
+  here, and the applied-econometrics preference for it is fully vindicated in the
+  design-based frame.
+- The classic anti-LPM objections have no force for ATE estimation in an experiment:
+  heteroskedasticity is handled by the HC2 default, and fitted probabilities outside [0, 1]
+  only matter when predicted probabilities are consumed, which the ATE never does. (If
+  calibrated predictions are the deliverable, that is a different task; use the logistic
+  working model for it.)
+- lm_lin on a binary outcome is the covariate-adjusted LPM. Nothing in Lin's agnostic theory
+  assumes a continuous outcome, so the never-hurts-precision guarantee and the sandwich
+  validity apply verbatim.
+- AME vs MEM: what a logit needs before it says anything interpretable. The average marginal
+  effect (AME) averages unit-level risk differences over the sample and equals the
+  g-computation risk difference; avg_comparisons computes it, and it is the standardization
+  target everywhere in this skill. The marginal effect at the mean (MEM) evaluates the
+  effect at the mean covariate vector, a profile that may describe no actual unit; under
+  nonlinearity MEM does not equal AME. Older Stata habits (margins, atmeans) produce the
+  MEM; do not report it.
+- Discrete and multivalued treatments: OLS on arm dummies reads out each arm's risk
+  difference against control directly. Multi-arm logit coefficients are conditional log-odds
+  contrasts carrying the same noncollapsibility problem, and per Lin the multi-arm OLS
+  adjustment should be separate per-arm regressions (pooled adjustment can hurt even in
+  balanced designs beyond two arms).
+- The three-tier summary of this skill's position: LPM coefficients are read directly
+  (primary); logit coefficients are never read (banned); the logit as an imputation engine
+  whose coefficient is never read is an optional precision upgrade (Guo-Basse, with its
+  checks and the no-guarantee caveat).
+
+## Lee bounds mechanics
+
+- p0 = (s_T - s_C)/s_T where s is the observation rate; trim the higher-observation arm by
+  p0: top for the lower bound, bottom for the upper bound. Sharp for
+  E[Y1 - Y0 | always observed] under randomization + monotone selection.
+- Estimator: sample trimming share, quantile threshold, trimmed mean; root-n normal with a
+  three-part variance (trimmed mean, quantile, trimming share); the third part was largest
+  in Job Corps. Bootstrap over the whole pipeline is the practical route (our judgment).
+- Imbens-Manski interval covers the effect (default); the set-coverage interval is wider and
+  only for identified-set claims.
+- Covariate tightening: cells from quintiles of OLS-predicted outcomes, trim within cells,
+  average over the control-selected covariate distribution (Chamberlain minimum distance for
+  the variance); weakly narrower by construction, 13 percent in Job Corps. If it widens,
+  the cells are too fine.
+- Anchors: week 208 log-wage bounds [-0.019, 0.093] at 6.8 percent trimming vs
+  Horowitz-Manski [-0.746, 0.802] (1/14th the width); week 90 with p0 near zero, bounds
+  [0.042, 0.043] vs untrimmed 0.043 (se 0.011); monotonicity balance test joint p = 0.851.
+- Bound width must track the differential observation rate across horizons; if it does not,
+  suspect the implementation.
+- Discrete outcomes: sort, drop whole observations to the greatest-integer trimming count,
+  cumulating design weights to the target share.
+- Under conditional-on-X randomization the machinery runs within cells, and the p0-zero
+  balance test is unavailable.
+
+## Heterogeneity toolkit
+
+- List-Shaikh-Xu bootstrap exploits cross-test correlation and beats Bonferroni; Romano-Wolf
+  stepdown is the general-purpose version.
+- Honest trees: sample-split so the partition sample and estimation sample are independent;
+  within-leaf means inherit randomization justification. Causal forests: pointwise
+  asymptotic normality; average_treatment_effect, best_linear_projection for interpretable
+  summaries, rank_average_treatment_effect as the modern detectable-heterogeneity test.
+- Constant-effect test (Crump-Hotz-Imbens-Mitnik): series fit of both conditional means,
+  test equality of coefficients.
+- Bertanha-Imbens LATE-generalization pair: E[Y(1)] equal for always-takers vs treated
+  compliers; E[Y(0)] equal for never-takers vs untreated compliers; test separately,
+  possibly after covariate adjustment.
+- QTE: marginal-quantile differences; bootstrap invalid at mass points (0.10 quantile
+  bootstrap SE exactly 0 with 30 percent zeros); use the exact test with the QTE statistic.
+
+## Interference designs
+
+- Cluster at the interaction boundary (markets, stores, social clusters).
+- Saturation (partial-population) designs: randomize the treated fraction across groups,
+  then units within; identifies direct and indirect effects (Hudgens-Halloran). The Crepon
+  displacement check: within-market differences varying with market-level treated share.
+- General networks: exact tests of sharp nulls with focal units, buffer units, and auxiliary
+  assignments (Athey-Eckles-Imbens); no coherent large-network asymptotics, so do not
+  substitute clustered SEs for the exact test.
+- Marketing instances: marketplace cannibalization, social-ad spillovers, budget-constrained
+  auctions, referral programs, livestream network effects.
+
+## Marketing translations
+
+- Small-cell email/pricing tests: rare-arm HC2 + Behrens-Fisher regime.
+- 90/10 holdouts: the imbalanced-arms case where Lin's interactions are load-bearing.
+- CUPED: fixed-slope regression adjustment on pre-period outcomes in Lin's survey-sampling
+  framing; lm_lin with the pre-period metric is the design-based version.
+- Conversion/click/churn lifts: report percentage-point risk differences, never adjusted
+  odds ratios; noncollapsibility breaks cross-segment and cross-platform OR comparisons.
+- Revenue per user: skewed, zero-inflated; log-OLS imputation with second-stage
+  recalibration, never the log-coefficient-as-lift.
+- Retention experiments: post-period behavior among survivors is the Lee case; differential
+  churn is the trimming share.
+- Uplift modeling: honest forests + policy learning; report the RATE test before claiming
+  targetable heterogeneity.
+- Geo experiments: cluster-level analysis primary, both estimands when market sizes vary;
+  displacement checks before scaling a winning arm.
+
+## Package index (verified against package docs 2026-07-28)
+
+| Package | Version | Role | Traps |
+|---|---|---|---|
+| randomizr | 1.0.1 (CRAN) | complete_ra / block_ra / cluster_ra / block_and_cluster_ra, declare_ra for ri2 | block_ra has no N (inferred from blocks); per-block counts are block_m, not m_each |
+| estimatr | 1.0.6 (CRAN) | difference_in_means (auto-detects blocked/clustered/matched-pair designs), lm_robust, lm_lin, iv_robust | difference_in_means se_type is only "default"/"none" (HC/CR strings error there); lm_lin formula is Y ~ Z only, covariates in a separate one-sided formula; CR2 is the clustered default (pinned also in causal-design's details; update the two pins together on refresh) |
+| ri2 | 0.4.1 (CRAN, 2025-10, maintained) | conduct_ri Fisher tests with declared designs; custom test statistics via test_function | data argument must be named; IPW = TRUE by default |
+| DeclareDesign | 1.1.1 (CRAN) | design declaration and power by simulation (diagnose_design) | estimator method arg is .method (with dot); declare_estimand is the deprecated alias of declare_inquiry |
+| grf | 2.6.1 (CRAN) | causal_forest, average_treatment_effect, best_linear_projection, rank_average_treatment_effect, test_calibration | dot-separated args (num.trees, W.hat); pass known W.hat in experiments; RATE priorities must come from a held-out forest (man page requires, signature does not enforce) (pinned also in causal-design's details; update the two pins together on refresh) |
+| marginaleffects | 0.32.0 (CRAN) | avg_comparisons for standardization (risk difference; lnoravg for the marginal log OR) | "oravg" does not exist; use comparison = "lnoravg" with transform = exp; vcov accepts "HC2"/"HC3" strings (pinned also in causal-design's details; update the two pins together on refresh) |
+| RobinCar | 1.2.0 (CRAN) | covariate adjustment under covariate-adaptive randomization (ANOVA/ANCOVA/ANHECOVA) | strata argument is car_strata_cols; quoted column names, unlike estimatr's bare names |
+| qte | 2.0.0 (CRAN, 2026-07) | QTE with bootstrap inference | ci.qte deprecated in 2.0.0; use unc_qte(yname, dname, xformla = ~1); all pre-2026-07 tutorials show the dead API |
+| wildrwolf | 0.7.0 (r-universe; ARCHIVED from CRAN 2024-05) | Romano-Wolf stepdown p-values | needs archived fwildclusterboot; accepts only fixest models; budget the p.adjust(holm) fallback |
+| PowerUpR | 1.1.0 (CRAN Archive; ARCHIVED 2026-03) | mdes.cra2/power.cra2/mrss.cra2 cluster-power closed forms | off CRAN; prefer hand-coding DEFF = 1 + (m-1) ICC in templates |
+| Lee bounds | none | no CRAN package implements Lee 2009 trimming bounds (checked the full index; ATbounds/bpbounds/rbounds/plausibounds are different things); vsemenova/leebounds is a replication archive, not installable, and its README example does not run against its own code | hand-roll (the template does) with a full-pipeline bootstrap |
+
+Stata mirror: ritest (randomization inference), mhtexp (List-Shaikh-Xu), rwolf, leebounds
+(Tauchmann 2014, the standard Lee-bounds implementation with tight() and cieffect), ivdesc
+(complier profiling).

--- a/skills/field-experiment/scripts/experiment_template.R
+++ b/skills/field-experiment/scripts/experiment_template.R
@@ -1,0 +1,193 @@
+# Field-experiment analysis template. Runnable end to end; every call signature verified
+# against package documentation on 2026-07-28 (randomizr 1.0.1, estimatr 1.0.6, ri2 0.4.1,
+# DeclareDesign 1.1.1, grf 2.6.1, marginaleffects 0.32.0, RobinCar 1.2.0, qte 2.0.0, all
+# CRAN). Adapt the CONFIG block and run section by section.
+#
+# API traps older tutorials get wrong:
+#   - estimatr::difference_in_means auto-detects the design (blocked, clustered,
+#     matched-pair); its se_type is only "default"/"none". HC/CR strings belong to
+#     lm_robust/lm_lin (HC2 default without clusters, CR2 with).
+#   - lm_lin: formula is Y ~ Z with ONLY treatment on the RHS; covariates go in a separate
+#     one-sided formula.
+#   - marginaleffects: comparison = "oravg" DOES NOT EXIST; use "lnoravg" (+ transform =
+#     exp for the odds-ratio scale).
+#   - qte 2.0.0 (2026-07) deprecated ci.qte; the current call is unc_qte(yname, dname, ...).
+#   - wildrwolf and PowerUpR are ARCHIVED from CRAN (2024-05 and 2026-03); install routes
+#     and fallbacks below.
+#   - Lee (2009) bounds have NO reliable R package (the Semenova GitHub repo is a
+#     replication archive whose README example does not run); hand-rolled below.
+
+## ---- CONFIG ----------------------------------------------------------------
+df <- your_data       # unit-level frame: y, z (0/1), stratum, cluster, x1, x2, pre_y,
+                      # s (observation gate, for the Lee block), y01 (binary 0/1 outcome,
+                      # for the binary-outcome block), d (0/1 treatment actually received,
+                      # for the noncompliance block)
+set.seed(94305)
+library(randomizr); library(estimatr); library(ri2)
+
+## ---- 1. Design: assignment and power ----------------------------------------
+# Stratified assignment (strata as fine as possible, >= 2 treated + 2 control each):
+# Z <- block_ra(blocks = df$stratum, prob = 0.5)      # N inferred from blocks
+# Clustered: cluster_ra(clusters = df$cluster, prob = 0.5)
+# Both: block_and_cluster_ra(blocks = ..., clusters = ...)
+# Power, individual randomization (matches the canon's closed form up to t-vs-normal):
+power.t.test(delta = 1, sd = 6, sig.level = 0.05,  # .05/.80: the field-standard planning
+             power = 0.80)                         # conventions. Returns n per arm
+# Cluster designs: hand-code the design effect DEFF = 1 + (m - 1) * ICC and inflate N
+# (PowerUpR::mdes.cra2 exists but the package was ARCHIVED from CRAN 2026-03; do not
+# build a pipeline on it). Stratified/complex designs: simulate with DeclareDesign:
+# library(DeclareDesign)
+# design <- declare_model(N = 500, U = rnorm(N), potential_outcomes(Y ~ 0.2*Z + U)) +
+#   declare_inquiry(ATE = mean(Y_Z_1 - Y_Z_0)) +
+#   declare_assignment(Z = complete_ra(N, prob = 0.5)) +
+#   declare_measurement(Y = reveal_outcomes(Y ~ Z)) +
+#   declare_estimator(Y ~ Z, .method = estimatr::lm_robust, inquiry = "ATE")  # .method!
+# diagnose_design(design, sims = 500)   # power is a default diagnosand; Monte Carlo
+#   error is negligible at 500 sims
+
+## ---- 2. Primary analysis: Neyman + randomization inference ------------------
+# Analyze as randomized: difference_in_means auto-detects blocked / clustered /
+# matched-pair designs from the arguments and picks the design-appropriate variance.
+difference_in_means(y ~ z, data = df)                       # complete randomization
+difference_in_means(y ~ z, blocks = stratum, data = df)     # stratified
+# Fisher exact p, same declaration that did the assignment:
+decl <- declare_ra(N = nrow(df), blocks = df$stratum, prob = 0.5)
+conduct_ri(y ~ z, declaration = decl, assignment = "z",
+           sharp_hypothesis = 0, data = df,
+           sims = 2000)   # Monte Carlo error negligible at this budget
+# Rank statistic under heavy tails / many zeros (custom statistic route):
+conduct_ri(test_function = function(d) with(d, mean(rank(y)[z==1]) - mean(rank(y)[z==0])),
+           declaration = decl, assignment = "z", data = df, sims = 2000)
+# Caveat: exact tests of SHARP nulls only; interval-estimate the ATE with Neyman/HC2,
+# not by inverting permutation tests (undercoverage under heterogeneity).
+
+## ---- 3. Covariate adjustment (Lin) -------------------------------------------
+# Unadjusted first, always. Then the demeaned fully-interacted regression:
+lm_lin(y ~ z, covariates = ~ pre_y + x1, data = df)         # HC2 default
+# se_type = "HC3" with small arms or leverage points.
+# Pre-reporting checks (minutes of compute):
+# (a) zero-effect coverage simulation: re-randomize under no effect, check empirical
+#     coverage of every planned estimator-variance pair (loop over declare_ra draws);
+# (b) leading-term bias estimate: cov of outcomes with squared demeaned covariates / n,
+#     worry only if a nontrivial fraction of the SE.
+
+## ---- 4. Binary and nonlinear outcomes (Freedman / Guo-Basse) -----------------
+# Primary: difference in proportions = difference_in_means on the binary y. For
+# precision, standardize an interacted logistic working model to the MARGINAL effect;
+# never report the logit coefficient (noncollapsible conditional estimand):
+fit <- glm(y01 ~ z * (pre_y + x1), family = binomial, data = df)
+marginaleffects::avg_comparisons(fit, variables = "z", vcov = "HC2")  # risk difference
+# Marginal odds ratio, if a referee wants that scale ("oravg" does not exist):
+marginaleffects::avg_comparisons(fit, variables = "z",
+                                 comparison = "lnoravg", transform = exp)
+# Guo-Basse per-arm imputation with the design-based MSE interval (their own snippet;
+# swap family = poisson for counts -- 45% shorter intervals than linear on their data):
+mu1 <- glm(y ~ pre_y + x1, family = binomial, data = subset(df, z == 1))
+mu0 <- glm(y ~ pre_y + x1, family = binomial, data = subset(df, z == 0))
+tau_gob <- mean(predict(mu1, df, "response") - predict(mu0, df, "response"))
+tau_gob + t.test(residuals(mu1, "response"), residuals(mu0, "response"))$conf.int
+# Pre-trust checks: no fitted values hugging 0/1 (separation); per-arm R2 not both
+# near 1; model flexibility small vs arm sizes. No universal never-worse guarantee:
+# platforms wanting one use linear imputation or no-harm calibration.
+# Skewed revenue: fit OLS on log(y), impute exp(Xb), then SECOND-STAGE OLS of y on the
+# fitted values per arm before imputing (recalibration); never the log coefficient.
+# Covariate-adaptive randomization (Pocock-Simon etc.): RobinCar:
+# RobinCar::robincar_linear(df, treat_col = "z", response_col = "y",
+#   car_strata_cols = "stratum", covariate_cols = c("pre_y", "x1"),
+#   car_scheme = "permuted-block", adj_method = "ANHECOVA")  # arg is car_strata_cols
+
+## ---- 5. Clustered designs: estimand first ------------------------------------
+# Cluster-average effect (primary): difference in means on cluster means.
+cl_means <- aggregate(cbind(y, z) ~ cluster, data = df, mean)
+difference_in_means(y ~ z, data = cl_means)
+# Unit-average effect: unit-level regression, CR2 + Satterthwaite dof:
+lm_robust(y ~ z, data = df, clusters = cluster, se_type = "CR2")
+# Report BOTH when cluster sizes vary; the gap is evidence effects covary with size.
+
+## ---- 6. Noncompliance: ITT + LATE, never as-treated --------------------------
+difference_in_means(d ~ z, data = df)     # first stage = compliance-share table
+difference_in_means(y ~ z, data = df)     # ITT, the randomization-justified number
+iv_robust(y ~ d | z, data = df, se_type = "HC2")   # LATE; exclusion/monotonicity
+# argued with the iv skill's discipline; weak first stage -> iv skill's AR machinery.
+# Balke-Pearl bounds when exclusion is doubtful: bpbounds (see iv template, section 4).
+
+## ---- 7. Attrition / gated outcomes: Lee bounds (hand-rolled; no R package) ----
+s1 <- mean(df$s[df$z == 1]); s0 <- mean(df$s[df$z == 0])
+c(s1 = s1, s0 = s0, diff = s1 - s0)       # differential observation rate FIRST
+# If |s1 - s0| ~ 0: monotonicity balance test within the selected sample, then report
+# the selected-sample estimate labeled "always-observed stratum". The joint p needs a
+# likelihood-ratio test against the null model (summary() gives per-coefficient Wald
+# p-values only, never a joint one):
+fit1 <- glm(z ~ pre_y + x1, family = binomial, data = subset(df, s == 1))
+fit0 <- glm(z ~ 1, family = binomial, data = subset(df, s == 1))
+anova(fit0, fit1, test = "LRT")           # monotonicity balance test, joint p
+# Otherwise Lee bounds (here assuming treatment RAISES observation; flip arms if not):
+lee_bounds <- function(d) {
+  s1 <- mean(d$s[d$z == 1]); s0 <- mean(d$s[d$z == 0])
+  p  <- (s1 - s0) / s1
+  y1 <- d$y[d$z == 1 & d$s == 1]; y0 <- d$y[d$z == 0 & d$s == 1]
+  c(lower = mean(y1[y1 <= quantile(y1, 1 - p)]) - mean(y0),
+    upper = mean(y1[y1 >= quantile(y1, p)]) - mean(y0), trim = p)
+}
+lb <- lee_bounds(df)
+# Bootstrap the WHOLE pipeline (trimming share included; its estimation error was the
+# largest variance component in Lee's application):
+B <- 2000   # 2000 draws give stable trim-share quantiles
+boots <- t(replicate(B, lee_bounds(df[sample(nrow(df), replace = TRUE), ])))
+se_l <- sd(boots[, "lower"]); se_u <- sd(boots[, "upper"])
+# Imbens-Manski interval (covers the EFFECT, the right default):
+cn <- uniroot(function(c) pnorm(c + (lb["upper"] - lb["lower"]) / max(se_l, se_u)) -
+                pnorm(-c) - 0.95, c(1, 3))$root   # 0.95: the conventional coverage level
+c(lb["lower"] - cn * se_l, lb["upper"] + cn * se_u)
+# Tighten: cells from quintiles of OLS-predicted outcomes on baseline X, lee_bounds
+# within each cell, average over the control-selected X distribution.
+# REQUIRED sentence in the writeup: who the marginal observed units are, hence which
+# end of the interval is credible.
+
+## ---- 8. Heterogeneity ---------------------------------------------------------
+# Pre-specified subgroups + Romano-Wolf. wildrwolf was ARCHIVED from CRAN 2024-05
+# (needs archived fwildclusterboot; r-universe serves 0.7.0 and it accepts ONLY
+# fixest models). Install if wanted:
+# install.packages("wildrwolf", repos = c("https://s3alfisc.r-universe.dev",
+#                                         "https://cloud.r-project.org"))
+# ms <- list(fixest::feols(y1 ~ z, df), fixest::feols(y2 ~ z, df))
+# wildrwolf::rwolf(ms, param = "z", B = 9999)   # B chosen so alpha*(B+1) is an integer
+# Holm fallback (conservative, always available): collect the p-values of the outcome
+# family into pvec; here the two outcomes the CONFIG frame carries, swap in yours:
+pvec <- c(y   = difference_in_means(y ~ z, data = df)$p.value,
+          y01 = difference_in_means(y01 ~ z, data = df)$p.value)
+p.adjust(pvec, method = "holm")
+# Data-driven: honest causal forest (grf; dot-separated arg names). Randomized
+# experiment: pass the KNOWN W.hat instead of estimating propensities.
+library(grf)
+X <- as.matrix(df[, c("pre_y", "x1", "x2")])
+cf <- causal_forest(X, df$y, df$z, W.hat = 0.5,
+                    num.trees = 2000,          # grf default, pinned for reproducibility
+                    clusters = df$cluster)
+average_treatment_effect(cf, target.sample = "all")
+best_linear_projection(cf, A = X[, c("pre_y", "x1")])
+test_calibration(cf)
+# Detectable heterogeneity (RATE): priorities MUST come from a forest fit on held-out
+# data (train/evaluate split; the signature does not enforce it, the man page does):
+half <- sample(nrow(df), nrow(df) / 2)
+cf_tr <- causal_forest(X[half, ], df$y[half], df$z[half], W.hat = 0.5)
+cf_ev <- causal_forest(X[-half, ], df$y[-half], df$z[-half], W.hat = 0.5)
+rank_average_treatment_effect(cf_ev, priorities = predict(cf_tr, X[-half, ])$predictions)
+
+## ---- 9. Quantile treatment effects --------------------------------------------
+# qte 2.0.0 renamed the interface; ci.qte is deprecated. Randomized experiment:
+library(qte)
+q <- unc_qte(yname = "y", dname = "z", data = df, xformla = ~1,
+             probs = seq(0.1, 0.9, 0.1),  # interior quantiles, where estimation is stable
+             biters = 1000)               # Monte Carlo error small at 1000 draws
+summary(q)
+# OUR caveat, not the package's: bootstrap CIs are unreliable at quantiles sitting on
+# mass points (many zeros); flag those quantiles and pair with an exact test using the
+# QTE as the ri2 test statistic.
+
+## ---- Session -------------------------------------------------------------------
+# Pin: estimatr >= 1.0.6, ri2 0.4.1, marginaleffects >= 0.32 (lnoravg spelling),
+# grf >= 2.6 (rank_average_treatment_effect), qte >= 2.0 (unc_qte API),
+# RobinCar >= 1.2 (car_strata_cols). Archived: wildrwolf (r-universe), PowerUpR
+# (CRAN Archive; prefer the hand-coded design effect).
+sessionInfo()

--- a/skills/iv/SKILL.md
+++ b/skills/iv/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: iv
+description: Design, estimate, validate, and write up an instrumental-variables analysis, covering single-instrument LATE designs, weak-instrument-robust inference, shift-share instruments, and formula/composite instruments that need recentering. Produces advice with citations, R estimation and diagnostics code, and a drafted methods paragraph. TRIGGER on "instrumental variable", "IV", "2SLS", "two-stage least squares", "LATE", "complier", "exclusion restriction", "first stage", "weak instrument", "Anderson-Rubin", "shift-share", "Bartik", "judge design", "examiner leniency", "encouragement design" (field-experiment leads these end to end, including the ITT/LATE analysis; here for the exclusion-restriction discipline and weak-instrument inference when the encouragement serves as an instrument), "price endogeneity", "cost shifter", "Hausman instrument", "simulated eligibility", "recentered instrument", or any setting where treatment is chosen by agents and an incentive or cost shifter moves it. Design triage across methods belongs to causal-design.
+---
+
+# Instrumental variables
+
+An opinionated IV workflow grounded in a read canon (references/canon.md, current as of
+2026-07-29): Imbens' Statistical Science perspective for the assumption structure and the LATE
+estimand, Keane-Neal's Annual Review guide for the weak-instrument inference regime, the two
+Borusyak-Hull(-Jaravel) papers for shift-share and formula instruments, and
+Mogstad-Santos-Torgovitsky's Econometrica framework for extrapolating beyond the compliers.
+The deliverable is the identification argument with the citation that justifies each leg, the
+estimation and diagnostics code in R (Stata mirrors noted where the canon is Stata-first), and
+a methods paragraph with the limitation stated in first person at the point of the choice.
+
+Refresh path: run the litreview skill on the method since the canon date and fold results into
+references/canon.md as flagged addenda.
+
+## When IV, and the four assumptions kept separate
+
+IV is the tool when unconfoundedness fails because treatment is chosen: agents select on
+anticipated gains (program participation, adoption, self-selected exposure), or the treatment is
+an equilibrium object like a price, where OLS mixes supply and demand slopes (the Fulton fish
+market numbers in references/details.md are the two-line demonstration). An instrument is an
+incentive or cost shifter: it changes the attractiveness of taking treatment without entering the
+potential outcomes.
+
+Four assumptions, argued separately because they have different characters (Imbens 2014):
+
+1. Unconfounded assignment of the instrument. Can hold by design (randomized encouragement) or
+   conditionally on covariates. On its own it justifies the reduced-form ITT effects ONLY, never
+   the IV ratio.
+2. Exclusion. Substantive in essentially every application; Imbens' line is that it holds by
+   design only in double-blind placebo trials. Argue it separately by compliance type: the
+   instrument can push always-takers and never-takers toward outcome-relevant side actions even
+   though it cannot change their treatment (draft-lottery never-takers stayed in school; a
+   retention-offer trigger that also flags the account for priority support).
+3. Monotonicity (no defiers). Safe when the instrument is a one-directional incentive (letter,
+   subsidy, default). Suspect in examiner and judge designs, where it requires the strict
+   examiner's approvals to nest the lenient examiner's, a strong behavioral claim. One-sided
+   noncompliance buys it for free and turns the LATE into an effect on treated compliers.
+4. Relevance, tested with the discipline in the next section, never with a full-sample afterthought.
+
+The estimand under all four is the complier average effect (LATE). Compliers are the focus
+because theirs is the only point-identified average, an honest second best. Report the compliance
+shares (always-takers, never-takers, compliers, three lines of code) and, when the ATE was the
+stated target, Manski bounds alongside the LATE. When the stated question is a rollout or an
+incentive change (a bigger subsidy, wider eligibility, "what if we gave it to everyone"), name
+the target as a PRTE and take the middle rung (Mogstad-Santos-Torgovitsky 2018): the LATE and
+the policy parameter are weighted averages of the same marginal treatment response functions, so
+the estimands already computed bound the policy parameter under stated MTR restrictions, with
+the extrapolation distance alpha explicit. The ladder to report: ITT/LATE first; MST bounds
+next, priced by the named restrictions and alpha; assumption-free Manski/Balke-Pearl bounds as
+the floor. When the assignment itself is the policy lever (encouragement campaigns, defaults),
+the ITT is the headline and rests on the fewest assumptions.
+
+## The inference regime: abandon the 2SLS t-test
+
+The binding constraint in modern IV practice is inference, and the canon's position (Keane-Neal
+2024) is blunt:
+
+- Test significance with the Anderson-Rubin test at EVERY instrument strength (CLR when
+  overidentified; they coincide with one instrument). Just-identified, AR is simply the robust
+  t-test on the instrument in the reduced form, so it costs one regression.
+- Confidence intervals only by inverting AR/CLR, never from the 2SLS standard error. Valid
+  intervals cannot be symmetric in finite samples, and an unbounded AR interval is an honest
+  statement that identification is not established, never something to suppress by switching
+  back to t-intervals.
+- Hold instruments to a robust first-stage F of about 50 (about 50/K^(3/4) with K instruments),
+  not 10. F of 10 only controls two-tailed t size; below roughly 50, 2SLS is quite likely
+  farther from the truth than OLS unless endogeneity is severe. The sample-F-to-certified-
+  population-F ladder, and when a severe-endogeneity relaxation of this bar is credible, are
+  in references/details.md.
+- Below F = 3.84 do not run IV at all; the AR interval will be unbounded and rightly so.
+- The reason the t-test dies even at strong F is power asymmetry, a mechanism worth knowing when
+  refereeing: the 2SLS standard error is spuriously small exactly when the estimate lands near
+  OLS. An IV estimate close to OLS with F between 10 and 50 and a significant t is the modal
+  reversed result in their AER audit (12 of 49 papers, 24 percent).
+- Estimator by identification status: just-identified, the 2SLS point estimate is fine (the
+  estimate, not its t-test). Overidentified: LIML under homoskedasticity, CUE under
+  heteroskedasticity or clustering, with CLR for inference; avoid 2SLS and two-step GMM. Never
+  mix (no CLR p-values stapled to a 2SLS estimate; no screening on t before applying AR).
+- Fewer instruments are better. Bias, size, and asymmetry all worsen with K. Legitimate extra
+  instruments come from functions of one continuous instrument or interactions with exogenous
+  covariates, which is exactly how Angrist-Krueger ended up many and weak.
+- Compute the F heteroskedasticity- or cluster-robust, always; effective F (Montiel
+  Olea-Pflueger) when overidentified and non-homoskedastic. Match clustering to the level of
+  instrument assignment.
+
+## Overidentification and heterogeneity, one rule
+
+Overid-test rejections conflate instrument invalidity with treatment-effect heterogeneity:
+different instruments (or share combinations) move different complier populations, so divergent
+estimates need not mean an invalid instrument, and with correlated instruments the pooled
+estimate need not be any complier average at all (Imbens 2014; Mogstad-Torgovitsky-Walters 2021
+via Borusyak-Hull-Jaravel 2025). A rejected J-test is a red flag for interpretability either
+way; what it does not do is cleanly convict the instrument. Say which reading you take and why.
+
+## Shift-share instruments: pick a path and defend it
+
+A shift-share instrument z_i = sum_k s_ik g_k (common shifts g_k weighted by exposure shares
+s_ik) does not get identification from "cov(z, eps) = 0". Commit to one of two paths
+(Borusyak-Hull-Jaravel 2025), each with its own estimator, standard errors, balance tests, and
+disqualifier:
+
+- Exogenous shifts: the shifts are a shock-level natural experiment (possibly conditional on
+  shift-level controls); the shares may be arbitrarily endogenous. Disqualifier, near-verbatim
+  from their Table 2: do not take this path if you would not use the shifts directly as an
+  instrument in a shift-level regression, for example because they are too few or endogenous.
+- Exogenous shares: every individual share satisfies a parallel-trends-style exogeneity
+  condition; shifts only pool the K share instruments and matter for power. Disqualifier: do not
+  take this path if you would not use a single share as an instrument on its own, for example
+  because the shares are generic. Generic shares (industry mix) proxy exposure to any industry
+  shock; tailored shares (origin-country migrant networks for migration treatments) can qualify.
+
+Three mechanical rules that are silently violated in practice:
+
+1. Control for the sum of shares whenever shares are incomplete (do not renormalize), interacted
+   with period indicators in stacked designs.
+2. On the shift path, use exposure-robust inference: the AKM variance estimator or the
+   equivalent shift-level regression (ssaggregate), which also delivers the honest first-stage F.
+   Conventional clustering misses the mechanical correlation between units with similar shares.
+3. Report the effective number of shifts, 1/sum_k s_k^2 on the importance weights. A small value
+   means a few shocks drive everything and no asymptotics protect you, whatever N is.
+
+Timing: measure shares at the beginning of the natural experiment generating the shifts, so
+shifts cannot feed back into shares, and lag only with a stated mechanism (it always costs
+power). On the share path, compute Rotemberg weights, name the shares that carry the design, and
+balance-test those shares against pre-period outcomes (Card's Philippines share fails this in
+every period, the canonical caught example). With many shares, TSLS is biased toward OLS: use
+JIVE, LIML, HFUL, or bias-corrected TSLS. In-sample estimated shifts (classic Bartik, Card) need
+the leave-out construction.
+
+## Formula instruments: recenter or control
+
+Trigger rule (Borusyak-Hull 2023): if the treatment or instrument is computed from exogenous
+shocks plus nonrandom exposure by a known formula, shock exogeneity is not enough. Their
+one-sentence version: randomizing transportation upgrades does not randomize the market access
+growth generated by them. Recognition is the hard part; the standing examples are network
+spillover counts (number of treated friends), market-access measures, and simulated eligibility
+instruments, and the structure also covers media-coverage instruments and randomized rollouts
+propagating through nonrandom networks.
+
+The fix is one-dimensional: simulate counterfactual shock vectors from a specified assignment
+process (a permutation class in natural experiments), recompute the instrument under each,
+average to get the expected instrument mu_i, then instrument with z_i - mu_i or control for
+mu_i. Recenter first in a true experiment; in a natural experiment prefer controlling for
+several candidate mu_i from different guessed assignment processes, which is doubly robust (a
+wrong candidate cannot introduce bias where none existed). The same draws give randomization
+inference and the balance test of the recentered instrument. The China HSR numbers (0.23
+significant collapsing to 0.08 insignificant after recentering) are the calibration for how much
+pure exposure bias can look like an effect. Ordinary controls do not substitute: geography
+absorbing 82 percent of the instrument's variation still left a significant biased estimate.
+
+## Diagnostics battery
+
+1. Robust first-stage F, computed at the level the design lives at: in-bandwidth for fuzzy RD
+   (that skill), shift-level for shift-share, cluster-robust at the assignment level otherwise.
+   Read it against the ladder in references/details.md, not against 10.
+2. Compliance-share table (binary instrument): pi_a, pi_n, pi_c. A thin complier slice means
+   wide intervals and honest extrapolation language.
+3. Balke-Pearl inequality checks (binary Y, X, Z): four testable inequalities implied by the
+   assumptions; a violation means the design is internally inconsistent, and passing proves
+   nothing. Worked flu-data numbers in references/details.md.
+4. OLS next to IV, always, and the OLS-proximity audit: t-significant IV near OLS with moderate
+   F is the configuration to distrust.
+5. Overid J (with CUE) where applicable, interpreted under the heterogeneity rule above.
+6. Balance of the instrument on predetermined covariates, with the design's controls and the
+   design's standard errors (exposure-robust on the shift path; RI for recentered instruments).
+   On the share path this is a pre-trends exercise and did-style scrutiny applies.
+7. TSLS-LIML divergence in overidentified designs as a cheap weak/many-instrument alarm.
+8. Placebo outcomes: lagged outcomes as the dependent variable, RI-based for recentered
+   designs (sharp null sidesteps the RI-with-heterogeneity complication).
+9. MST feasibility tests, two cheap re-solves of the extrapolation LP
+   (Mogstad-Santos-Torgovitsky 2018): restrict the MTR pairs to zero average selection bias
+   and re-solve, then to zero selection on gains. Infeasibility rejects that behavioral
+   hypothesis and turns the OLS-IV gap of item 4 into a formal test; with unrestricted MTRs,
+   infeasibility is item 3's Balke-Pearl falsification in general form.
+
+## The live dispute, carried honestly
+
+Whether the just-identified 2SLS t-test is rescuable. Angrist-Kolesár 2024 defend it (size is
+approximately fine at realistic endogeneity); Lee et al. 2022 patch it with tF/VtF critical
+values. The canon's position (Keane-Neal) is that both miss the binding problem: power, not
+size. The t-test has near-zero power against effects opposite the OLS bias, which under
+publication bias manufactures spurious literature-wide consensus, and tF inherits the asymmetry.
+Default here: AR/CLR and the F-50 standard. When a referee pushes back with Angrist-Kolesár,
+report both and cite the dispute; the AR test costs one regression, so there is no economy
+argument for the t-test.
+
+## R implementation
+
+The complete runnable pipeline is scripts/iv_template.R (estimation, the full weak-IV inference
+menu, compliance shares and Balke-Pearl checks, both shift-share paths with exposure-robust
+inference, recentering with RI, and an optional ivmte block for MST extrapolation bounds), with
+every call verified against package documentation. The core:
+
+```r
+library(fixest); library(ivmodel); library(ivDiag)
+est <- feols(y ~ w1 + w2 | x ~ z, data = df, vcov = ~cl)   # 2SLS point estimate
+m   <- ivmodel(Y = df$y, D = df$x, Z = df$z, X = df[, c("w1","w2")])
+AR.test(m); CLR(m)                       # identification-robust tests + inverted CIs
+LIML(m); Fuller(m)                       # overidentified / many-weak point estimates
+ivDiag(data = df, Y = "y", D = "x", Z = "z",
+       controls = c("w1","w2"), cl = "cl")   # bootstrapped F, effective F, AR, tF in one call
+```
+
+Shift-share: ShiftShareSE (reg_ss / ivreg_ss, AKM and AKM0) and the shift-level equivalent
+regression via ssaggregate. Recentering is a hand-coded permutation loop (no package needed;
+the template has it). Package index with versions, links, and traps in references/details.md.
+
+## Methods paragraph template
+
+> Treatment here is chosen, not assigned: [selection story]. We instrument with [instrument],
+> which shifts the incentive to take treatment through [channel]. Assignment of the instrument
+> is [randomized / plausibly unconfounded conditional on X], which justifies the reduced-form
+> intention-to-treat estimates; the IV estimate additionally requires exclusion, which we assess
+> separately for always-takers and never-takers ([arguments]), and monotonicity, which [holds
+> because the instrument is a one-directional incentive / is threatened because this is an
+> examiner-style design, and we report the corresponding bounds]. The estimand is the complier
+> average effect (Imbens 2014); compliers are [share] of the sample. Our instrument's robust
+> first-stage F is [value], certifying a population F of at least [ladder value] at 95 percent
+> confidence; following Keane and Neal (2024) we report Anderson-Rubin [CLR] tests and inverted
+> confidence intervals in place of 2SLS t-statistics. [Shift-share designs add: identification
+> follows the exogenous-[shifts/shares] path of Borusyak, Hull, and Jaravel (2025), with
+> (exposure-robust inference and the effective number of shifts reported / Rotemberg weights and
+> per-share balance tests reported).] A limitation of this design is that it identifies effects
+> for compliers only. [If the question stops at the compliers, say so and stop. Otherwise:]
+> Because our policy question concerns [the rollout / the incentive change], the target is the
+> policy-relevant treatment effect for [policy population]. Following Mogstad, Santos, and
+> Torgovitsky (2018) we report bounds on it consistent with our IV and OLS estimands under
+> [the MTR restrictions imposed: bounded outcomes / decreasing MTE / spline of stated degree],
+> for a policy that raises participation by [alpha]. The bounds [range] widen as the
+> extrapolation grows, which is the price of asking about individuals the instrument did not
+> move.
+
+Every claim traces to references/canon.md; keys live in causal-design/references/causal.bib.
+
+## Handoffs
+
+- causal-design: whether IV is the right tool at all; clustering and inference questions shared
+  across designs.
+- rdd: fuzzy RD is IV at a cutoff; its first-stage and exclusion discipline lives there, the
+  weak-IV inference regime here.
+- did: the share-exogeneity path is a stack of DiD-style exposure designs, so parallel-trends
+  scrutiny and pre-trend tools from did apply to share balance.
+- field-experiment: randomized encouragement designs end to end (including the ITT/LATE
+  analysis) and randomization inference on a simple physically randomized instrument;
+  recentered and formula instruments keep their RI machinery here.
+- preregister: pre-specifying the instrument, specification, and weak-IV fallback before
+  outcomes are seen (experiment-first skill; adapt its structure for quasi-experimental PAPs).

--- a/skills/iv/references/canon.md
+++ b/skills/iv/references/canon.md
@@ -1,0 +1,158 @@
+# IV canon
+
+Current as of 2026-07-29. These sources are hand-picked; nothing enters this file without
+explicit human approval. BibTeX keys point into ../../causal-design/references/causal.bib.
+Refresh: litreview on the method since the date above, results proposed as flagged addenda.
+
+## Imbens (2014)
+
+Statistical Science 29(3): 323-358. Key: `imbens2014instrumental`.
+
+- Role: the conceptual foundation; why economists reach for IV, what each assumption says, and
+  the LATE estimand's honest defense.
+- Settles: IV is for treatments that are chosen (selection on anticipated gains) or that are
+  equilibrium objects (prices); the four assumptions are kept separate because unconfounded
+  assignment of the instrument justifies the ITT only, never the IV ratio; exclusion is
+  substantive in essentially every application and must be argued by compliance type;
+  monotonicity is safe for one-directional incentives and suspect for examiner designs; the
+  LATE is the only point-identified average and should travel with compliance shares and Manski
+  bounds when the ATE was the target; overid-test rejections under heterogeneity may reflect
+  instrument-specific complier populations; TSLS-LIML divergence flags weak or many
+  instruments; the Balke-Pearl inequalities make the assumptions partially testable; the AR
+  statistic inverts into weak-instrument-valid confidence sets.
+- Binds when: any IV analysis; every exclusion argument; every choice among ITT, LATE, bounds,
+  and structural estimands.
+- Implement: estimator-level paper, names no software; R mappings (ivreg, fixest, ivmodel) are
+  ours, in references/details.md.
+- Quote: the second-best defense of LATE (the trial-that-enrolled-only-men analogy); exclusion
+  "satisfied by design" only in double-blind placebo-controlled trials with noncompliance.
+
+## Keane and Neal (2024)
+
+Annual Review of Economics 16: 185-212. Key: `keane2024practical`.
+
+- Role: the weak-instrument inference regime; the canon's rules for testing, intervals, and
+  instrument-strength standards.
+- Settles: abandon the 2SLS t-test at every instrument strength (power asymmetry: the 2SLS
+  standard error is spuriously small when the estimate lands near OLS, rank correlation -0.92
+  at population F 29.4); AR always (CLR overidentified), intervals only by inversion; the F
+  ladder (sample 10 certifies population 2.3; 50 certifies 29.4; 104.7 certifies 73.75 at 5
+  percent size); target robust F about 50, scaled 50/K^(3/4); below 3.84 do not run IV;
+  just-identified AR is the reduced-form robust t; overidentified use LIML/CUE + CLR, avoid
+  2SLS and two-step GMM; never mix estimators and tests; one-sided t size distortions are
+  severe at any realistic strength and t power against effects opposite the OLS bias is near
+  zero, which manufactures publication-bias consensus; 24 percent of audited AER IV papers with
+  F under 50 flip under AR/CLR.
+- Binds when: every linear IV analysis, whatever the instrument's provenance; refereeing IV
+  papers (the near-OLS significant-t pattern).
+- Implement: Stata-first (weakiv, ivreg2 cue, weakivtest); R route is ivmodel + ivDiag, our
+  mapping, in references/details.md.
+- Quote: "If your first stage F is that small you should not be running 2SLS anyway!" (on
+  F < 3.84).
+
+## Borusyak, Hull, and Jaravel (2025)
+
+Journal of Economic Perspectives 39(1): 181-204. Key: `borusyak2025practical`.
+
+- Role: the shift-share practitioner guide; the two-path fork and both checklists.
+- Settles: shift-share identification is a committed choice between exogenous shifts (shares
+  arbitrarily endogenous; needs many effective shifts, shift-level controls as s-weighted
+  aggregates, exposure-robust inference via AKM or the equivalent shift-level regression) and
+  exogenous shares (each share a valid DiD-style instrument; must be tailored, not generic;
+  Rotemberg weights name the shares that carry the design); the Table 2 disqualifiers (would
+  you use the shifts, or a single share, directly?); control the sum of shares when incomplete;
+  share timing at the start of the natural experiment; leave-out shifts when estimated
+  in-sample; many-share designs need JIVE/LIML/HFUL/bias-corrected TSLS; failed share
+  sensitivity conflates invalidity with heterogeneity (Mogstad-Torgovitsky-Walters).
+- Binds when: any instrument that is a weighted average of common shocks; OLS exposure designs
+  with shift-share treatments; refereeing Bartik-style marketing IVs (generic category-mix
+  shares fail the share path).
+- Implement: ssaggregate (Stata/R), bartik_weight for Rotemberg weights, ShiftShareSE for AKM;
+  details and traps in references/details.md.
+- Quote: the two disqualifiers, near-verbatim from Table 2; the generic-versus-tailored shares
+  distinction (generic industry shares proxy exposure to essentially any industry shock).
+
+## Borusyak and Hull (2023)
+
+Econometrica 91(6): 2155-2185. Key: `borusyak2023nonrandom`.
+
+- Role: the formula-instrument framework; validity for constructed treatments and instruments.
+- Settles: exogenous shocks feeding a known formula do not make the composite exogenous,
+  because exposure is predetermined and endogenous; the expected instrument mu_i (average of
+  the instrument over simulated counterfactual shock draws) is the sole confounder; recenter
+  (z - mu) or control for mu; recenter-then-control in experiments, control for several
+  candidate mu_i in natural experiments (double robustness); ordinary controls purge the bias
+  only if they span mu_i (geography R2 of 0.82 was not enough); consistency needs many
+  dispersed shocks; recentered IV is a convex-weighted complier average under monotonicity,
+  rescaling by the counterfactual variance recovers unweighted estimands; the same draws give
+  RI tests and intervals (Hodges-Lehmann inversion, not the naive re-randomized estimator
+  distribution); China HSR employment elasticity 0.23 (0.075) collapses to 0.08 (0.097)
+  recentered.
+- Binds when: spillover counts, market access, simulated eligibility, media-coverage
+  instruments, randomized rollouts propagating through nonrandom networks; any instrument
+  built by formula from shocks plus exposure.
+- Implement: hand-coded permutation loop (the template has it); ShiftShareSE for the linear
+  special case; RI from the same draws.
+- Quote: "randomizing transportation upgrades does not randomize the market access growth
+  generated by them."
+
+## Mogstad, Santos, and Torgovitsky (2018)
+
+Econometrica 86(5): 1589-1619. Key: `mogstad2018using`.
+
+- Role: the extrapolation framework; what the IV estimands say about parameters beyond the
+  complier average (PRTEs, ATE/ATT/ATU, extrapolated LATEs), made computable.
+- Settles: every treatment parameter and every IV-like estimand (IV slope, TSLS components,
+  OLS slope, saturated cell means) is a weighted average of the same two marginal treatment
+  response functions with identified weights, so bounds on the target come from a linear
+  program over MTR pairs consistent with the estimands and the stated restrictions; saturated
+  (d,z)-cell estimands attain sharpness (the feasible set is exactly the MTR pairs matching
+  E[Y|D,Z], which exhausts the data); assumptions are priced continuously (their worked
+  example: sharp nonparametric [-0.138, 0.407] shrinks to [0, 0.067] under decreasing MTRs
+  plus a ninth-degree polynomial, truth 0.046) and bounds collapse to the LATE as the
+  extrapolation distance alpha goes to zero; point identification has exactly two routes, both
+  nested as special cases (a continuous instrument whose propensity-score support covers the
+  target weights, or a parametric MTR space of dimension at most the number of independent
+  estimands, the Brinch-Mogstad-Wiswall linear form for a binary instrument); an empty
+  feasible set is a specification test (unrestricted MTRs reproduce the Balke-Pearl testable
+  implications; restricting to zero average selection bias or zero selection on gains turns
+  emptiness into a test of that behavioral hypothesis); under weak identification feed the LP
+  the undivided covariance form of the IV estimand (their footnote 3).
+- Binds when: the stated question is a rollout, expansion, or incentive change, so the target
+  is a PRTE; natural-experiment instruments (weather, stockouts, outages) whose compliers no
+  policy would move; ATU-style "would it work on the non-adopters" questions; any
+  point-identified extrapolation, whose functional-form price this framework audits.
+- Scope limits: identification analysis only; the published version has no inference procedure
+  (that is in the 2017 NBER working paper w23568), so bounds travel without confidence
+  statements unless bootstrapped through software.
+- Implement: the paper ships no code (AMPL plus Gurobi); the practical route is the ivmte R
+  package (Shea-Torgovitsky 2023, `shea2023ivmte`), package row and solver traps in
+  references/details.md, optional template block in scripts/iv_template.R.
+
+## Named disputes the skill carries
+
+1. Just-identified t-test: Keane-Neal (abandon it; power asymmetry is the binding problem) vs
+   Angrist-Kolesár 2024 (size is fine at realistic endogeneity) and Lee et al. 2022 (tF/VtF
+   critical values fix size). Default: AR/CLR and the F-50 standard; report both when pushed,
+   cite the dispute. Presented as live, not settled.
+2. Overid rejections: invalidity vs heterogeneity (both canon papers, plus
+   Mogstad-Torgovitsky-Walters 2021). Not a dispute between authors but a fork in
+   interpretation the skill refuses to collapse.
+
+## Primary papers cited through the canon
+
+Resolver-verified entries in causal.bib (see the IV block there for keys and PREPRINT flags):
+Imbens-Angrist 1994 (LATE theorem); Angrist-Imbens-Rubin 1996 (IV in potential outcomes);
+Staiger-Stock 1997 and Bound-Jaeger-Baker 1995 (weak-IV founding); Anderson-Rubin 1949 (the AR
+test); Moreira 2003 (CLR), 2009 (UMPU optimality), Moreira-Moreira 2019 (heteroskedastic
+optimality); Kleibergen 2005 (GMM identification-robust tests); Andrews-Stock-Sun 2019 (weak-IV
+survey); Lee-McCrary-Moreira-Porter 2022 (tF); Angrist-Kolesár 2024 (just-ID defense);
+Keane-Neal 2023 (power asymmetry mechanics); Montiel Olea-Pflueger 2013 (effective F); Dufour
+1997 (unbounded-CI impossibility); Young 2022 (robust-F evidence); Balke-Pearl 1997 and
+Imbens-Rubin 1997 (bounds and inequality tests); Bekker 1994 (many-instrument asymptotics);
+Angrist-Imbens-Krueger 1999 (JIVE); Hausman et al. 2012 (HFUL); Kolesár et al. 2015
+(bias-corrected TSLS); Borusyak-Hull-Jaravel 2022, Adão-Kolesár-Morales 2019,
+Goldsmith-Pinkham-Sorkin-Swift 2020 (the three shift-share pillars); Mogstad-Torgovitsky-
+Walters 2021 (heterogeneity and multiple instruments); Autor-Dorn-Hanson 2013, Card 2009,
+Bartik 1991, Currie-Gruber 1996, Angrist-Krueger 1991 (worked designs);
+Jaeger-Ruist-Stuhler 2018 (dynamic shift-share caveat).

--- a/skills/iv/references/details.md
+++ b/skills/iv/references/details.md
@@ -1,0 +1,244 @@
+# IV lookup details
+
+Heavy reference content the SKILL.md points into. Current as of 2026-07-28.
+
+## The F ladder (Keane-Neal Table 1)
+
+What a sample robust first-stage F certifies about the population F at 95 percent confidence,
+and the resulting worst-case two-tailed t size:
+
+| Sample F | Certified population F | Max two-tailed size |
+|---|---|---|
+| 10 | 2.3 | 13.5% |
+| 16.38 | 5.78 | 10% |
+| 23.1 | 10 | 8.6% |
+| 50 | 29.44 | 6.4% |
+| 104.7 | 73.75 | 5% |
+
+The sample F is a noisy noncentral draw around the population F and does not concentrate with
+N; large N alone fixes nothing. With K instruments the F-50 target scales as roughly
+50/K^(3/4). Below sample F = 3.84 the AR interval is unbounded, which is the design's verdict.
+
+## The power asymmetry, mechanically
+
+Two channels (Keane-Neal 2023): the second-stage residual variance is a quadratic in beta
+minimized at OLS, so sigma-hat is smallest when the 2SLS estimate lands near OLS; and sample
+covariance between the instrument and the structural error simultaneously inflates the apparent
+first stage and pulls the estimate toward OLS. Together they make the 2SLS standard error
+artificially small near OLS and large far from it (rank correlation of estimate and SE of
+-0.92 at population F 29.4, rho 0.8). Consequences: one-sided t size is severely distorted at
+any realistic strength (100 percent of null rejections land on the OLS-bias side at F = 10);
+power against effects opposite the OLS bias is near zero (0.2 percent for a true beta of -0.3
+at F = 2.3); with publication bias, the t-test manufactures a spurious literature-wide
+consensus in the OLS direction. AR largely removes the asymmetry and is UMPU just-identified
+(Moreira 2009), keeping optimality under heteroskedasticity and autocorrelation
+(Moreira-Moreira 2019).
+
+## Prior-on-rho calibration (how strong must the instrument be?)
+
+For any hypothesized beta_p, the implied rho is the correlation between the residuals of
+(y - x beta_p on z) and the first stage; beta_p = 0 gives the reduced-form residual correlation
+as the upper bound under suspected positive selection. With a uniform prior on rho over the
+plausible range, 2SLS beats OLS in distance to truth only 26 percent of the time at population
+F 2.3, 47 percent at 10, 65 percent at 29.44. Severe suspected endogeneity relaxes the F-50
+demand, but only when the severity is credible ex ante, from theory or the institutional
+setting, never from the observed OLS-IV gap alone. When invoked, report the ladder position,
+the rho argument, and AR/CLR intervals anyway; those remain valid at any instrument strength.
+Mismeasured regressors can push rho negative, so include that side when measurement error is
+live.
+
+## Estimator and test menu
+
+| Setting | Point estimate | Test and interval |
+|---|---|---|
+| Just-identified | 2SLS (= IV ratio = ILS) | AR (reduced-form robust t); interval by inversion |
+| Overidentified, homoskedastic | LIML | CLR (Moreira 2003) |
+| Overidentified, heteroskedastic/clustered | CUE (LIML + robust VCE as fallback) | Kleibergen 2005 GMM CLR |
+| Many instruments | LIML (Bekker-consistent), JIVE, HFUL, bias-corrected TSLS | CLR; Hansen J alongside CUE |
+| Many weak + severe endogeneity | Fuller, Andrews-Armstrong unbiased | same |
+
+Never attach CLR p-values to a 2SLS estimate; never screen on t before AR. TSLS and LIML are
+identical just-identified and diverge exactly when instruments are weak or many, so their gap
+is itself a diagnostic. With few clusters the F and chi2 versions of AR can diverge; check
+both (our own operational note, not from the canon).
+
+## Compliance shares and Balke-Pearl checks (binary Y, X, Z)
+
+Shares from two conditional means: pi_a = pr(X=1|Z=0), pi_n = pr(X=0|Z=1),
+pi_c = 1 - pi_a - pi_n. The first-stage ITT on treatment equals the complier share, so the
+first-stage table doubles as the compliance table. The assumptions imply four testable
+inequalities of the form pr(Y=1, X=0 | Z=1) <= pr(Y=1, X=0 | Z=0). Worked flu-encouragement
+numbers (Imbens 2014): left side 30/1389 = 0.0216 vs right side 31/72 = 0.0211, a slight
+statistically insignificant violation, showing the tests have bite. Violation means at least
+one assumption is false; passing proves nothing (no consistent test exists). Manski natural
+bounds from the same 2x2x2 table travel with the LATE when the ATE was the target: flu ATE
+bounds [-0.24, 0.64] against a complier LATE of -0.125 (0.090), complier share 0.119.
+
+## Beyond-LATE extrapolation (MST 2018)
+
+Mogstad-Santos-Torgovitsky 2018 (`mogstad2018using`); software companion Shea-Torgovitsky
+2023 (`shea2023ivmte`).
+
+The decomposition: every target parameter (ATE, ATT, ATU, any LATE, the PRTE class) and every
+IV-like estimand (IV slope, TSLS components, OLS slope, saturated cell means) is a weighted
+average of the same two marginal treatment response functions m0(u, x) = E[Y0 | U = u, X = x]
+and m1(u, x) = E[Y1 | U = u, X = x], with identified weights; their difference is the MTE. The
+LATE averages the MTE over u in (p(0), p(1)]; a policy parameter averages it elsewhere. The
+extrapolated LATE(p(0), p(1) + alpha) is a convex weight on the point-identified LATE plus a
+term integrating the MTE over (p(1), p(1) + alpha], so everything said beyond the complier
+interval is a claim about that second term, and every feasible MTR pair still reproduces the
+LATE (internal validity is never traded away). PRTE parameterizations with closed-form
+weights: additive (participation up alpha points), proportional (up alpha percent), an
+additive shift in one instrument component; get alpha from the planned rollout or an auxiliary
+choice model. Bounds come from minimizing and maximizing the target over MTR pairs consistent
+with the estimands and the stated restrictions, a linear program; bounds collapse to the LATE
+as alpha goes to zero.
+
+The assumption ladder, on their worked example (trinary instrument, binary outcome, target
+LATE(0.35, 0.9), truth 0.046):
+
+| Constraints on the MTR pairs | Bounds |
+|---|---|
+| IV slope only | [-0.421, 0.5] |
+| IV + OLS slopes | [-0.411, 0.5] |
+| all saturated (d,z)-cell estimands (sharp nonparametric) | [-0.138, 0.407] |
+| + decreasing MTRs + ninth-degree polynomial | [0, 0.067] |
+
+Sharpness rule (their Proposition 3): with discrete D and Z, the indicators of every (d, z)
+cell, the information in a saturated regression of Y on D and Z, make the feasible set exactly
+the MTR pairs matching E[Y|D,Z], which exhausts the data. Leaving estimands out leaves bounds
+valid but wider than needed. Report the nonparametric bounds next to the restricted bounds so
+the reader sees what each assumption bought, and bounds as a function of alpha (their Figure 8
+is the template) so the reader sees how fast extrapolation is priced; a conclusion that
+appears only at high polynomial rigidity is an assumption, not a finding. The same LP doubles
+as the specification test: an empty feasible set with unrestricted MTRs falsifies the joint IV
+assumptions (Balke-Pearl in general form), and restricted to zero average selection bias or
+zero selection on gains, emptiness rejects that behavioral hypothesis.
+
+## The fish-market numbers (price endogeneity in two lines)
+
+OLS of log quantity on log price in the Fulton whiting data: -0.54 (0.18), a variance-weighted
+mix of supply and demand slopes with ambiguous sign. Stormy-weather supply-shifter IV: demand
+elasticity -1.08 (0.46); TSLS with the trivalued instrument -1.014 (0.384), LIML -1.016
+(0.384). OLS understates the demand elasticity by half. A supply shifter identifies demand and
+a demand shifter identifies supply; without one side's shifter, that side stays unidentified.
+
+## Shift-share checklists (BHJ 2025, worked examples attached)
+
+Shift path (worked on Autor-Dorn-Hanson 2013):
+1. Name the confounder OLS suffers from; describe the idealized shift-level experiment.
+2. Bridge observed to ideal shifts with shift-level controls entered as s-weighted aggregates
+   and unit-level controls; ask whether the proxy-to-ideal gap is itself confounded (ADH's
+   non-US import growth passes; classic Bartik national growth rates do not).
+3. Control the sum of shares if incomplete, interacted with period FE in stacked designs; do
+   not renormalize. This control alone shrinks ADH's total-employment effects.
+4. Lag shares to the start of the natural experiment; with serially correlated shifts, use
+   innovations or lag to the first shocked period. Lagging does not fix dynamic effects
+   (Jaeger-Ruist-Stuhler); panels need the appendix treatment.
+5. Report shift-level descriptives including the effective number of shifts 1/sum s_k^2
+   (cluster-level if shifts correlate within clusters); treat the shifts as the sample.
+6. Balance-test at both levels: g_k on shift-level confounder proxies; predetermined unit
+   variables on z_i with exposure-robust SEs.
+7. Estimate with exposure-robust inference (AKM/AKM0 or the ssaggregate shift-level equivalent
+   regression, which reproduces the unit-level coefficient exactly and gives the honest F);
+   check stability across control sets and weighting.
+
+Share path (worked on Card 2009 immigration):
+1. Argue shares are tailored to the treatment (they mediate only shocks to x), ideally with
+   quasi-experimental share variation, not mere lagging.
+2. Control sums of share groups so identification comes from composition, not level (control
+   total migrant share; identify from origin mix).
+3. Compute Rotemberg weights; name the carrying shares (Mexico about half the weight for
+   high-school-equivalent workers).
+4. Balance-test the instrument and the high-weight shares on pre-period outcomes (the
+   Philippines share fails in all periods, the caught example).
+5. Check sensitivity across pooling schemes (one share at a time, TSLS/GMM, visual-IV plot,
+   Sargan-Hansen), switching to JIVE/LIML/HFUL/bias-corrected TSLS when K is large. Dispersion
+   among high-F high-weight shares is the red flag; interpret under the heterogeneity rule.
+
+Network-exposure designs (fraction of friends treated) are shift-share with shares =
+normalized adjacency and shifts = treatment dummies; wrap the randomized rollout in the shift
+path and control the sum of shares when some nodes were ineligible. When the treatment itself
+is shift-share (OLS exposure designs), the same frameworks apply with x = z.
+
+## Recentering mechanics (Borusyak-Hull 2023)
+
+1. Partition determinants into shocks g (willing to call exogenous) and exposure w
+   (predetermined, endogenous).
+2. Specify the shock assignment process. RCT: the protocol. Natural experiment:
+   exchangeability, i.e. permute realized shocks within strata of similar shocks (the HSR
+   application permutes completion among built and unbuilt lines with the same number of
+   cross-prefecture links).
+3. Draw S counterfactual shock vectors (1,999 there; any fixed S identifies, variance cost at
+   most (S+1)/S), recompute z_i under each, average to mu_i.
+4. Instrument with z - mu, or control for mu. Experiment: recenter, then controls for
+   precision. Natural experiment: control for several candidate mu_i (double robustness; a
+   wrong candidate cannot introduce bias where none existed).
+5. Same draws give the balance test (regress recentered z on predetermined covariates; RI joint
+   p from the sum-of-squared-fitted-values statistic; HSR geography R2 drops 0.824 to 0.083,
+   joint p 0.443) and RI intervals by Hodges-Lehmann inversion of
+   T = (1/N) sum (z_i - mu_i)(y_i - b x_i) (interval inversion assumes a constant-effect
+   model; under heterogeneous effects with unbalanced designs report the sharp-null test plus
+   Neyman-style intervals instead, per field-experiment). Never use the distribution of the
+   estimator across re-randomized shocks (the re-randomized instrument has a true first stage
+   of zero).
+6. Heterogeneous effects: recentered IV is a convex complier-type average with weights
+   proportional to Var(z_i - mu_i | w); rescale by that variance for unweighted estimands.
+7. Do not substitute simple observables (friend counts, latitude polynomials) for mu unless the
+   protocol makes them exactly proportional; unit FE purge exposure bias only when mu is
+   time-invariant (stationary shocks, stable exposure), which growing networks violate.
+8. Endogenous treatment case: build the candidate instrument by zeroing the endogenous
+   argument, x = h(g, w, u) instrumented by recentered h(g, w, 0).
+
+Caveat the paper itself flags: passing the RI balance tests supports the counterfactual
+specification, and does not directly certify shock exogeneity; the placebo-outcome test is the
+check aimed at that assumption.
+
+## Marketing translations
+
+- Price endogeneity: cost shifters and Hausman-style other-market prices routinely land F in
+  the 10-30 band, where 2SLS beats OLS less than half the time absent severe endogeneity; a
+  demand elasticity near OLS with a significant t is the suspect configuration. Model-implied
+  optimal instruments and cost shocks aggregated through nonrandom input shares are formula
+  instruments and need recentering.
+- Advertising exposure: randomized encouragement (ghost ads, PSA holdouts) is the flu-letter
+  design; reach-based vs exposure-based effects is ITT vs LATE. Media-coverage instruments
+  (transmitter placement x terrain) are on the formula-instrument list.
+- Platform and network spillovers: fraction-of-friends-treated regressions in influencer
+  seeding and referral programs need the mu adjustment even with randomized seeding, because
+  connected users are mechanically more exposed. Staggered platform rollouts with
+  audience-overlap shares are shift-share.
+- Retail demand: Jaravel-style category demand growth instrumented by national sociodemographic
+  shifts weighted by the category's sales shares across groups is the scanner-data template.
+  Generic category-mix or channel-mix shares are generic shares and cannot carry the share
+  path; shares built from the treatment's specific diffusion channel can.
+- Content moderation and review routing: examiner designs; interrogate monotonicity (strict
+  reviewer's approvals must nest the lenient one's), and note the leniency instrument has a
+  composite flavor that invites the recentering audit.
+- Distance instruments (store, warehouse, delivery coverage): condition on generic distance,
+  instrument with the specific version (the McClellan-Newhouse trick).
+
+## Package index (verified against package docs 2026-07-28; the ivmte row on 2026-07-29)
+
+| Package | Version | Role | Traps |
+|---|---|---|---|
+| fixest | 0.14.2 (CRAN) | 2SLS with FE and clustered SEs; first stage via summary(est, stage = 1); fitstat(~ ivf1 + ivwald1 + sargan + wh) | IV part must be the LAST formula element, after fixed effects; fitstat keywords lowercase (pinned also in did's details; update the two pins together on refresh) |
+| ivreg | 0.6-8 (CRAN) | TSLS with diagnostics rows (weak instruments, Wu-Hausman, Sargan); successor to AER::ivreg | three-part form is y ~ exogenous \| endogenous \| instruments; in the two-part form, controls not repeated after the pipe silently become instruments; vcov. must be a function when diagnostics = TRUE |
+| ivmodel | 1.9.1 (CRAN) | AR.test and CLR with inversion CIs (matrix of interval rows; unions and unbounded sets happen), KClass/LIML/Fuller, heteroSE and clusterID options | KClass has a capital K; single endogenous regressor; takes data vectors, not formulas |
+| ivDiag | 1.0.6 (CRAN; yiqingxu.org/packages/ivDiag) | one-call audit: F.standard/robust/cluster/bootstrap/effective, AR with inverted CI, tF (Lee et al.), ltz local-to-zero | every variable passed as a name string; pulls the lfe dependency chain |
+| ShiftShareSE | 1.1.0 (CRAN, Kolesar) | reg_ss / ivreg_ss with method = "akm" / "akm0" (AKM0 = null-imposed, better small-K coverage); sector_cvar clusters shocks | X is the aggregated shift-share vector, shares go in W, the instrument never appears in the formula; the akm0 "se" is a normalized CI length, never a t-stat input |
+| ssaggregate | GitHub kylebutts/ssaggregate (0.0.0.9000, pushed 2025-11) | BHJ shock-level aggregation for the equivalent shift-level regression and the exposure-robust F | dev version, no CRAN release or visible tests; n/s/l/t are strings while vars/controls are formulas; template keeps a hand-coded fallback |
+| bpbounds | 0.1.8 (CRAN) | Balke-Pearl inequality checks and ACE bounds (binary Y, X; Z with 2-3 categories) | xtabs order is positional treatment-outcome-instrument with margin = 3 on the instrument |
+| ManyIV | GitHub kolesarm/ManyIV (0.0.2.9000) | many-instrument SEs (Kolesár 2018 minimum distance, JoE 204(1):86-100, distinct from Kolesár-Rothe 2018 on discrete running variables in the rdd skill), JIVE/UJIVE, Sargan + modified Cragg-Donald overid | rough dev API (man pages carry TODOs); for single-endogenous LIML/Fuller use ivmodel instead |
+| AER | 1.2-17 (CRAN) | legacy ivreg (two-part formula only), kept for compatibility notes | superseded by the ivreg package |
+| ivmte | 1.4.0 (CRAN, 2021-09-17; GitHub jkcshea/ivmte slightly ahead, last commit 2024-08-27) | MST bounds and extrapolation, single entry point ivmte(): target 'ate'/'att'/'atu'/'late'/'genlate' with genlate.lb/.ub the u-interval (the alpha dial) or custom target.weight0/1; MTR space via m0/m1 formulas with uSpline(degree, knots, intercept); ivlike list of regression formulas as the estimands; shape flags m0/m1/mte .lb/.ub/.inc/.dec enforced on the audit grid (initgrid.nx/.nu, audit.nx/.nu); bootstraps for inference; cite `shea2023ivmte` | needs one of gurobi/cplexapi/rmosek/lpsolveapi; the only fully free solver (lpSolveAPI) is roughly an order of magnitude slower and cannot run the regression-based direct criterion (QCQP, Gurobi or MOSEK only), so with it always supply ivlike moments; point = TRUE forces GMM and silently ignores every shape constraint; the unobservable in m0/m1 must match uname (default u); m0/m1 bounds default to the observed outcome range, which is the bounded-outcome assumption |
+
+R has no reliable CUE implementation; for the overidentified heteroskedastic case the canon's
+CUE + CLR recipe runs in Stata (ivreg2 with cue, then weakiv), with LIML(heteroSE = TRUE) as
+the R fallback. Rotemberg weights: reference implementation at github.com/paulgp/bartik-weight
+(Stata and R code, not a CRAN package); the template hand-codes the just-identified GPSS
+decomposition and labels it as our implementation.
+
+Stata mirror (the Keane-Neal workflow is Stata-first): ivregress 2sls/liml, ivreg2 (cue, J),
+weakiv (AR/CLR inversion, Finlay-Magnusson-Schaffer), weakivtest (effective F), ssaggregate,
+bartik_weight, manyiv.

--- a/skills/iv/scripts/iv_template.R
+++ b/skills/iv/scripts/iv_template.R
@@ -1,0 +1,231 @@
+# IV analysis template. Runnable end to end; every call signature verified against package
+# documentation on 2026-07-28 (fixest 0.14.2, ivreg 0.6-8, ivmodel 1.9.1, ivDiag 1.0.6,
+# ShiftShareSE 1.1.0, bpbounds 0.1.8, all CRAN; ssaggregate and ManyIV from GitHub; ivmte
+# 1.4.0, CRAN, verified 2026-07-29). Adapt the CONFIG block and run section by section.
+#
+# API traps older tutorials get wrong:
+#   - fixest: the IV part (endo ~ inst) must be the LAST formula element, after fixed effects
+#   - ivmodel: the k-class function is KClass (capital K); data vectors, not formulas
+#   - ivDiag: every variable is passed as a name string, never a formula
+#   - ShiftShareSE: X = the aggregated shift-share vector, the share matrix goes in W, and the
+#     instrument never appears in the formula; the "akm0" se is a normalized CI length, NOT a
+#     standard error, so never build a t-stat from it
+#   - ivreg two-part formula: controls must be repeated after the pipe or they silently become
+#     excluded instruments; the three-part form (y ~ ex | en | in) avoids this
+#   - ivmte: point = TRUE silently ignores every shape constraint; the only fully free solver
+#     (lpSolveAPI) cannot run the regression-based direct criterion, so pass ivlike moments
+
+## ---- CONFIG ----------------------------------------------------------------
+df <- your_data              # replace
+# y  = outcome; d = endogenous treatment; z = instrument(s); x1, x2 = exogenous controls;
+# cl = cluster id at the level of INSTRUMENT assignment (Imbens 2014's flu example:
+# physicians were randomized, so cluster on physician, not patient).
+set.seed(94305)
+
+library(fixest); library(ivmodel); library(ivDiag)
+
+## ---- 1. OLS next to IV, always ---------------------------------------------
+# Report OLS alongside IV in every table; the OLS-vs-IV gap is data, and the
+# OLS-proximity audit (section 3) needs it.
+# vcov = ~cl is fixest's CR1; fine here because inference runs through AR/CLR, not
+# the 2SLS t. With few clusters (judge/examiner designs) use CR2 or wild bootstrap
+# for any coefficient you report directly.
+ols <- feols(y ~ d + x1 + x2, data = df, vcov = ~cl)
+est <- feols(y ~ x1 + x2 | d ~ z, data = df, vcov = ~cl)   # 2SLS; IV part last
+summary(est, stage = 1)                    # first stage (stage = 1; default prints stage 2)
+fitstat(est, ~ ivf1 + ivwald1 + wh)        # first-stage F, robust Wald, Wu-Hausman
+# With fixed effects: feols(y ~ x1 | firm + year | d ~ z, ...) -- IV part still last.
+
+## ---- 2. Weak-IV-robust inference (the headline inference) -------------------
+# AR at every instrument strength; CIs only by inversion (Keane-Neal 2024).
+m <- ivmodel(Y = df$y, D = df$d, Z = df[, c("z"), drop = FALSE],
+             X = df[, c("x1", "x2")])
+# Heteroskedastic / clustered variants: ivmodel(..., heteroSE = TRUE) or
+# ivmodel(..., clusterID = df$cl). Single endogenous regressor only.
+# With few clusters the F and chi2 versions of AR can diverge; check both (references/details.md).
+AR.test(m)     # $ci is a matrix of interval rows: possibly a union, possibly unbounded.
+CLR(m)         # coincides with AR when just-identified; the overidentified default test.
+# An unbounded AR set is the design's verdict (identification not established at 95%),
+# never something to suppress by quoting the bounded t-interval instead.
+LIML(m); Fuller(m, b = 1)      # overidentified / many-weak point estimates
+KClass(m, k = c(0, 1))         # OLS and TSLS in one call (capital K)
+
+## ---- 3. One-call audit: F ladder, effective F, tF, AR ------------------------
+g <- ivDiag(data = df, Y = "y", D = "d", Z = "z",
+            controls = c("x1", "x2"), cl = "cl", nboots = 1000)
+g$F_stat   # F.standard / F.robust / F.cluster / F.bootstrap / F.effective
+g$AR       # AR test + inversion CI
+g$tF       # Lee et al. (2022) tF on the effective F, for the referee who asks
+# Read F.robust against the Keane-Neal ladder (references/details.md): 50 certifies ~29,
+# 10 certifies only 2.3. Below 3.84, stop: do not run IV.
+# OLS-proximity audit: if the 2SLS estimate is near OLS, F is in the 10-50 band, and only
+# the t-test is significant, treat significance as suspect until AR confirms.
+# Sensitivity to exclusion violations (local-to-zero, prior on the direct effect):
+# ltz(data = df, Y = "y", D = "d", Z = "z", controls = c("x1", "x2"), prior = c(0, 0.05))
+# prior = c(0, 0.05) is an illustrative placeholder: set the prior on the direct effect
+# from your setting's plausible violation size.
+
+## ---- 4. Compliance shares, Balke-Pearl checks, Manski bounds (binary d, z) ---
+pi_a <- mean(df$d[df$z == 0])              # always-takers
+pi_n <- mean(1 - df$d[df$z == 1])          # never-takers
+pi_c <- 1 - pi_a - pi_n                    # compliers = the first-stage ITT
+c(pi_a = pi_a, pi_n = pi_n, pi_c = pi_c)
+# A thin complier slice means wide CIs and honest extrapolation language, not a bug.
+# Balke-Pearl inequality checks + ACE bounds (needs binary y too):
+library(bpbounds)
+bp_tab <- xtabs(~ d + y01 + z, data = df)  # POSITIONAL: treatment, outcome, instrument
+summary(bpbounds(prop.table(bp_tab, margin = 3)))   # margin = 3 conditions on z
+# $inequality FALSE = at least one IV assumption is internally inconsistent; stop and
+# rework the exclusion argument. bplb/bpub are the Manski-style ACE bounds to report
+# NEXT TO the LATE whenever the ATE was the stated target.
+
+## ---- 5. Overidentified designs ----------------------------------------------
+library(ivreg)   # maintained successor to AER::ivreg; three-part formula
+fit <- ivreg(y ~ x1 + x2 | d | z1 + z2, data = df)   # exogenous | endogenous | instruments
+summary(fit, diagnostics = TRUE)   # Weak instruments, Wu-Hausman, Sargan rows
+# TSLS-LIML divergence is a cheap weak/many-instrument alarm (they are identical
+# just-identified): compare coef(fit) with LIML(m2)$point.est where m2 <- ivmodel(...,
+# Z = df[, c("z1","z2")]). Under heteroskedasticity the canon wants CUE + CLR; R has no
+# reliable CUE, so use LIML with heteroSE = TRUE and report the Stata route
+# (ivreg2, cue + weakiv) when it matters. Interpret a Sargan/J rejection under the
+# heterogeneity rule (SKILL.md): divergent instruments may move different compliers.
+# Many instruments: JIVE/UJIVE and many-instrument-valid SEs (Kolesár 2018 minimum
+# distance, JoE 204(1):86-100; a different paper from Kolesár-Rothe 2018 on discrete
+# running variables, which belongs to rdd) live in
+# remotes::install_github("kolesarm/ManyIV"): IVreg(y ~ d + x1 | z1 + z2, data = df,
+# inference = "standard"), then IVoverid() -- dev-version API, check before relying on it.
+
+## ---- 6. Shift-share, shift path (BHJ 2025) -----------------------------------
+# Objects: S = N x K share matrix (rows = units, cols = shocks/sectors), gk = length-K
+# shock vector, z_ss = as.vector(S %*% gk) the unit-level instrument.
+# 6a. Effective number of shifts, the pre-test design diagnostic:
+sk <- colMeans(S); sk <- sk / sum(sk)      # importance weights (weight rows if design is)
+1 / sum(sk^2)                              # report next to N; small = no asymptotics protect you
+# 6b. Incomplete shares: if rowSums(S) is not 1 for everyone, CONTROL the sum of shares
+# (interacted with period FE in stacked designs); do not renormalize.
+df$sum_shares <- rowSums(S)
+# 6c. Exposure-robust inference (AKM / AKM0), Kolesar's ShiftShareSE:
+library(ShiftShareSE)
+ivreg_ss(y ~ x1 + sum_shares | d, X = z_ss, data = df, W = S,
+         method = c("ehw", "akm", "akm0"))
+# reg_ss(y ~ x1 + sum_shares, X = z_ss, data = df, W = S, method = c("akm", "akm0"))
+# gives the reduced form; sector_cvar= clusters shocks. AKM0 inverts the null-imposed
+# test and has better coverage with few effective shifts.
+# 6d. Equivalent shift-level regression (BHJ): reproduces the unit-level coefficient
+# exactly and delivers the honest exposure-robust first-stage F. R port of ssaggregate:
+# remotes::install_github("kylebutts/ssaggregate")  (dev version; hand-code if in doubt)
+# library(ssaggregate)
+# ind <- ssaggregate(data = df_long, shares = shares_long, vars = ~ y + d,
+#                    n = "sector", s = "share", l = "unit", controls = ~ x1)
+# ind <- merge(ind, shocks, by = "sector")
+# sl  <- feols(y ~ 1 | d ~ g, data = ind, weights = ~s_n, vcov = ~shock_cluster)
+# fitstat(sl, ~ ivf1)                      # the exposure-robust F to report
+# 6e. Balance: g_k on shock-level confounder proxies (shift-level regression), and
+# predetermined unit covariates on z_ss with the akm SEs above.
+
+## ---- 7. Shift-share, share path (GPSS 2020) ----------------------------------
+# Rotemberg weights: which shares carry the design. Hand-coded from the GPSS
+# just-identified decomposition (reference implementation: github.com/paulgp/bartik-weight,
+# Stata and R); this block is OUR implementation, label it as such:
+x_perp <- resid(feols(d ~ x1 + x2, data = df))       # endogenous var, residualized
+z_perp <- resid(feols(z_var ~ x1 + x2, data = df))   # z_var = as.vector(S %*% gk)
+alpha_k <- sapply(seq_len(ncol(S)), function(k) {
+  gk[k] * sum(resid(feols(S[, k] ~ x1 + x2, data = df)) * x_perp)
+}) / sum(z_perp * x_perp)
+sort(alpha_k, decreasing = TRUE)[1:5]     # weights sum to 1, some may be negative
+# Per-share audit for the top-weight shares: one-share-at-a-time IV estimates, and
+# balance of each high-weight share against PRE-period outcome changes (did-style
+# pre-trend scrutiny; Card's Philippines share is the canonical caught example).
+# Many shares: TSLS is biased toward OLS; use JIVE (ManyIV), LIML/Fuller (ivmodel),
+# or HFUL, and read dispersion across pooling schemes under the heterogeneity rule.
+
+## ---- 8. Formula instruments: recenter or control (Borusyak-Hull 2023) --------
+# Trigger: treatment/instrument = known formula f(shocks g; exposure w). Shock
+# exogeneity is NOT enough; compute the expected instrument and recenter.
+S_draws <- 1999
+perm_z <- replicate(S_draws, {
+  g_cf <- ave(gk, strata, FUN = sample)   # permute shocks WITHIN exchangeability strata
+  compute_instrument(g_cf, w)             # your formula f(g; w), recomputed per draw
+})                                        # N x S_draws matrix
+mu   <- rowMeans(perm_z)                  # expected instrument: the sole confounder
+df$z_re <- df$z_formula - mu
+rec <- feols(y ~ x1 | d ~ z_re, data = df, vcov = ~cl)   # or control for mu instead:
+# feols(y ~ x1 + mu | d ~ z_formula, ...); in natural experiments prefer controlling
+# for SEVERAL candidate mu's from different guessed assignment processes (double robust).
+# 8a. RI balance test: regress z_re on predetermined covariates; joint p from the
+# sum-of-squared-fitted-values statistic across draws:
+Tstat <- function(zv) { f <- fitted(feols(zv ~ x1 + x2, data = df)); sum(f^2) }
+T_obs  <- Tstat(df$z_re)
+T_null <- apply(perm_z - mu, 2, Tstat)
+mean(T_null >= T_obs)                     # RI joint balance p-value
+# 8b. RI confidence interval by Hodges-Lehmann inversion (NEVER the distribution of
+# the estimator across re-randomized shocks: that instrument has a true first stage
+# of zero). T(b) = mean(z_re * (y - b * d)):
+ri_p <- function(b) {
+  t_obs <- mean(df$z_re * (df$y - b * df$d))
+  t_cf  <- apply(perm_z - mu, 2, function(zv) mean(zv * (df$y - b * df$d)))
+  mean(abs(t_cf) >= abs(t_obs))
+}
+grid <- seq(-2, 2, by = 0.01)             # widen until both endpoints are excluded
+range(grid[sapply(grid, ri_p) > 0.05])    # the RI 95% interval
+# 8c. Placebo outcomes (lagged y as outcome) with the same RI machinery test shock
+# exogeneity itself; the balance test only validates the counterfactual specification.
+
+## ---- 9. OPTIONAL: beyond-LATE extrapolation bounds (MST 2018, ivmte) ---------
+# When the policy question is a rollout or an incentive change, the target is a PRTE, not the
+# LATE: bound a generalized LATE extrapolated alpha beyond the complier interval, anchored by
+# the IV-like estimands under stated MTR restrictions (Mogstad-Santos-Torgovitsky 2018,
+# implemented by ivmte; see references/details.md for the package row).
+# SOLVER TRAP: ivmte needs one of gurobi / cplexAPI / Rmosek / lpSolveAPI. The only fully
+# free solver (lpSolveAPI) is roughly an order of magnitude slower and cannot run the
+# regression-based direct criterion (a QCQP; Gurobi or MOSEK only), so this section always
+# passes explicit ivlike moments, the route every solver can handle.
+have_solver <- any(requireNamespace("gurobi",     quietly = TRUE),
+                   requireNamespace("cplexAPI",   quietly = TRUE),
+                   requireNamespace("Rmosek",     quietly = TRUE),
+                   requireNamespace("lpSolveAPI", quietly = TRUE))
+if (requireNamespace("ivmte", quietly = TRUE) && have_solver) {
+  library(ivmte)
+  p0 <- pi_a                      # p(0) = pr(d = 1 | z = 0), from the compliance table
+  p1 <- 1 - pi_n                  # p(1) = pr(d = 1 | z = 1)
+  alpha <- 0.10                   # stated extrapolation: participation up 10 points beyond
+                                  # p(1); set it from the planned rollout or a choice model
+  # Estimands: the saturated regression of y on d and z attains sharp bounds with discrete
+  # d and z (MST Proposition 3); the plain z and d regressions add the IV and OLS slopes.
+  # MTR space: spline knots sit at the propensity support points (degree 0 with these knots
+  # is MST Proposition 4's exact nonparametric route); degree 2 is arbitrary smoothing, so
+  # rerun at higher degrees as the sensitivity analysis for functional form. m0/m1 bounds
+  # are set to the observed outcome range (also the default), which is the bounded-outcome
+  # assumption; mte.dec = TRUE is monotone treatment selection (earlier takers gain more),
+  # a behavioral claim to defend in the text. Shape constraints are enforced on the audit
+  # grid (initgrid.nx/.nu, audit.nx/.nu); defaults are fine at this scale.
+  # Do NOT set point = TRUE to force a number: it switches to GMM point estimation and
+  # silently ignores every shape constraint.
+  mst_bounds <- function(a) {
+    ivmte(data = df,
+          target = "genlate",
+          genlate.lb = p0, genlate.ub = min(p1 + a, 1),
+          m0 = ~ uSpline(degree = 2, knots = c(p0, p1)),
+          m1 = ~ uSpline(degree = 2, knots = c(p0, p1)),
+          m0.lb = min(df$y), m0.ub = max(df$y),
+          m1.lb = min(df$y), m1.ub = max(df$y),
+          ivlike = c(y ~ z, y ~ d, y ~ d * z),
+          propensity = d ~ z,
+          mte.dec = TRUE)
+  }
+  mst_bounds(alpha)               # the headline bounds at the stated alpha
+  # Sensitivity: bounds as a function of alpha (MST Figure 8 is the template). They collapse
+  # to the LATE as alpha -> 0 and widen as the policy reaches beyond the compliers; report
+  # the widening as the stated price of the question. Grid spans plausible rollout sizes.
+  for (a in c(0.05, 0.10, 0.15, 0.20)) {
+    cat("alpha =", a, "\n")
+    print(mst_bounds(a))
+  }
+}
+
+## ---- Session ----------------------------------------------------------------
+# Pin: fixest >= 0.14 (IV formula order), ivreg >= 0.6 (three-part formula),
+# ivmodel 1.9.1 (KClass capitalization), ivDiag >= 1.0.6 (F_stat vector incl.
+# F.effective), ShiftShareSE 1.1.0 (X-vs-W roles), bpbounds >= 0.1.8; optional
+# ivmte 1.4.0 plus an LP solver (section 9).
+sessionInfo()

--- a/skills/preregister/SKILL.md
+++ b/skills/preregister/SKILL.md
@@ -60,6 +60,8 @@ If the description has no directional hypothesis, ask once. Do not invent a dire
 | Observational confirmatory analysis | `osf`, preanalysis-plan variant |
 | Ambiguous | `aspredicted` |
 
+The 1 to 3 DVs cut is a rule of thumb for form length, not a registry rule.
+
 AEA RCT registration is required for field experiments at AEA journals (lab experiments are
 exempt) and accepted by Marketing Science and Management Science; either OSF or AEA works for
 the marketing journals. Clinical trials (ClinicalTrials.gov, ISRCTN) belong in their own
@@ -119,8 +121,9 @@ Do not merge sections across styles. The registries ask for different things.
 
 ### Sample size, power, and stopping rule
 
-A preregistration without a number here is not binding, so this field is MUST in every style.
-Record all of:
+This field is MUST in every style. That elevation is our own requirement, deliberately
+stricter than the registries' forms, kept because a preregistration without a number here
+does not bind anything. Record all of:
 
 - the effect size assumed, and where it comes from: a pilot, a prior study with a citation, or
   the smallest effect size of interest. Do not power off a published point estimate without
@@ -146,8 +149,10 @@ in the underpowering.
 
 ### What would falsify this
 
-MUST in every style, written as its own field even though only OSF has an obvious slot for it.
-For each hypothesis, state the pattern of data that would count against it: the sign, the
+MUST in every style, written as its own field even though only OSF has an obvious slot for
+it. This elevation too is our own requirement, deliberately stricter than the registries'
+forms, kept because a preregistration that nothing could falsify does not constrain
+anything. For each hypothesis, state the pattern of data that would count against it: the sign, the
 confidence interval excluding the region of interest, the manipulation check failing, the
 predicted moderation not appearing. For any hypothesis predicting no effect, give equivalence
 bounds and a TOST test (Lakens 2017), because a non-significant test is not evidence of absence.
@@ -174,8 +179,12 @@ document still gets written but is reported as INCOMPLETE with the count of unre
 - Internal consistency. If randomized, the unit of randomization matches the unit of analysis or
   the analysis plan handles the clustering. If observational, the identification strategy is
   named.
-- Manipulation checks. At least one is named for any experiment, and the plan says whether
-  failing participants are excluded (decided now, not later).
+- Manipulation checks. At least one is named for any lab or survey experiment, where a
+  manipulated construct needs verification, and the plan says whether failing participants
+  are excluded (decided now, not later). Natural field experiments and A/B tests of
+  deployed treatments are exempt: the treatment is the deployed change itself, so there is
+  no manipulated construct to check by design. A field study that does run one still
+  decides the exclusion rule now.
 - Exploratory analyses are in their own section and labeled as exploratory.
 
 ## Phase 5. Verify the citations

--- a/skills/rdd/SKILL.md
+++ b/skills/rdd/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: rdd
+description: Design, estimate, validate, and write up a regression discontinuity analysis, in both the continuity and local-randomization frameworks, with the full falsification battery and a refusal rule for designs that fail validation. Produces advice with citations, R estimation and diagnostics code, and a drafted methods paragraph. TRIGGER on "regression discontinuity", "RDD", "RD design", "running variable", "cutoff", "threshold", "rdrobust", "bandwidth", "McCrary test", "density test", "fuzzy RD", "regression kink", or any setting where treatment switches at a known score threshold (loyalty tiers, spend thresholds, ranking cutoffs, algorithmic triggers, eligibility scores, age or tenure rules). Design triage across methods belongs to causal-design.
+---
+
+# Regression discontinuity
+
+An opinionated RD workflow grounded in a read canon (references/canon.md, current as of
+2026-07-28): the Cattaneo-Titiunik Annual Review of Economics survey and its applied companion,
+the Cattaneo-Keele-Titiunik guide, which includes a real failed design this skill uses as its
+refusal template. The deliverable is the specification decision with the citation that justifies
+it, the estimation and diagnostics code in R (Stata and Python exist for the whole suite), and a
+methods paragraph with the limitation stated in first person at the point of the choice.
+
+Refresh path: run the litreview skill on the method since the canon date and fold results into
+references/canon.md as flagged addenda.
+
+## The design gate: is this an RD at all?
+
+An RD requires a score, a known cutoff, and a treatment rule that existed ex ante and is
+verifiable. Before any estimation, write the qualitative account: who computes the score, was
+the cutoff public, can agents precisely control their score near it. Precise manipulation is the
+most important threat. Lab-measured or third-party-computed scores resist it; self-influenced
+scores (customer spend near a tier threshold, follower counts near a monetization bar) invite
+exactly the sorting the density test detects, so the falsification battery carries more weight
+in marketing settings than in the medical originals.
+
+Two red flags, the first disqualifying on its own (from the failed Oncotype-DX application in
+Cattaneo-Keele-Titiunik 2023):
+
+1. Treatment take-up jumps at score values away from the official cutoff (the rule was soft:
+   reps contact leads below the threshold, managers grant status matches early). Plot take-up
+   against the score before anything else.
+2. Covariate imbalance already in the smallest window around the cutoff: disqualifying when
+   the imbalanced covariate plausibly drives the outcome (the balance battery's standard,
+   below), otherwise a serious flag that demands an explanation before proceeding.
+
+When a design fails, say so and decline to report an effect; the guide's own verdict on its
+failed application ("the evidence does not support an RD analysis") is the template. Route the
+question back to causal-design for another identification strategy.
+
+## Triage: two frameworks, and which one leads
+
+Sharp vs fuzzy is a fact of the institution, not a choice: sharp when the rule binds
+mechanically (a trial expires, a discount ends at an anniversary), fuzzy whenever anyone can
+cross their assignment (overrides, opt-ins). Under fuzziness always report both ITT effects (on
+take-up and on the outcome) alongside the fuzzy ratio.
+
+Continuity vs local randomization is decided by the score:
+
+- Continuous score, many observations near the cutoff: continuity framework with local
+  polynomials leads; local randomization is the robustness complement.
+- Discrete score (rule of thumb: roughly 30 or fewer distinct values) or very few observations
+  near the cutoff: local randomization leads. Continuity methods there extrapolate from the
+  nearest mass points and their effective sample size is the number of mass points, not the
+  number of observations. Discrete running variables (weeks of tenure, order counts, months
+  since signup) are the norm in marketing data, which makes this branch more common than the
+  econ literature suggests.
+- Local randomization needs a strictly stronger assumption (potential outcomes unrelated to the
+  score inside the window), which must be argued, not assumed.
+
+When both frameworks apply, run both; agreement is a robustness result, and the local
+randomization CIs covering the continuity point estimate counts as consistency. Expect the
+window to be far narrower than the bandwidth (in the guide's HIV application, 121 patients vs
+2,593), so a local-randomization null alongside a significant continuity estimate can be a power
+difference, not a contradiction.
+
+## The consensus recipe (continuity framework)
+
+Local linear regression, triangular kernel, MSE-optimal bandwidth, robust bias-corrected
+confidence intervals (Calonico-Cattaneo-Titiunik). Report both the conventional and the robust
+interval. The one-line justification: conventional 95 percent intervals at the MSE-optimal
+bandwidth cover only about 80 percent, and bias correction with the matching variance adjustment
+restores coverage at the same bandwidth.
+
+Hard rules from the review, stated as prohibitions because that is how it states them:
+
+- Bandwidths must be data-driven and criterion-optimal; choosing one by hand "is discouraged."
+  MSE-optimal for the point estimate, CE-optimal when the interval is the object. Distinct
+  left/right bandwidths are available when curvature differs by side.
+- Global polynomial fits are visualization only, never estimation (Gelman-Imbens): boundary
+  behavior, counterintuitive weighting, overfitting.
+- Polynomial order: p = 1 default, p = 2 as the robustness check, never high order.
+- Covariates are for precision only; they cannot restore identification of the canonical RD
+  parameter, and adjusting an invalid design changes the parameter rather than rescuing it. The
+  point estimate should barely move when covariates enter; a large move signals imbalance.
+
+## The local-randomization recipe
+
+Select the window by nested covariate-balance tests: start from the smallest window with at
+least about 10 observations per side, enlarge until balance rejects, using a deliberately loose
+threshold (p < 0.15, no multiplicity correction, since over-rejection just shrinks the window).
+Then difference in means inside the window, with Fisherian randomization inference when the
+window holds few observations (exact under the sharp null; point estimates and CIs then require
+a constant-effect model), Neyman or super-population inference when it is well populated.
+
+## Fuzzy designs: the IV discipline applies
+
+The fuzzy estimand is a complier average effect at the cutoff under relevance, exclusion, and
+monotonicity, so the iv skill's habits transfer:
+
+- Test the first stage inside the bandwidth or window, never on the full sample; the full-sample
+  F overstates strength. The guide's contrast is the anchor: F around 698 in the valid design,
+  F = 1.51 (Fisherian p = 0.32) in the failed one. An in-bandwidth first-stage F that is neither
+  the strong nor the hopeless extreme goes to the iv skill's ladder: read it against the F
+  targets there and report Anderson-Rubin/CLR intervals rather than the 2SLS t.
+- Argue exclusion qualitatively and concretely: it fails if crossing the cutoff changes behavior
+  through anything other than treatment (a low churn score triggering a retention call AND a
+  flag another team acts on).
+- Monotonicity: safe when crossing the threshold moves treatment in one direction only; suspect
+  when overrides run in both directions (the failed-design pattern above, reps contacting
+  below-threshold leads while managers grant early crossings, is exactly the defiers case);
+  one-sided noncompliance buys it for free.
+- Run fuzzy-ratio balance tests: instrument strength amplifies covariate bias, so imbalance
+  invisible to ITT balance can surface in the ratio.
+- Use one MSE-optimal bandwidth for the ratio, not separate ones for numerator and denominator.
+
+## Falsification battery
+
+In the order the guide applies them, with each check's bandwidth convention:
+
+1. Qualitative manipulation account (who computes the score, who knows the cutoff).
+2. Density continuity test (rddensity, robust bias-corrected) plus the exact binomial count
+   test in small windows (framework-free, works for discrete scores; keep the window narrow
+   enough that a constant assignment probability is sensible). A discontinuous density is
+   neither necessary nor sufficient for invalidity, but it demands an explanation; sorting can
+   be administrative rather than strategic.
+3. Covariate and placebo-outcome balance: the full RD machinery with each predetermined
+   covariate as the outcome, a fresh MSE-optimal bandwidth per covariate, robust p-values. A
+   failure on a covariate that plausibly drives the outcome invalidates the design. The
+   equivalence-test formulation (null of imbalance) is the more honest variant when you want to
+   claim balance affirmatively.
+4. Placebo cutoffs: re-run at artificial cutoffs, one side of the true cutoff at a time so
+   treatment effects do not contaminate the placebo.
+5. Donut hole: drop the observations at and immediately adjacent to the cutoff, keep the
+   original bandwidth, re-estimate. Binds hardest where agents can time their crossing (spend
+   thresholds). Large swings mean the effect rides on the most manipulable observations.
+6. Bandwidth and window sensitivity: instability at or below the chosen bandwidth is the
+   warning sign; failure far above it is expected by construction and not damning.
+
+Ex-post power calculations from observed effects are unreliable; when a null matters, report
+minimum detectable effects instead (rdpower).
+
+## The live dispute, carried honestly
+
+Robust bias correction (this canon's school) vs honest uniform-in-bias inference
+(Armstrong-Kolesar, Imbens-Wager; R package RDHonest). The honest school bounds the second
+derivative by a constant M and gets uniformly valid intervals; the canon's objection is that a
+data-driven M destroys the uniformity that motivates the method, and a manual M is equivalent to
+choosing the bandwidth by hand. Default here: RBC. When a referee or coauthor asks for honest
+intervals, report RDHonest alongside with the M choice justified in text, and cite both sides.
+
+## Extensions, briefly
+
+- Kink designs: same machinery on first derivatives; identification is more delicate.
+- Multiple cutoffs or scores (tiered loyalty programs; geographic borders such as DMA
+  boundaries): cutoff-specific effects or normalize-and-pool (rdmulti), with the pooled
+  estimand's interpretation checked.
+- RD in time: hard to justify as standard RD; the local-randomization framework is the
+  adaptation when it works at all. Prefer did or synthetic-control for policy-date designs.
+- Extrapolation beyond the cutoff LATE needs added assumptions: multi-cutoff variation,
+  pre-period outcomes, ignorability-based, or derivative-based local extrapolation. Say which
+  when claiming anything away from the cutoff.
+
+## R implementation
+
+The complete runnable pipeline is scripts/rdd_template.R (estimation in both frameworks, fuzzy
+diagnostics, the full falsification battery, power/MDE), with every call verified against the
+rdpackages suite. The core:
+
+```r
+library(rdrobust); library(rddensity); library(rdlocrand)
+rdplot(y, x, c = cutoff)                      # anatomy first
+summary(rdrobust(y, x, c = cutoff))           # sharp: local linear, triangular, MSE-h, RBC
+summary(rdrobust(d, x, c = cutoff))           # first stage / ITT on take-up
+summary(rdrobust(y, x, c = cutoff, fuzzy = d))# fuzzy ratio
+summary(rddensity(x, c = cutoff))             # manipulation
+w <- rdwinselect(x, Z, c = cutoff)            # local-randomization window
+rdrandinf(y, x, cutoff = cutoff, wl = w$w_left, wr = w$w_right)
+```
+
+Package index with versions and links in references/details.md. Stata and Python mirrors of the
+whole suite live at rdpackages.github.io; the guide ships full replication code in all three.
+
+## Methods paragraph template
+
+> Treatment assignment changes discontinuously at [cutoff] in [score], a rule set by
+> [institution] before the outcomes we study, and units [cannot / can only imprecisely] control
+> their score near it. We estimate the RD effect with local linear regression, a triangular
+> kernel, and an MSE-optimal bandwidth, and report robust bias-corrected confidence intervals
+> (Calonico, Cattaneo, and Titiunik 2014; Cattaneo and Titiunik 2022). We validate the design
+> with the Cattaneo-Jansson-Ma density test and an exact binomial test, covariate balance at the
+> cutoff with per-covariate bandwidths, placebo cutoffs, donut-hole estimates, and bandwidth
+> sensitivity [and, for the fuzzy design, verify first-stage strength within the estimation
+> bandwidth and report intention-to-treat effects alongside the complier estimate]. The estimate
+> is local to the cutoff; a limitation of this design is that it does not identify effects for
+> [units far from the threshold], and I extrapolate only [not at all / under the stated
+> assumption], which costs [generalizability across the score distribution].
+
+Every claim traces to references/canon.md; keys live in causal-design/references/causal.bib.
+
+## Handoffs
+
+- causal-design: whether an RD exists at all; where to go when the design gate fails.
+- iv: the fuzzy branch's in-bandwidth first stage and exclusion argument live here;
+  weak-instrument inference (the F ladder, AR/CLR intervals) lives in iv, along with
+  many-instrument and shift-share logic.
+- did / synthetic-control: policy-date designs masquerading as RD in time.
+- preregister: pre-specifying an RD on an upcoming threshold change.

--- a/skills/rdd/references/canon.md
+++ b/skills/rdd/references/canon.md
@@ -1,0 +1,68 @@
+# RDD canon
+
+Current as of 2026-07-28. These sources are hand-picked; nothing enters this file without
+explicit human approval. BibTeX keys point into ../../causal-design/references/causal.bib.
+Refresh: litreview on the method since the date above, results proposed as flagged addenda.
+
+## Cattaneo and Titiunik (2022)
+
+Annual Review of Economics 14: 821-851. Key: `cattaneo2022rdd`.
+
+- Role: the survey of record; the two-framework spine and the consensus defaults.
+- Settles: an RD needs a score, a known cutoff, and an ex-ante verifiable rule; precise
+  manipulation is the central threat; conventional CIs at the MSE-optimal bandwidth cover about
+  80 percent, robust bias correction restores coverage at the same bandwidth; ad hoc bandwidths
+  are discouraged outright; global polynomials are visualization only (Gelman-Imbens); fuzzy RD
+  is local IV with a complier estimand; covariates are precision-only; discrete scores route to
+  local randomization, with mass points as the effective sample size; density test (CJM) plus
+  exact binomial count as complements; extrapolation needs added assumptions; ex-post power is
+  unreliable, report MDEs.
+- Binds when: any RD analysis; framework choice; every prohibition above.
+- Implement: the rdpackages suite (rdrobust, rddensity, rdlocrand, rdpower, rdmulti);
+  RDHonest is the rival school's package.
+- Quote: bandwidths chosen "in an arbitrary manner" are discouraged; global polynomials "not
+  recommended for analysis beyond visualization"; the 95-to-80 percent coverage fact.
+
+## Cattaneo, Keele, and Titiunik (2023)
+
+Statistics in Medicine 42(24): 4484-4513. Key: `cattaneo2023guide`.
+
+- Role: the applied workflow companion, adapted here from medicine to marketing; the failure
+  anatomy.
+- Settles: the ordered empirical workflow (qualitative account, plots, both frameworks,
+  falsification, fuzzy diagnostics) with exact code in R/Stata/Python; the roughly-30-distinct-
+  values discreteness rule; window-selection mechanics (10 per side minimum, loose p < 0.15
+  threshold, no multiplicity correction); first stage tested inside the bandwidth, never
+  full-sample (F 698 valid vs F 1.51 failed); fuzzy-ratio balance; per-check bandwidth
+  conventions (fresh per covariate for balance, original for donut, one-sided placebo cutoffs);
+  the two disqualifying red flags (off-cutoff take-up jumps, smallest-window imbalance; the
+  skill conditions the second on outcome relevance, per SKILL.md) and the refusal to estimate
+  when a design fails.
+- Binds when: executing any RD; every fuzzy design; deciding whether to walk away.
+- Implement: the verbatim R workflow block (reproduced in scripts/rdd_template.R); replication
+  at rdpackages.github.io.
+- Quote: "a weak IV test that uses all observations is likely to overstate the strength of the
+  instrument"; the failed application "does not pass basic RD validation/diagnostic tests, and
+  the evidence does not support an RD analysis."
+
+## Named dispute the skill carries
+
+Robust bias-corrected inference (this canon) vs honest uniform-in-bias inference
+(Armstrong-Kolesar; Imbens-Wager; package RDHonest). The canon's critique: a data-driven
+smoothness constant destroys the uniformity, and a manual one is hand-picking the bandwidth by
+another name. Default RBC; offer RDHonest alongside on request with the M choice defended in
+text. Presented as live, not settled.
+
+## Primary papers cited through the canon
+
+Resolver-verified entries in causal.bib (see the RDD block there for keys and PREPRINT flags):
+Calonico-Cattaneo-Titiunik 2014 (robust bias correction); Hahn-Todd-van der Klaauw 2001
+(continuity identification); Cattaneo-Frandsen-Titiunik 2015 (local randomization);
+Cattaneo-Jansson-Ma 2020 (density test); McCrary 2008 (manipulation test); Lee 2008 (close
+elections); Gelman-Imbens 2019 (against global polynomials); Calonico-Cattaneo-Farrell 2020
+(CE-optimal bandwidths); Calonico-Cattaneo-Farrell-Titiunik 2019 (covariates);
+Cattaneo-Titiunik-Vazquez-Bare 2017 (inference comparison, binomial test) and 2019 (power);
+Card-Lee-Pei-Weber 2015 (kink); Imbens-Wager 2019 and Armstrong-Kolesar (honest school);
+Kolesar-Rothe 2018 (discrete scores); Pei-Lee-Card-Weber (polynomial order);
+Cattaneo-Idrobo-Titiunik Foundations and Extensions volumes; Ludwig-Miller 2007 (placebo-outcome
+exemplar); Calonico-Cattaneo-Titiunik 2015 (RD plots); Hartman (equivalence testing).

--- a/skills/rdd/references/details.md
+++ b/skills/rdd/references/details.md
@@ -1,0 +1,99 @@
+# RDD lookup details
+
+Heavy reference content the SKILL.md points into. Current as of 2026-07-28.
+
+## Package index (verified 2026-07-28; suite home rdpackages.github.io)
+
+| Package | CRAN version | Role | Traps |
+|---|---|---|---|
+| rdrobust | 4.0.0 (2026-05) | rdrobust, rdbwselect, rdplot | `all=` removed from rdrobust(), now summary(fit, all=TRUE); cluster= needs vce="cr1/2/3" (use cr2, our default across these skills, following the small-G cluster-robust literature); masspoints="adjust" default |
+| rddensity | 3.0 (2026-05) | density + built-in binomial table, rdplotdensity | argument is camelCase `massPoints`; binomial via bino/binoW/binoNW |
+| rdlocrand | 2.0 (2026-05) | rdwinselect, rdrandinf, rdsensitivity, rdrbounds | rdwinselect needs covariates; level=0.15 default is the loose balance threshold by design |
+| rdpower | 3.0 (2026-05) | rdpower, rdsampsi, rdmde | `rdpow` is the Stata name only; data = cbind(Y, X) |
+| rdmulti | 2.0.0 (2026-05) | rdmc, rdms, rdmcplot | C is an observation-level cutoff vector |
+| RDHonest | GitHub (kolesarm/RDHonest) | honest-school intervals | manual smoothness constant M; the canon's critique applies |
+
+Replication repos: github.com/rdpackages-replication/{CKT_2023_SIM, CIT_2024_CUP, CIT_2020_CUP}.
+rdrr.io serves stale 2023 builds of these packages; never verify signatures there. The fuzzy
+output reports no F statistic; first-stage strength comes from its own sharp RD at fixed
+bandwidths (z squared ~ F for one instrument), or a manual kernel-weighted regression, which is
+our addition and should be labeled as such.
+
+## Falsification checklist with per-check conventions
+
+| Check | Convention | Failure means |
+|---|---|---|
+| Qualitative manipulation account | written before estimation | design suspect regardless of tests |
+| Density test (rddensity, RBC) | own bandwidth; show the plot | sorting (strategic or administrative); explain or walk away |
+| Binomial count test | small windows; constant assignment probability must be sensible, so keep the window narrow (a trending density fails it mechanically) | same as density; works for discrete scores |
+| Covariate / placebo-outcome balance | fresh MSE-optimal bandwidth PER covariate; RBC p-values; equivalence-test variant to claim balance affirmatively | invalid if the covariate plausibly drives the outcome |
+| Placebo cutoffs | one side of the true cutoff at a time | unexplained jump undermines continuity |
+| Donut hole | drop cutoff-adjacent observations, KEEP the original bandwidth | effect rides on the most manipulable observations |
+| Bandwidth sensitivity | instability at or below chosen h is the warning; failure far above is expected | curvature or manipulation, not a license to cherry-pick |
+| Take-up plot (fuzzy) | before estimation | off-cutoff jumps = soft rule = likely fatal |
+
+## Window selection mechanics (local randomization)
+
+Nested Fisherian balance tests on predetermined covariates: start from the smallest window with
+about 10 observations per side, enlarge stepwise, stop before balance rejects. Threshold
+deliberately loose (p < 0.15 or 0.10) with no multiplicity correction, because over-rejection
+only shrinks the window (conservative in the right direction). Use the omnibus or minimum
+p-value across covariates. Expect the window to be much narrower than the continuity bandwidth;
+a local-randomization null next to a significant continuity estimate can be power, not
+contradiction (ART: 121 vs 2,593 observations).
+
+## Fuzzy diagnostics
+
+- First stage inside the bandwidth/window only. Anchors: F about 698 (valid ART design) vs
+  F = 1.51, Fisherian p = 0.32 (failed chemotherapy design).
+- Fuzzy-ratio balance tests: instrument strength amplifies covariate bias.
+- One MSE-optimal bandwidth for the ratio, not separate numerator/denominator bandwidths.
+- Exclusion argued concretely: crossing the cutoff must move the outcome only through
+  treatment. Marketing example that fails it: a churn-score threshold that triggers both the
+  retention offer under study and a separate priority-support flag.
+
+## Discrete scores
+
+Roughly 30 or fewer distinct values: treat as discrete. Local randomization applies as-is; RD
+plots need no binning (plot mass-point means); continuity methods extrapolate from the nearest
+mass points and their effective N is the number of mass points (Kolesar-Rothe for honest
+inference in that case). Marketing norm, not exception: weeks of tenure, order counts, months
+since signup, integer spend tiers.
+
+## Estimation defaults and their citations
+
+- Local linear (p=1), triangular kernel, MSE-optimal bandwidth, RBC intervals: the consensus
+  recipe. p=2 and uniform kernel as robustness. Data-driven polynomial-order choice exists
+  (Pei-Lee-Card-Weber).
+- CE-optimal bandwidth when the interval is the object; separate left/right bandwidths when
+  curvature differs (Arai-Ichimura); clustered variants exist.
+- The 95-to-80 percent coverage fact is the one-line justification for RBC.
+- Simple RBC implementation detail: inference at polynomial order p+1 with the MSE-optimal
+  bandwidth for order p.
+
+## Extrapolation menu (claims away from the cutoff need one of these)
+
+Multi-cutoff variation; pre-period outcomes; conditional ignorability on covariates
+(Angrist-Rokkanen); derivative-based local extrapolation (Dong-Lewbel). Absent one, the
+methods paragraph says the estimate is local to the cutoff, full stop.
+
+## Power and MDE
+
+Ex-post power from observed effects is unreliable. For nulls that matter, report minimum
+detectable effects (rdpower: rdpow, rdsampsi). For ex-ante design (choosing which threshold
+experiment to run), rdsampsi gives the required N near the cutoff.
+
+## Marketing translations (from the medical guide, adapted)
+
+- Fuzzy algorithmic triggers: churn-score retention offers, lead-score outreach, credit
+  approvals, fraud review. Human overrides make these fuzzy; the ITT-vs-complier distinction
+  and in-bandwidth F carry over directly.
+- Sharp tenure/calendar rules: trial expiry, promotional-rate rolloffs at month 12, student
+  discounts, anniversary-based status expiry. Discrete running variables, so the
+  local-randomization branch leads.
+- Threshold designs with self-influenced scores: spend-based loyalty tiers, follower-count
+  monetization bars. Manipulation is live (customers time purchases); density, binomial, and
+  donut tests carry more weight here than in medicine.
+- Multi-cutoff: tiered programs (silver/gold/platinum). Geographic RD: DMA advertising borders.
+- Bunching at price breaks is adjacent but distinct; bunching identification needs parametric
+  assumptions and is out of scope here.

--- a/skills/rdd/scripts/rdd_template.R
+++ b/skills/rdd/scripts/rdd_template.R
@@ -1,0 +1,120 @@
+# RDD analysis template. Runnable end to end; every call signature verified against the
+# rdpackages suite on 2026-07-28 (rdrobust 4.0.0, rddensity 3.0, rdlocrand 2.0, rdpower 3.0,
+# rdmulti 2.0.0, all CRAN). Suite home: rdpackages.github.io. Adapt the CONFIG block and run
+# section by section. Do NOT trust rdrr.io for these packages (stale 2023 builds).
+#
+# rdrobust 4.0.0 API changes older tutorials get wrong:
+#   - `all=` was REMOVED from rdrobust(); it now lives in summary(fit, all = TRUE)
+#   - `data=` is new (bare column names allowed); covs= accepts a one-sided formula
+#   - cluster= requires vce = "cr1"/"cr2"/"cr3" (other vce values auto-map with a warning)
+
+## ---- CONFIG ----------------------------------------------------------------
+df <- your_data              # replace
+y  <- df$y                   # outcome
+x  <- df$score               # running variable
+d  <- df$takeup              # observed treatment (fuzzy designs only)
+Z  <- as.matrix(df[, c("cov1", "cov2")])   # predetermined covariates
+CUT <- 350                   # the cutoff
+
+library(rdrobust); library(rddensity); library(rdlocrand); library(rdpower)
+
+## ---- 1. Anatomy first ------------------------------------------------------
+# Global p=4 fit is for VISUALIZATION ONLY, never estimation.
+rdplot(y, x, c = CUT)
+# Fuzzy pre-check: take-up against the score. Jumps AWAY from the official cutoff
+# are the first disqualifying red flag (soft rule).
+rdplot(d, x, c = CUT)
+# Discrete scores (roughly <= 30 distinct values): no binning, plot mass-point means,
+# and lead with the local-randomization branch (section 5).
+length(unique(x))
+
+## ---- 2. Sharp estimation (continuity framework) ----------------------------
+# Consensus recipe: local linear (p=1 default), triangular kernel (default),
+# MSE-optimal bandwidth (bwselect="mserd" default), robust bias-corrected CIs.
+fit <- rdrobust(y, x, c = CUT)
+summary(fit, all = TRUE)          # Conventional + Bias-Corrected + Robust rows
+
+# With covariates (precision only; the point estimate should barely move):
+fit_cov <- rdrobust(y, x, c = CUT, covs = Z)
+# With clustering (note the vce requirement in 4.0.0):
+# fit_cl <- rdrobust(y, x, c = CUT, cluster = df$cluster, vce = "cr2")
+# Robustness variants: p = 2, uniform kernel, CE-optimal bandwidth:
+fit_p2 <- rdrobust(y, x, c = CUT, p = 2)
+fit_ce <- rdrobust(y, x, c = CUT, bwselect = "cerrd")
+
+## ---- 3. Fuzzy estimation and diagnostics -----------------------------------
+fzy <- rdrobust(y, x, c = CUT, fuzzy = d)
+summary(fzy, all = TRUE)          # prints a first-stage block before the ratio
+# First stage as its own sharp RD at the SAME bandwidths (CKT 2023 pattern):
+h <- fzy$bws[1]; b <- fzy$bws[2]
+fs <- rdrobust(d, x, c = CUT, h = h, b = b)
+summary(fs)
+# Weak-instrument check INSIDE the bandwidth, never full-sample. The package
+# reports no F; the native strength measure is the first-stage z (fs output),
+# z^2 ~ F for one instrument. The manual kernel-weighted F below is OUR addition,
+# not from the guides:
+inb <- abs(x - CUT) <= h
+wgt <- pmax(0, 1 - abs(x - CUT) / h)               # triangular weights
+fs_lm <- lm(d ~ I(x >= CUT) * I(x - CUT), weights = wgt, subset = inb)
+# ITT effects on take-up and outcome are reported ALONGSIDE the fuzzy ratio, always.
+
+## ---- 4. Manipulation testing -----------------------------------------------
+# Density test (jackknife vce per the applied guide) + built-in binomial table
+# (bino = TRUE default in rddensity 3.0; binoP = 0.5 null, 10 nested windows).
+mtest <- rddensity(X = x, c = CUT, vce = "jackknife")
+summary(mtest)
+rdplotdensity(mtest, X = x)
+# Manual binomial route on the chosen local-randomization window (guide's pattern):
+# binom.test(sum(x >= CUT & inwin), sum(inwin), 1/2)
+# Keep windows narrow: a trending density fails the constant-probability null
+# mechanically, which is not evidence of sorting.
+
+## ---- 5. Local randomization branch -----------------------------------------
+# Window by nested covariate balance: loose threshold level = 0.15 (default),
+# minimum ~10 obs per side, no multiplicity correction (over-rejection only
+# shrinks the window). R = running variable, X = covariate matrix.
+w <- rdwinselect(R = x, X = Z, cutoff = CUT, reps = 1000, seed = 50)
+# Fisherian inference in the selected window (exact under the sharp null):
+ri <- rdrandinf(Y = y, R = x, cutoff = CUT, wl = w$w_left, wr = w$w_right,
+                reps = 1000, seed = 50)
+# Fuzzy local randomization:
+# rdrandinf(Y = y, R = x, cutoff = CUT, wl = w$w_left, wr = w$w_right,
+#           fuzzy = c(d, "tsls"))
+# Window sensitivity: rdsensitivity(Y = y, R = x, cutoff = CUT, wlist = ..., tlist = ...)
+
+## ---- 6. Falsification battery ----------------------------------------------
+# 6a. Covariate / placebo-outcome balance: full RD machinery per covariate,
+#     FRESH MSE-optimal bandwidth each time (do not reuse the outcome bandwidth).
+for (j in seq_len(ncol(Z))) {
+  cat("--", colnames(Z)[j], "--\n")
+  print(summary(rdrobust(Z[, j], x, c = CUT)))
+}
+# 6b. Placebo cutoffs: one side of the true cutoff at a time, so real treatment
+#     effects cannot contaminate the placebo. The +/-50 offset is scaled to the
+#     CUT = 350 example; adapt it to your score's scale.
+summary(rdrobust(y[x >= CUT], x[x >= CUT], c = CUT + 50))
+summary(rdrobust(y[x < CUT],  x[x < CUT],  c = CUT - 50))
+# 6c. Donut hole: drop cutoff-adjacent observations, KEEP the original bandwidths.
+donut <- abs(x - CUT) > 1     # tune the radius to the score's granularity
+summary(rdrobust(y[donut], x[donut], c = CUT, h = fit$bws[1], b = fit$bws[2]))
+# 6d. Bandwidth sensitivity: instability at or below the MSE-optimal h is the
+#     warning sign; degradation far above it is expected by construction.
+for (hh in c(0.75, 1, 1.25, 1.5) * fit$bws[1]) {
+  print(summary(rdrobust(y, x, c = CUT, h = hh)))
+}
+
+## ---- 7. Power and MDE (report with any null result) ------------------------
+# R functions are rdpower()/rdsampsi()/rdmde(); rdpow is the Stata name.
+# data = two columns, outcome then running variable.
+pow <- rdpower(data = cbind(y, x), cutoff = CUT, tau = 5)   # tau in outcome units
+# Ex-ante design: rdsampsi(data = cbind(y, x), cutoff = CUT, tau = 5)
+
+## ---- 8. Multiple cutoffs (tiered programs) ----------------------------------
+# library(rdmulti)
+# cvec <- df$tier_cutoff                       # observation-level cutoff values
+# rdmc(Y = y, X = x, C = cvec)                 # per-cutoff + pooled estimands
+
+## ---- Session ----------------------------------------------------------------
+# Pin: rdrobust >= 4.0.0 (the `all`/summary and cluster/vce changes above),
+# rddensity >= 3.0 (built-in binomial table), rdlocrand 2.0, rdpower 3.0.
+sessionInfo()

--- a/skills/synthetic-control/SKILL.md
+++ b/skills/synthetic-control/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: synthetic-control
+description: Design, estimate, validate, and write up a synthetic control analysis, including synthetic difference-in-differences, augmented/penalized variants, and factor-model/matrix-completion relatives for panel counterfactuals. Produces advice with citations, R estimation and diagnostics code, and a drafted methods paragraph. TRIGGER on "synthetic control", "synthetic DiD", "SDID", "donor pool", "comparative case study", "weighted counterfactual", "geo holdout", "CausalImpact", "matrix completion", "interactive fixed effects", "gsynth", "generalized synthetic control", or any setting where one or a few aggregate units (a state, market, DMA, category, platform region) got treated and untreated units must form the counterfactual. Staggered-adoption panels with many treated units belong to did; design triage across methods belongs to causal-design. Prospective geo experiments (choosing treatment markets by design) belong to field-experiment.
+---
+
+# Synthetic control
+
+An opinionated synthetic-control workflow grounded in a read canon (references/canon.md,
+current as of 2026-07-28): Abadie's JEL survey, the practice manual by the method's originator,
+with the synthetic-DiD bridge and the DiD-vs-SC boundary supplied by the Arkhangelsky-Imbens
+panel survey (shared with the did skill). The deliverable is the feasibility verdict with the
+citation that justifies it, the estimation and diagnostics code in R, and a methods paragraph
+with the limitation stated in first person at the point of the choice.
+
+Refresh path: run the litreview skill on the method since the canon date and fold results into
+references/canon.md as flagged addenda.
+
+## The feasibility gate: is SC usable here at all?
+
+The method's originator is explicit that mechanical applications are risky and that there are
+situations where the honest answer is to walk away. Check before estimating:
+
+- One or a few treated AGGREGATE units (state, market, country, category), a donor pool of
+  genuinely comparable untreated units, and outcomes that co-move across units.
+- A long pre-period. But a long T0 cannot repair a bad fit: the bias bound is derived under
+  (near-)perfect predictor fit, and when pre-period fit is poor the recommendation is to not
+  use synthetic control, full stop.
+- The converse trap: good pre-period fit with a short T0 or a noisy outcome can be spurious
+  overfitting on transitory shocks, and a larger donor pool makes overfitting easier, so a
+  bigger J is not automatically better.
+- The expected effect must be large relative to unit-specific outcome volatility. Compare
+  the effect you expect against the treated unit's pre-period residual volatility (for
+  instance the pre-period RMSPE, or the outcome's detrended SD) and report that comparison.
+  Sales and attention data are volatile, and when the effect is not clearly larger,
+  pre-filter unit-specific noise (denoising a la robust SC) or concede the effect is
+  undetectable. The judgment and its basis go in the writeup.
+- No anticipation, or shift T0 earlier than any plausible anticipation (harmless if too
+  early, because the effect path is unrestricted). Forward-buying before an announced price
+  change is the marketing version of the problem.
+- No interference: donors exposed to the treatment (neighboring markets, national campaign
+  spillover) are handled in design (drop them, check the fit cost) or kept with the bias
+  signed and the estimate reported as a bound.
+- The treated unit should be plausibly inside the donors' convex hull; weights are
+  nonnegative and sum to one, so SC never extrapolates. Extreme treated units in levels
+  need an outcome transformation (differences, growth rates, pre-mean deviations) or SDID,
+  and differencing inflates the noise share of variance, which raises overfitting risk.
+
+When the gate fails, say so and decline to estimate; route back to causal-design. When the
+gate fails on pre-period length or convex-hull grounds, check the extensions map (forward
+DiD, augmented DiD, HCW) before declining and routing back.
+
+## Donor pool discipline
+
+Exclude donors treated with similar interventions in the window, donors hit by large
+idiosyncratic shocks that would not have hit the treated unit, and donors dissimilar on
+observed or suspected unobserved attributes. The canon's line: including units the analyst
+regards as unsuitable controls "is a recipe for bias." The worked precedents: dropping US
+states with their own tobacco programs (Prop 99), restricting the reunification donor pool to
+OECD economies.
+
+## Estimator anatomy and researcher degrees of freedom
+
+The counterfactual is a convex combination of donors chosen so the synthetic unit matches the
+treated unit's pre-intervention predictors, with predictor-importance weights V. The
+constraints buy transparency and sparsity: at most k donors get positive weight, and you can
+name them. Panel regression on the same data is implicitly a synthetic control whose weights
+sum to one but can be negative, so it extrapolates silently (four donor countries get negative
+regression weights in the reunification example).
+
+The degrees of freedom, each with a discipline:
+
+- Predictors: pre-intervention outcomes PLUS substantive covariates. Pre-outcomes alone push
+  excluded covariates into the unobserved loadings and raise the bias bound.
+- V: inverse-variance as the simple default; better, minimize pre-period MSPE or pick V by a
+  training/validation split of the pre-period. Cross-validated V is not always unique, so show
+  the estimate is stable across reasonable V choices.
+- Weights are computed from pre-intervention data only, so the design can be locked, even
+  preregistered, before post-treatment outcomes are seen; the canon compares this to a
+  pre-analysis plan. Use that: fix the specification before looking at effects.
+
+## The boundary: DiD, SC, or synthetic DiD
+
+One continuous decision path, not competing methods:
+
+- DiD is the special case of the SC factor model with constant factor loadings. If the treated
+  unit's pre-trend parallels a plausible comparison average, use did.
+- When the pre-period plot shows the donor average diverging from the treated unit before
+  treatment, parallel trends has already failed and SC is the tool. The sharpest known
+  routing result: under selection on lagged outcomes with autocorrelated errors, DiD is
+  inconsistent even as the pre-period grows while SC is consistent (Arkhangelsky-Hirshberg,
+  via the panel survey). If units select into treatment on recent outcomes, that is the SC
+  regime.
+- Synthetic DiD is SC with unit weights plus analogous time weights and a DiD-style
+  adjustment: it does not require the pre-fit to be perfect, it differences the remaining gap
+  out. The price is a stable-bias assumption on that gap. In simulations calibrated to real
+  panels, SDID typically outperforms DiD, SC, and matrix completion. Practical default: run
+  canonical SC when the gate passes cleanly; when level fit is the sticking point, move to
+  SDID and say why.
+- Staggered adoption with many treated units forecloses the standard SC estimator; that is
+  did territory (or multisynth / the factor-model estimators, below).
+
+## Inference
+
+The primary mode is design-based permutation, honest about its limits:
+
+- In-space placebos: reassign treatment to each donor, refit, pool the gaps. The test
+  statistic is the post/pre RMSPE ratio, which corrects for placebos that fit badly
+  pre-period; p is the treated unit's rank among J+1 ratios. Report the spaghetti plot of
+  placebo gaps, never only p; the plot carries the magnitude.
+- The smallest attainable p is 1/(J+1). A tiny donor pool cannot deliver conventional
+  significance, and pretending otherwise is the error. One-sided versions of the statistic
+  add real power in small pools.
+- Uniform permutation is a benchmark, not a model of assignment; sensitivity to non-uniform
+  assignment and test-inversion confidence sets exist (Firpo-Possebom).
+- Model-based complements when intervals are wanted: conformal inference (Chernozhukov et
+  al.) and prediction intervals (scpi). For SDID, placebo, jackknife, and bootstrap variance
+  estimators ship with the estimator. The data-shape conditions for choosing among them are
+  in references/details.md.
+
+## Diagnostics battery
+
+1. Pre-period fit, the entry gate: table the treated unit's predictor values against the
+   synthetic unit's and plot both trajectories over the whole pre-period. Visible gaps in
+   either mean do not proceed (tighten the pool, change predictors or transformation,
+   bias-correct, move to SDID, or abandon).
+2. Backdating (in-time placebo, the Heckman-Hotz preprogram test): move the intervention date
+   back, re-estimate on pre-data only. Pass has two parts: no effect opens during the fake
+   post-period, and the gap still opens at the true date with the same sign and shape. A
+   pre-gap estimates the bias's direction and size. Caveat carried from the panel survey:
+   backdating assumes strict exogeneity and backfires under selection on recent shocks (the
+   AMA Marketing News routing source (Li, Luo, and Pattabhiramaiah 2024; 'AMA' hereafter)
+   states this exercise as one of two mandatory best practices; the strict-exogeneity caveat
+   here governs when it is informative).
+3. In-space placebos with the RMSPE ratio (above).
+4. Leave-one-out on positive-weight donors: refit dropping each in turn; the conclusion must
+   not hinge on one donor. When it does, check whether that donor had its own intervention or
+   shock.
+5. Robustness across predictor sets, V choices, and tightened donor pools; drift as the pool
+   tightens signals interpolation bias from dissimilar donors.
+6. Outcome-transformation check when levels are hard to match (levels vs differences vs
+   growth rates vs pre-mean deviations), remembering the noise-amplification tradeoff and
+   that matching changes alone is not credible when the level itself drives dynamics.
+7. Spillover accounting: with and without exposed donors; when kept, sign the bias and
+   interpret the estimate as a bound.
+
+## Extensions, and when to reach for them
+
+- Imperfect fit on a unit that must stay in: bias-corrected/augmented SC (ridge outcome
+  model on the residuals; augsynth), or penalized SC.
+- Many treated or disaggregated units: one SC per treated unit, aggregated; the penalized
+  estimator (pensynth) restores uniqueness and sparsity for inside-the-hull units and spans
+  pure SC to one-to-one matching; multisynth handles staggered timing.
+- Both N and T modestly large: interactive fixed effects and matrix completion (gsynth,
+  fect, MC-NNM) relax the convex-combination restriction entirely; the panel survey's
+  unified view is that DiD, SC, unconfoundedness, and matrix completion are one imputation
+  objective under different restrictions, so divergence across them is diagnostic.
+- Volatile single-market outcomes with a Bayesian time-series counterfactual: CausalImpact,
+  the tool marketing analytics teams usually already run for geo tests; the canon situates
+  it among SC relatives, so treat its output with this skill's diagnostics, and note its
+  counterfactual leans on one unit's own time series plus covariates.
+- SC-type weights with many controls and few pre-periods need regularization; unregularized
+  in-sample fit can be perfect and meaningless.
+- Treated outcome outside the donor convex hull: augmented DiD (Li and Van den Bulte 2023),
+  a different method from Ben-Michael's ridge-augmented SC in augsynth despite the
+  near-identical name. Too few pre-periods: forward DiD (Li 2024); controls far fewer than
+  pre-periods: HCW OLS (Hsiao, Ching, and Wan 2012). Fuller map in references/details.md.
+
+## R implementation
+
+The complete runnable pipeline is scripts/synth_template.R (canonical SC with the full
+diagnostics battery, SDID, augmented and penalized variants, factor-model robustness,
+conformal and prediction intervals), with every call verified against package documentation.
+The core:
+
+```r
+library(tidysynth)                       # canonical ADH workflow with built-in placebos
+out <- df |>
+  synthetic_control(outcome = y, unit = unit, time = year,
+                    i_unit = "TREATED", i_time = T0, generate_placebos = TRUE) |>
+  generate_predictor(time_window = pre_window, ...) |>
+  generate_weights(optimization_window = pre_window) |>
+  generate_control()
+plot_trends(out); plot_placebos(out); grab_significance(out)   # RMSPE-ratio table
+
+library(synthdid)                        # the SDID branch
+setup <- panel.matrices(panel, unit = "unit", time = "year",
+                        outcome = "y", treatment = "treated")
+tau <- synthdid_estimate(setup$Y, setup$N0, setup$T0)
+sqrt(vcov(tau, method = "placebo"))
+```
+
+Package index with versions, links, and traps in references/details.md.
+
+## Methods paragraph template
+
+> [Treatment] hit [treated unit] at [date]; no comparable unit did, so we construct a
+> synthetic control from [J] donors, excluding [units] for [own interventions / shocks /
+> spillovers] (Abadie 2021). Predictors are [pre-period outcomes and covariates]; predictor
+> weights are chosen by [cross-validation on the pre-period], and the resulting synthetic
+> unit puts weight on [named donors]. Pre-period fit is [shown in table/figure]. We report
+> permutation inference with the post/pre RMSPE ratio over in-space placebos (Abadie,
+> Diamond, and Hainmueller 2010); with [J] donors the smallest attainable p is 1/(J+1),
+> [which is a limitation of the design, not the method: statistical significance in the
+> conventional sense is out of reach and we lean on magnitude and the placebo distribution].
+> We validate with backdating, leave-one-out donor exclusion, and robustness across predictor
+> sets and donor pools. [If fit is imperfect: because the synthetic unit cannot match
+> pre-period levels exactly, we use synthetic difference-in-differences (Arkhangelsky et al.
+> 2021), which differences out the remaining gap; I note this trades the perfect-fit
+> requirement for the assumption that the gap would have been stable, which I cannot test
+> directly.] The estimand is the effect on [treated unit] alone, and I generalize to
+> [other units] only [not at all / under the stated assumption].
+
+Every claim traces to references/canon.md; keys live in causal-design/references/causal.bib.
+
+## Handoffs
+
+- did: parallel pre-trends hold, or staggered adoption with many treated units; synthetic
+  DiD lives HERE, did points back for it.
+- causal-design: whether any panel counterfactual is credible; the taxonomy that routes
+  between did, SC, and factor models.
+- rdd: policy-date designs masquerading as RD in time arrive here when one or a few aggregate
+  units switch at a date; treat the date as the event, not a cutoff.
+- field-experiment: prospective geo experiments (choosing treatment markets by design rather
+  than analyzing one after the fact).
+- preregister: locking weights and specification before post-period outcomes exist.

--- a/skills/synthetic-control/references/canon.md
+++ b/skills/synthetic-control/references/canon.md
@@ -1,0 +1,75 @@
+# Synthetic-control canon
+
+Current as of 2026-07-28. These sources are hand-picked; nothing enters this file without
+explicit human approval. BibTeX keys point into ../../causal-design/references/causal.bib.
+Refresh: litreview on the method since the date above, results proposed as flagged addenda.
+
+## Abadie (2021)
+
+Journal of Economic Literature 59(2): 391-425. Key: `abadie2021using`.
+
+- Role: the practice manual by the method's originator; feasibility conditions, diagnostics,
+  and the when-to-walk-away rules.
+- Settles: the counterfactual is a convex donor combination (no extrapolation, sparse,
+  nameable weights) while panel regression is implicitly SC with silently negative weights;
+  DiD is the constant-loadings special case of the SC factor model; the bias bound holds
+  under near-perfect predictor fit, so poor pre-fit means do not use SC and a long T0 does
+  not rescue it; short-T0 or noisy-outcome fit can be overfitting, and a larger donor pool
+  makes that easier; donor discipline (exclude own-intervention, shocked, and dissimilar
+  units); predictors are pre-outcomes plus covariates, never pre-outcomes alone; V by
+  cross-validation with non-uniqueness disclosed; weights are computable pre-post and can be
+  locked like a pre-analysis plan; inference is design-based permutation on the post/pre
+  RMSPE ratio with p floor 1/(J+1) and the spaghetti plot mandatory; backdating and
+  leave-one-out are the standing placebos; spillover-exposed donors are dropped or the bias
+  is signed and the estimate read as a bound; extensions map (penalized, bias-corrected,
+  SDID, matrix completion, conformal/prediction intervals).
+- Binds when: any SC analysis; the feasibility verdict; every diagnostics choice.
+- Implement: names methods, not software; the package mapping (Synth/tidysynth/SCtools,
+  augsynth, pensynth, synthdid, scpi, gsynth/fect, CausalImpact, scinference) is ours, in
+  references/details.md.
+- Quote: including units the analyst regards as unsuitable controls "is a recipe for bias";
+  SC weights "can play a role similar to pre-analysis plans in randomized control trials";
+  the recommendation against SC when the predictor-fit discrepancy is large.
+
+## Arkhangelsky and Imbens (2024), boundary sections
+
+Shared canon with did (key: `arkhangelsky2024causal`; full entry in the did skill's canon).
+What this skill takes from it:
+
+- The unified view: unconfoundedness regression, SC, DiD, and nuclear-norm matrix completion
+  solve one imputation objective under different restrictions, so divergence across them is a
+  diagnostic, not a nuisance.
+- SDID = TWFE plus SC unit weights plus analogous time weights; in simulations calibrated to
+  real panels it typically outperforms DiD, SC, and MC-NNM.
+- The routing result: under selection on lagged outcomes with autocorrelated errors, DiD is
+  inconsistent even with a long pre-period while SC is consistent (Arkhangelsky-Hirshberg).
+  This is the citable rule for choosing SC over DiD when units select on recent outcomes.
+- The backdating caveat: placebo-in-time assumes strict exogeneity and backfires under
+  selection on past shocks.
+- Frame guidance: single treated unit in a square/fat panel is SC territory; block assignment
+  with both dimensions modestly large favors SDID/MC/IFE over TWFE; staggered adoption
+  forecloses standard SC.
+
+## Named positions the skill carries
+
+1. Ferman-Pinto (imperfect pretreatment fit; demeaned SC) are the loyal opposition inside the
+   canon: SC's properties degrade under imperfect fit, and demeaning moves the estimator
+   toward DiD logic. The skill's response is the Abadie line (walk away or bias-correct) plus
+   the SDID bridge, with the Ferman-Pinto caveat cited when fit is marginal.
+2. A&I vs AAFP on whether to move past TWFE at all is carried in the did skill; here it only
+   surfaces as the reason SDID and factor methods get a seat at the table.
+
+## Primary papers cited through the canon
+
+Resolver-verified entries in causal.bib (see the synthetic-control block there for keys and
+PREPRINT flags): Abadie-Gardeazabal 2003 (origin); Abadie-Diamond-Hainmueller 2010 (the
+estimator, bias bound, permutation inference) and 2015 (cross-validated V, in-time placebo,
+reunification); Abadie-L'Hour 2021 (penalized SC); Ben-Michael-Feller-Rothstein 2021
+(augmented SC); Arkhangelsky et al. 2021 (synthetic DiD); Athey et al. 2021 (matrix
+completion); Xu 2017 (generalized SC / IFE); Doudchenko-Imbens 2016 (the synthesis, elastic
+net); Ferman-Pinto 2021 (imperfect fit); Chernozhukov-Wuthrich-Zhu 2021 (conformal);
+Cattaneo-Feng-Titiunik 2021 (prediction intervals); Brodersen et al. 2015 (BSTS /
+CausalImpact); Firpo-Possebom 2018 (sensitivity, confidence sets); Heckman-Hotz 1989
+(preprogram test); Amjad-Shah-Shen 2018 (robust SC denoising); Athey-Imbens 2017 (the
+"most important innovation" framing); Klossner et al. 2018 (V non-uniqueness); Liu-Wang-Xu
+2024 (counterfactual estimators guide, fect).

--- a/skills/synthetic-control/references/details.md
+++ b/skills/synthetic-control/references/details.md
@@ -1,0 +1,147 @@
+# Synthetic-control lookup details
+
+Heavy reference content the SKILL.md points into. Current as of 2026-07-28.
+
+## The factor model and the bias bound
+
+Outcomes follow a linear factor model Y_jt = delta_t + theta_t Z_j + lambda_t mu_j + eps_jt.
+DiD is the special case lambda_t = lambda (constant loadings); SC lets unobserved-factor
+coefficients vary over time, which is why it survives visibly non-parallel pre-trends. Under
+the factor model and perfect predictor fit (X1 = X0 W*), the bias of the SC effect estimate is
+controlled by the ratio of the transitory-shock scale to T0, and it INCREASES with donor-pool
+size J and with the number of unobserved factors. Consequences the skill states as rules: poor
+fit is disqualifying (the bound assumes fit away), long T0 does not rescue bad fit, and short
+T0 or noisy outcomes plus a big pool invite overfitting on transitory shocks. Excluded
+covariates get absorbed into mu_j and raise the bound, which is why pre-outcomes-only predictor
+sets are banned.
+
+## The unified imputation view (routing logic)
+
+SC is a "vertical regression" (treated unit's pre-period outcomes on control units' outcomes,
+weights nonnegative summing to one); unconfoundedness-on-lagged-outcomes is the "horizontal
+regression"; without constraints the two imputations coincide. DiD, SC, unconfoundedness, and
+nuclear-norm matrix completion all minimize one fit-a-low-rank-plus-fixed-effects objective
+under different restrictions (DiD: rank 0; SC: convex unit weights; MC-NNM: cross-validated
+nuclear-norm penalty). Divergence among them is a specification diagnostic. The sharpest
+routing result: under selection on lagged outcomes with autocorrelated errors, DiD is
+inconsistent even as T0 grows while SC is consistent and asymptotically unbiased.
+
+## V and predictor mechanics
+
+- V default ladder: inverse-variance rescaling (simple), pre-period MSPE minimization
+  (better), training/validation split of the pre-period with out-of-sample fit (best).
+- Cross-validated V is not always unique (Klossner et al.); show stability across reasonable
+  V choices.
+- Fewer predictor rows give sparser weights. A single pre-period outcome average sufficed for
+  reunification only because OECD GDP co-moves strongly; that is the exception.
+- Sparsity fact: when X1 lies outside the convex hull of X0 with columns in general position,
+  at most k donors get positive weight; the weights are nameable and should be named.
+- Outcome transformations when levels cannot be matched: differences, growth rates,
+  deviations from pre-intervention means (Ferman-Pinto). Each moves SC toward DiD logic and
+  inflates the noise share of variance; matching changes alone is not credible when the level
+  itself drives dynamics (growth convergence, life-cycle earnings, baseline-dependent sales).
+
+## Inference details
+
+- RMSPE ratio: r_j = post-period RMSPE / pre-period RMSPE per unit j; p = (1/(J+1)) sum
+  I{r_j >= r_1}. Alternative: drop placebos with pre-RMSPE far above the treated unit's and
+  compare post-RMSPEs directly. One-sided statistics (positive or negative parts of the gaps)
+  add power in small pools.
+- The p floor is 1/(J+1). With 12 donors the best attainable p is 0.077; say so instead of
+  hunting significance.
+- Design-based framing: the permutation distribution conditions on the sample and benchmarks
+  extremeness against uniform assignment; it is exact randomization inference only if
+  treatment were actually randomized. Firpo-Possebom: sensitivity analysis to non-uniform
+  assignment and test-inversion confidence sets.
+- Model-based complements: conformal inference (Chernozhukov-Wuthrich-Zhu; exchangeability of
+  residuals under the null, a different maintained assumption than the factor model, per the
+  Ferman-Pinto caveat that E[u_t Y_jt] = 0 generally fails), and scpi prediction intervals
+  that decompose uncertainty into weight estimation and post-period shocks.
+- SDID variance: placebo, jackknife, or bootstrap estimators; placebo is the few-treated
+  default. The block bootstrap and jackknife estimators need many treated units. The placebo
+  estimator (what the AMA Marketing News routing source (Li, Luo, and Pattabhiramaiah 2024;
+  'AMA' hereafter) calls "permutation") works with one or few treated units but needs a
+  moderate-to-large donor pool and roughly similar outcome variances across treated and
+  control groups. Divergence across the applicable procedures signals the data shape does
+  not support the chosen one.
+- Backdating doubles as a bias estimate: if biases are stable in time, subtract the
+  pre-period "effect" (the DiD-flavored corrections of Arkhangelsky et al. and
+  Chernozhukov-Wuthrich-Zhu).
+
+## Multiple treated units and imperfect fit
+
+- Many treated units: one SC per treated unit, aggregate with population or size weights.
+  Inside-the-hull treated units make weights non-unique; the penalized estimator (Abadie-
+  L'Hour) adds lambda times the weighted sum of pairwise predictor discrepancies, is unique
+  and sparse for lambda > 0, and spans pure SC (lambda to 0) to one-to-one matching (lambda
+  to infinity), lambda by cross-validation.
+- Poorly fitted units that must stay in an aggregate: bias-correct with a regression
+  adjustment on the discrepancies (equivalently SC on regression residuals; Abadie-L'Hour,
+  Ben-Michael-Feller-Rothstein). augsynth's ridge augmentation is the standard
+  implementation; report both raw and augmented.
+- Staggered timing across treated units: multisynth (staggered augsynth) or hand the design
+  to did.
+- Volatile outcomes: filter unit-specific noise before fitting (singular value thresholding,
+  robust SC); common-factor volatility is what the SC itself absorbs.
+
+## Extensions map (method to source to package)
+
+| Situation | Method | Source | Package |
+|---|---|---|---|
+| Canonical, one treated aggregate unit | ADH SC | abadie2010synthetic | Synth / tidysynth (+ SCtools placebos) |
+| Imperfect pre-fit | augmented (ridge) SC | benmichael2021augmented | augsynth |
+| Disaggregated / many treated | penalized SC | abadie2021penalized | pensynth |
+| Level gaps, stable-bias plausible | synthetic DiD | arkhangelsky2021synthetic | synthdid |
+| N and T both modest-plus | IFE / generalized SC | xu2017generalized | gsynth, fect |
+| Same, nuclear-norm route | matrix completion | athey2021matrix | fect (mc), MCPanel |
+| Prediction intervals | scpi | cattaneo2021prediction | scpi |
+| Conformal / t-test inference | conformal SC | chernozhukov2021exact | scinference |
+| Single-market BSTS counterfactual | CausalImpact (the AMA figure's 'Bayesian SC') | brodersen2015inferring | CausalImpact |
+| Elastic-net weights | Doudchenko-Imbens | doudchenko2016balancing | augsynth ridge or glmnet by hand |
+| Noisy outcomes | robust SC (denoise first) | amjad2018robust | (SVD thresholding by hand) |
+| Treated outcome outside the donor convex hull | augmented DiD (Li and Van den Bulte), scales the control average | li2023augmented | author replication code, no CRAN package |
+| Outcome in donor range but too few pre-periods for SC | forward DiD (Li), forward-selects a control subset then applies DiD | li2024forward | author replication code, no CRAN package |
+| Control units far fewer than pre-treatment periods | HCW OLS (Hsiao, Ching, and Wan), regression on a small control set | hsiao2012panel | plain OLS, no package needed |
+
+The AMA routing source's 'augmented DiD' (Li and Van den Bulte 2023, convex-hull repair) is a
+different estimator from the augmented (ridge) SC row above (Ben-Michael et al.); do not conflate
+the two.
+
+## Marketing translations
+
+- Geo rollouts: a pricing, assortment, or feature change in one DMA/country with untouched
+  markets as donors; the CausalImpact use case, upgraded with this skill's donor discipline
+  and permutation inference.
+- Regulation: state-level advertising or privacy rules hitting one state (the Prop 99
+  template, literally a marketing-regulation outcome).
+- Platform shocks: a policy change hitting one category, region, or creator tier; channel- or
+  streamer-level panels where channels co-move (Twitch-YouTube style data).
+- Anticipation: forward-buying before announced price changes; shift T0 to the
+  announcement, not the enactment.
+- Interference: national campaigns contaminate donor markets; drop exposed donors or sign
+  the bias and report a bound.
+- Volatility screen: sales and attention series are noisy, so the effect-vs-volatility gate
+  and pre-filtering matter more here than in the macro applications.
+- Aggregation note: SC needs aggregate units that co-move; customer-level rollouts belong to
+  field-experiment or did, not here.
+
+## Package index (verified against package docs 2026-07-28)
+
+| Package | Version | Role | Traps |
+|---|---|---|---|
+| tidysynth | 0.2.1 (CRAN) | modern ADH pipeline: synthetic_control, generate_predictor/weights/control, grab_significance (RMSPE-ratio table), plot_placebos | ipop tuning args are snake_case (margin_ipop/sigf_ipop/bound_ipop); the package's OWN examples use dot-case names that fall into ... and are silently ignored; needs >= 20 donors for p < .05 |
+| Synth | 1.1-10 (CRAN, 2026-04, still maintained) | original dataprep/synth/synth.tab/path.plot/gaps.plot | unit and time variables must be numeric; time.plot defaults to the pre-period, extend it explicitly; dot-case Margin.ipop here (opposite of tidysynth); no placebo machinery of its own |
+| SCtools | 0.3.3.1 (CRAN) | in-space placebos for Synth objects: generate.placebos, mspe.test, plot_placebos | strategy = "multiprocess" deprecated (use "multisession"); prunes at 20x MSPE by default vs tidysynth's 2x |
+| synthdid | 0.0.9 (GitHub synth-inference, not on CRAN) | SDID: panel.matrices, synthdid_estimate, sc_estimate/did_estimate trio, vcov(placebo/jackknife/bootstrap) | single treated unit: placebo is the ONLY valid vcov method; panel.matrices matches columns by position unless named; balanced panel, block adoption only |
+| augsynth | 0.2.0 (GitHub ebenmichael, not on CRAN) | augmented SC (progfunc = "ridge"), conformal summary; multisynth for staggered many-treated | current signature has t_int AFTER data (the repo README shows the old order); fixedeff default differs (FALSE single, TRUE multisynth) |
+| pensynth | 0.8.2 (CRAN) | penalized SC with cross-validated lambda (cv_pensynth) | Synth orientation, units in COLUMNS; Z1/Z0 hold-out outcome matrices are required for CV |
+| scpi | 4.0.1 (CRAN) | scdata/scest/scpi prediction intervals, scplot; multi-treated variants scdataMulti/scplotMulti | w.constr is a list (list(name = "simplex")), not a string; default solver is CLARABEL (ECOS tutorials stale); scpi() is simulation-heavy |
+| gsynth | 1.4.0 (CRAN) | generalized SC / IFE (Xu 2017) | estimator default is now "gsynth"; "ife" means IFE-with-EM; force default "unit" (fect's is "two-way"); GitHub README stale at 1.3.1; parametric bootstrap CIs biased in both directions (Li and Sonnier 2023, li2023statistical); prefer subsampling or the corrected inference |
+| fect | 2.4.5 (CRAN; dev at xuyiqing/fect) | counterfactual estimators suite (fe/ife/mc/gsynth/cfe), placebo and carryover tests, effective successor to gsynth | no "bspline" in 2.x; flags camelCase (placeboTest) but periods dot-case (placebo.period); CV default NULL (auto); parametric bootstrap CIs biased in both directions (Li and Sonnier 2023, li2023statistical); prefer subsampling or the corrected inference |
+| CausalImpact | 1.4.1 (CRAN) | BSTS single-series counterfactual for geo tests | response must be the first column; covariates must be unaffected by the intervention; no donor weights, so donor discipline does not transfer |
+| scinference | 0.0.0.9000 (GitHub kwuthrich, commit 567c688, 2021) | conformal and cross-fit t-test inference (Chernozhukov-Wuthrich-Zhu) | underscore argument names; default alpha 0.10; CIs need an explicit ci_grid; research code, pin the commit |
+| MCPanel | GitHub susanathey/MCPanel | original matrix-completion code | fect method = "mc" is the maintained route |
+
+Stata and Python mirrors exist (Stata sdid and synth/synth_runner; Python pysyncon, and scpi
+ships its own Python interface) but were NOT API-verified in this pass; check signatures
+against their docs before citing them in a methods section.

--- a/skills/synthetic-control/scripts/synth_template.R
+++ b/skills/synthetic-control/scripts/synth_template.R
@@ -1,0 +1,180 @@
+# Synthetic-control analysis template. Runnable end to end; every call signature verified
+# against package documentation on 2026-07-28 (tidysynth 0.2.1, Synth 1.1-10, SCtools 0.3.3.1,
+# scpi 4.0.1, pensynth 0.8.2, gsynth 1.4.0, fect 2.4.5, CausalImpact 1.4.1, all CRAN;
+# synthdid 0.0.9, augsynth 0.2.0, scinference 0.0.0.9000 from GitHub, not on CRAN).
+# Adapt the CONFIG block and run section by section.
+#
+# API traps older tutorials get wrong:
+#   - tidysynth ipop tuning args are snake_case (margin_ipop/sigf_ipop/bound_ipop); the
+#     package's OWN examples use Margin.ipop etc., which fall into ... and are SILENTLY
+#     IGNORED (defaults run instead). Synth uses the dot-case names; opposite conventions.
+#   - augsynth's current signature is augsynth(form, unit, time, data, t_int = NULL); the
+#     repo README still shows the old positional order. Pass data= and t_int= by name.
+#   - synthdid: with a single treated unit, vcov method = "placebo" is the only valid one.
+#   - gsynth's estimator default is now "gsynth"; estimator = "ife" means IFE-with-EM.
+#   - fect flags are camelCase (placeboTest) but their periods dot-case (placebo.period).
+#   - scpi's w.constr is a list (list(name = "simplex")), solver default is CLARABEL.
+
+## ---- CONFIG ----------------------------------------------------------------
+df <- your_panel             # long panel: unit, year, y, covariates; balanced
+TREATED <- "California"      # treated unit
+T0      <- 1988              # last pre-treatment period (i_time = intervention year)
+PRE     <- 1970:1988         # pre-period window
+set.seed(94305)
+
+## ---- 1. Feasibility gate, before any estimation ------------------------------
+# Plot the treated unit against the raw donor mean over the full pre-period. If the
+# donor mean tracks the treated unit, did may suffice; if it diverges pre-treatment,
+# SC territory. Also check: co-movement, effect size vs outcome volatility, donor
+# count (p floor is 1/(J+1)), anticipation (shift T0 to announcement if needed).
+# Donor discipline: drop donors with their own interventions, big idiosyncratic
+# shocks, or spillover exposure BEFORE fitting, and record why.
+
+## ---- 2. Canonical SC (tidysynth) --------------------------------------------
+library(tidysynth)
+out <- df |>
+  synthetic_control(outcome = y, unit = unit, time = year,
+                    i_unit = TREATED, i_time = T0,
+                    generate_placebos = TRUE) |>
+  generate_predictor(time_window = PRE,
+                     income  = mean(income,  na.rm = TRUE),
+                     price   = mean(price,   na.rm = TRUE)) |>
+  generate_predictor(time_window = 1975, y_1975 = y) |>   # lagged-outcome predictors
+  # ipop values copied from the tidysynth worked example, not a recommendation;
+  # the optimizer defaults are usually fine.
+  generate_weights(optimization_window = PRE,
+                   margin_ipop = .02, sigf_ipop = 7, bound_ipop = 6) |>  # snake_case!
+  generate_control()
+# The entry gate: pre-period fit table and trajectory plot. Visible gaps = stop
+# (tighten pool, change predictors/transformation, bias-correct, or move to SDID).
+out |> grab_balance_table()
+out |> plot_trends(time_window = 1970:2000)
+out |> grab_unit_weights()          # name the donors; sparsity is a feature
+out |> grab_predictor_weights()     # V; show robustness to reasonable alternatives
+
+## ---- 3. Permutation inference (in-space placebos) ----------------------------
+out |> plot_placebos()              # prune = TRUE drops placebos with pre-RMSPE > 2x treated
+out |> plot_placebos(prune = FALSE) # report the unpruned spaghetti too
+out |> plot_mspe_ratio()
+out |> grab_significance()          # post/pre MSPE ratio, rank, fishers_exact_pvalue
+# The p floor is 1/(J+1): with fewer than 20 donors, p < .05 is unreachable; say so
+# and lean on magnitude plus the placebo distribution. One-sided variants (positive
+# or negative parts of the gaps) add power in small pools; compute from
+# grab_synthetic_control(placebo = TRUE) if needed.
+
+## ---- 4. In-time placebo (backdating) -----------------------------------------
+# Re-run with the intervention moved back and post-T0 data EXCLUDED. Pass = no gap
+# opens in the fake post-period AND the real gap still opens at T0. A pre-gap
+# estimates the bias's size and direction. Caveat: assumes strict exogeneity;
+# misleading under selection on recent shocks (Arkhangelsky-Hirshberg).
+back <- df |> dplyr::filter(year <= T0) |>
+  synthetic_control(outcome = y, unit = unit, time = year,
+                    i_unit = TREATED, i_time = 1980, generate_placebos = FALSE) |>
+  generate_predictor(time_window = 1970:1980,
+                     income = mean(income, na.rm = TRUE)) |>
+  generate_weights(optimization_window = 1970:1980) |>
+  generate_control()
+back |> plot_trends()
+
+## ---- 5. Leave-one-out on positive-weight donors ------------------------------
+w <- out |> grab_unit_weights()
+# > 0.01 rather than > 0: skip weights that are numerically zero from the optimizer.
+for (dnr in w$unit[w$weight > 0.01]) {
+  loo <- df |> dplyr::filter(unit != dnr) |>
+    synthetic_control(outcome = y, unit = unit, time = year,
+                      i_unit = TREATED, i_time = T0, generate_placebos = FALSE) |>
+    generate_predictor(time_window = PRE, income = mean(income, na.rm = TRUE)) |>
+    generate_weights(optimization_window = PRE) |>
+    generate_control()
+  # collect and overlay the counterfactuals; the conclusion must not hinge on one donor
+}
+# Same refit pattern for predictor-set, V, and tightened-donor-pool robustness.
+
+## ---- 6. Classic route (Synth + SCtools), if a coauthor wants it --------------
+# library(Synth); library(SCtools)
+# dp  <- dataprep(foo = as.data.frame(df), predictors = c("income", "price"),
+#                 special.predictors = list(list("y", 1975, "mean")),
+#                 dependent = "y", unit.variable = "unit_num",       # must be numeric
+#                 unit.names.variable = "unit", time.variable = "year",
+#                 treatment.identifier = 3, controls.identifier = c(1:2, 4:39),
+#                 time.predictors.prior = PRE, time.optimize.ssr = PRE,
+#                 time.plot = 1970:2000)                             # extend past T0!
+# fit <- synth(data.prep.obj = dp)          # dot-case Margin.ipop HERE (not tidysynth)
+# synth.tab(synth.res = fit, dataprep.res = dp)
+# tdf <- generate.placebos(dp, fit, strategy = "multisession")       # not "multiprocess"
+# plot_placebos(tdf); mspe.test(tdf)$p.val
+
+## ---- 7. Synthetic DiD (level gaps, stable-bias assumption) -------------------
+# devtools::install_github("synth-inference/synthdid")   # not on CRAN
+library(synthdid)
+panel <- as.data.frame(df[, c("unit", "year", "y", "treated")])
+setup <- panel.matrices(panel, unit = "unit", time = "year",
+                        outcome = "y", treatment = "treated")   # names, not positions
+tau_sdid <- synthdid_estimate(setup$Y, setup$N0, setup$T0)
+sqrt(vcov(tau_sdid, method = "placebo"))    # single treated unit: placebo is the ONLY option
+plot(tau_sdid); synthdid_units_plot(tau_sdid)
+# The SC-DID-SDID trio on one panel is itself a diagnostic (divergence = the
+# additive or convex restriction is doing work):
+tau_sc  <- sc_estimate(setup$Y, setup$N0, setup$T0)
+tau_did <- did_estimate(setup$Y, setup$N0, setup$T0)
+# Requires block adoption on a balanced panel; staggered adoption -> multisynth/fect.
+
+## ---- 8. Augmented SC (imperfect fit that must stay in) -----------------------
+# devtools::install_github("ebenmichael/augsynth")       # not on CRAN
+library(augsynth)
+asyn <- augsynth(y ~ treated, unit = unit, time = year, data = df,
+                 progfunc = "ridge", scm = TRUE)   # t_int inferred; pass by name if set
+summary(asyn)                                      # conformal inference by default
+plot(asyn)
+# Report raw SC and augmented side by side; a large augmentation term means the
+# convex weights alone could not match, which is information, not decoration.
+# Staggered many-treated: multisynth(y ~ treated, unit = unit, time = year,
+#                                    data = df, n_leads = 10); plot(msyn, levels = "Average")
+# Disaggregated units / penalized SC: pensynth::cv_pensynth(X1, X0, Z1, Z0)
+# (units in COLUMNS, Synth orientation; Z1/Z0 hold-out outcomes required).
+
+## ---- 9. Factor-model / matrix-completion robustness (fect) -------------------
+library(fect)
+# nboots = 200 in both calls is a quick-run value; raise to 2000 or more for publication.
+fout <- fect(y ~ treated + income, data = df, index = c("unit", "year"),
+             method = "ife", CV = TRUE, r = c(0, 5),
+             se = TRUE, vartype = "bootstrap", nboots = 200)
+plot(fout, type = "gap")
+fect(y ~ treated + income, data = df, index = c("unit", "year"),
+     method = "mc", CV = TRUE, se = TRUE, nboots = 200)   # nuclear-norm route
+# Built-in falsification: placeboTest = TRUE, placebo.period = c(-2, 0);
+# carryoverTest = TRUE, carryover.period = c(1, 2). (camelCase flag, dot-case period)
+# fect method = "gsynth" reproduces gsynth (Xu 2017) inside fect; standalone gsynth
+# 1.4.0 remains fine, but note its force default is "unit" vs fect's "two-way".
+
+## ---- 10. Prediction intervals (scpi) -----------------------------------------
+library(scpi)
+sd_ <- scdata(df = as.data.frame(df), id.var = "unit", time.var = "year",
+              outcome.var = "y", period.pre = PRE, period.post = 1989:2000,
+              unit.tr = TREATED, unit.co = setdiff(unique(df$unit), TREATED))
+est <- scest(sd_, w.constr = list(name = "simplex"))     # list, not a string
+# sims = 200 is a quick-run value; raise to 2000 or more for publication.
+pin <- scpi(sd_, w.constr = list(name = "simplex"), sims = 200,
+            e.method = "gaussian", u.missp = TRUE)
+scplot(pin)
+# Conformal alternative (Chernozhukov-Wuthrich-Zhu):
+# devtools::install_github("kwuthrich/scinference")  # research code, pin the commit
+# scinference(Y1, Y0, T1 = 12, T0 = length(PRE),
+#             inference_method = "conformal", estimation_method = "sc")  # underscores;
+# default alpha is 0.10, and CIs need an explicit ci_grid.
+
+## ---- 11. CausalImpact, as comparison point only ------------------------------
+# BSTS counterfactual from the treated unit's own series plus covariates; no donor
+# weights, so this skill's donor discipline does not apply, and covariates must be
+# unaffected by the intervention. Response must be the FIRST column.
+# library(CausalImpact); library(zoo)
+# ci <- CausalImpact(zoo(cbind(y_treated, x1, x2), years),
+#                    pre.period = c(1970, 1988), post.period = c(1989, 2000))
+# plot(ci); summary(ci, "report")
+
+## ---- Session ----------------------------------------------------------------
+# Pin: tidysynth 0.2.1 (snake_case ipop args), synthdid 0.0.9 @ 70c1ce3, augsynth
+# 0.2.0 @ 7a90ea4 (t_int after data), scinference @ 567c688, fect >= 2.4.5 (no
+# bspline; camelCase test flags), gsynth >= 1.4.0 (estimator default "gsynth"),
+# scpi >= 4.0.1 (CLARABEL, list-valued w.constr).
+sessionInfo()


### PR DESCRIPTION
Adds six skills and updates one.

**New**
- `causal-design` triages a causal question to the identification strategy the data can support, then hands off. Owns the selection-on-observables branch itself: overlap, doubly robust estimation, double machine learning, causal forests, sensitivity analysis.
- `did` heterogeneity-robust difference-in-differences, event-study diagnostics, honest pre-trend bounds.
- `synthetic-control` synthetic control and synthetic DiD, augmented and penalized variants, factor models.
- `rdd` continuity and local-randomization frameworks with the design gate and falsification battery.
- `iv` weak-instrument-robust inference, shift-share and formula instruments, exclusion-restriction discipline.
- `field-experiment` stratified and clustered designs, randomization inference, power, attrition, pre-specified heterogeneity.

**Updated**
- `preregister` scopes the manipulation-check requirement to lab and survey experiments (a deployed-change A/B test has no manipulated construct to check), labels the two MUST elevations as this workflow's own policy rather than a registry rule, and adds the registry-choice rule of thumb.

Each skill ships a hand-picked canon (`references/canon.md`), lookup detail (`references/details.md`), and a runnable R template (`scripts/`). The five method skills share one bibliography at `skills/causal-design/references/causal.bib`, 155 entries, validated with biber.

README gains six table rows and a revised summary line. SETUP.md gains the R package prerequisites, separated into the CRAN set and the six that install from GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfQJ1JMk1AmoHChKk55UDm