### PR TITLE
Fix the quickstart, six template defects, and three wrong numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Everything in this repository, including the two example decks and their figures
 ```bash
 git clone https://github.com/ericluo04/claude-academic-workflow
 cd claude-academic-workflow
+mkdir -p ~/.claude/skills ~/.claude/agents ~/.claude/assets
 cp -R skills/* ~/.claude/skills/
 cp agents/tikz-reviewer.md ~/.claude/agents/
-mkdir -p ~/.claude/assets && cp -R slide-tooling ~/.claude/assets/quarto-yale
+cp -R slide-tooling ~/.claude/assets/quarto-yale
 ```
 
 Then read [SETUP.md](SETUP.md): it names every path and helper the skills assume (the Crossref contact address, the PDF helper, the Overleaf glob) and how to adjust each one. `CLAUDE.md` is the author's working global configuration, shared as an example. The three `style/house.md` files in the slide skills are stubs for your own taste: author line, closing-slide wording, palette rationale, density calibration.
@@ -60,7 +61,7 @@ Two live example decks, rendered by these skills and published on GitHub Pages:
 
 Both are static pages that make zero network requests at display time; the [index](https://ericluo04.github.io/claude-academic-workflow/) links them with keyboard shortcuts. Their sources are in `examples/`, and the live copies are those sources rendered against the starter theme in `slide-tooling/`, exactly as they render out of the box.
 
-The decks demonstrate what the pipeline can do; how your slides should look stays your call. The starter theme carries the machinery inside one worked look (paper ground, Literata display headings over IBM Plex Sans text, a plum accent), and the theme file marks every spot where your own taste replaces it. How wordy each slide is, the palette, the typography, and the staging rhythm are all preferences written down in plain text, in the doctrine and pacing sections of the `research-talk` and `teaching-lecture` skill files and in the SCSS variables at the top of the starter theme, so changing any of them is editing a paragraph or a variable. If the examples strike you as ugly, that is the expected case: rewrite the preferences until the output matches your own taste.
+The decks demonstrate what the pipeline can do; how your slides should look stays your call. The starter theme carries the machinery inside one worked look (paper ground, Literata display headings over IBM Plex Sans text, a plum accent), and the theme file marks every spot where your own taste replaces it. How wordy each slide is, the palette, the typography, and the staging rhythm are all preferences written down in plain text, in the content-doctrine section of the `research-talk` skill file, the pacing-and-structure section of the `teaching-lecture` one, and the SCSS variables at the top of the starter theme, so changing any of them is editing a paragraph or a variable. If the examples strike you as ugly, that is the expected case: rewrite the preferences until the output matches your own taste.
 
 What Quarto reveal.js gives you:
 
@@ -70,7 +71,7 @@ What Quarto reveal.js gives you:
 - Citations straight from a `.bib` file, rendered with a hover preview of the full reference and collected into a paginated list at the end.
 - Video embedded with one HTML tag.
 
-Beamer does the second of those and not the other three; its animation exists but is far less flexible. PowerPoint does none of them well: transitions and animations are not scriptable, and nothing in the AI-authoring chain writes its equation format, so an agent-written deck comes out static with its math as text or images. Either is a reasonable choice when a venue or your coauthors require it, when the talk already lives there, or when you simply prefer it and it fits your workflow better.
+Beamer does the second of those and not the other four; its animation exists but is far less flexible. PowerPoint does none of them well: transitions and animations are not scriptable, and nothing in the AI-authoring chain writes its equation format, so an agent-written deck comes out static with its math as text or images. Either is a reasonable choice when a venue or your coauthors require it, when the talk already lives there, or when you simply prefer it and it fits your workflow better.
 
 An important note: rendering needs a network. Quarto fetches its reveal.js dependencies the first time, and code chunks install what they import. Presenting does not, because `slide-tooling/` vendors MathJax and both typefaces, so a finished deck opens from a local file with the wifi off. That last part is this repo's doing rather than Quarto's default, which loads MathJax from a CDN and leaves the equations blank on a podium laptop with no connection.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -9,22 +9,23 @@ Everything here was extracted from one researcher's working configuration, so th
 - Node 22 or newer, for the two deck gates (`deck-check.mjs`, `stage-check.mjs`; they use node's built-in WebSocket, no npm install).
 - A TeX distribution (MacTeX or TeX Live) with `latexmk`, for `compile-latex` and `tikz-iterate`; ghostscript for rasterizing.
 - `uv`, for the self-contained Python helpers (`paper.py` and the `pdfread.py` PDF helper run via `uv run` shebangs).
-- R with ggplot2 if you render the example decks (their figures are R chunks).
-- R with the estimation packages, for the causal-inference skills. Their script templates are the reference implementations, and each one loads only what its own design needs, so install per skill rather than all at once. The CRAN side spans `fixest`, `did`, `didimputation`, `staggered`, `bacondecomp`, `TwoWayFEWeights`, `HonestDiD`, `rdrobust`, `rddensity`, `rdlocrand`, `rdpower`, `rdmulti`, `ivreg`, `ivmodel`, `ivDiag`, `ivmte`, `Synth`, `tidysynth`, `scpi`, `SCtools`, `fect`, `CausalImpact`, `grf`, `policytree`, `WeightIt`, `sensemakr`, `estimatr`, `marginaleffects`, `randomizr`, `DeclareDesign`, `ri2`, `qte`, `clubSandwich`, `summclust`, `fwildclusterboot`, `ShiftShareSE`, `bpbounds`, and `zoo`. Six live on GitHub and need `remotes::install_github()`: `ebenmichael/augsynth`, `jonathandroth/pretrends`, `synth-inference/synthdid`, `kylebutts/ssaggregate`, `kwuthrich/scinference`, and `kolesarm/ManyIV`. Each skill's `references/details.md` carries a package index with the version the template was written against and the API quirks worth knowing.
+- R 4.1 or newer. The `synthetic-control` script template uses the native pipe (`|>`), which older R does not parse. Add ggplot2 and knitr if you render the example decks (their figures are R chunks run through the knitr engine).
+- R with the estimation packages, for the causal-inference skills. Their script templates are the reference implementations, and each one loads only what its own design needs, so install per skill rather than all at once. The CRAN side spans `fixest`, `did`, `didimputation`, `staggered`, `bacondecomp`, `TwoWayFEWeights`, `HonestDiD`, `rdrobust`, `rddensity`, `rdlocrand`, `rdpower`, `rdmulti`, `ivreg`, `ivmodel`, `ivDiag`, `ivmte`, `Synth`, `tidysynth`, `scpi`, `SCtools`, `fect`, `CausalImpact`, `grf`, `policytree`, `WeightIt`, `sensemakr`, `estimatr`, `marginaleffects`, `randomizr`, `DeclareDesign`, `ri2`, `qte`, `clubSandwich`, `summclust`, `fwildclusterboot`, `ShiftShareSE`, `bpbounds`, `dplyr`, and `zoo`. Six live on GitHub and need `remotes::install_github()`: `ebenmichael/augsynth`, `jonathandroth/pretrends`, `synth-inference/synthdid`, `kylebutts/ssaggregate`, `kwuthrich/scinference`, and `kolesarm/ManyIV`. Each skill's `references/details.md` carries a package index with the version the template was written against and the API quirks worth knowing.
 
 ## Install
 
 ```bash
+mkdir -p ~/.claude/skills ~/.claude/agents ~/.claude/assets
 cp -R skills/* ~/.claude/skills/
 cp agents/tikz-reviewer.md ~/.claude/agents/
-mkdir -p ~/.claude/assets && cp -R slide-tooling ~/.claude/assets/quarto-yale
+cp -R slide-tooling ~/.claude/assets/quarto-yale
 ```
 
 The skills refer to the slide tooling at `~/.claude/assets/quarto-yale/`, which is why the copy keeps that name. A new deck then starts with `quarto add ~/.claude/assets/quarto-yale --no-prompt` and `cp -R ~/.claude/assets/quarto-yale/{mathjax,fonts} .`, and uses `format: starter-revealjs`.
 
 ## What to adjust
 
-- The Crossref and OpenAlex contact address. `skills/bibcheck/SKILL.md` and `skills/reading-papers/scripts/paper.py` carry `you@example.edu` placeholders; set a real address (or export `SCHOLAR_MAILTO`). The polite pools these APIs run for real contacts are faster and more reliable.
+- The `you@example.edu` placeholder, in three files. `skills/bibcheck/SKILL.md` and `skills/reading-papers/scripts/paper.py` use it as the Crossref and OpenAlex contact address; set a real one (or export `SCHOLAR_MAILTO`). The polite pools these APIs run for real contacts are faster and more reliable. `skills/research-talk/assets/starter-template.qmd` uses it on the closing contact slide.
 - API keys. `paper.py` and the Zotero launcher source `~/.claude/secrets/scholar.env` if it exists, with `S2_API_KEY`, `OPENALEX_API_KEY`, and optional `ZOTERO_API_KEY`/`ZOTERO_LIBRARY_ID`. All are optional; the tools degrade to the public pools without them.
 - House style. `skills/research-talk/style/house.md`, `skills/teaching-lecture/style/house.md`, and `skills/slide-review/style/house.md` are stubs: your author line, closing-slide wording, palette rationale, and density calibration go there. The slide skills read those files for values.
 - Your theme. `slide-tooling/starter-theme.scss` is deliberately plain and comments mark where taste goes; the example decks under `docs/` are that theme rendered as-is, so what you see is the starting point and the look is yours to build.

--- a/skills/causal-design/references/causal.bib
+++ b/skills/causal-design/references/causal.bib
@@ -1,8 +1,9 @@
 % Shared bibliography for the causal-inference skill family.
 % Every entry is resolver-verified (Crossref/OpenAlex via paper.py) at read time; nothing here
 % is typed from memory. Keys are stable; method skills reference them. Copy this file into a
-% project's Paper/ folder as needed. Current as of 2026-07-28. DiD entries below; other areas
-% get appended as their skills are built.
+% project's Paper/ folder as needed. Current as of 2026-07-28. The file is complete for all six
+% areas and runs in this order: DiD, RDD, IV, synthetic control, field experiments, and the
+% causal-design router's selection-on-observables branch.
 
 @article{roth2023whats,
   title   = {What's trending in difference-in-differences? A synthesis of the recent econometrics literature},

--- a/skills/causal-design/scripts/unconfoundedness_template.R
+++ b/skills/causal-design/scripts/unconfoundedness_template.R
@@ -36,6 +36,7 @@ library(marginaleffects) # 0.32.0
 ## is the most common mistake" (Imbens 2024) -- audit the covariate list before running.
 
 X <- as.matrix(df[, c("x1", "x2", "x3")])
+set.seed(94305)
 
 ## ---- 1. Overlap FIRST (violations move the estimand, not just the estimator) ----------
 cf <- causal_forest(X, df$y, df$d,

--- a/skills/did/scripts/did_template.R
+++ b/skills/did/scripts/did_template.R
@@ -19,6 +19,7 @@ YNAME <- "y"; TNAME <- "period"; IDNAME <- "unit"; GNAME <- "first_treated"
 CLUSTER <- "cluster"
 XFORMLA <- NULL              # e.g. ~ x1 + x2 for conditional PT; NULL = unconditional
 df <- your_data              # replace
+set.seed(94305)
 
 ## ---- 0. Packages -----------------------------------------------------------
 # CRAN: did (2.5.x), HonestDiD (0.2.8), didimputation (0.5.x), TwoWayFEWeights (2.1.x),
@@ -140,9 +141,9 @@ pt$event_plot_pretest
 
 ## ---- 5. TWFE alongside, and Sun-Abraham cross-check ------------------------
 # Post-treatment indicator for the TWFE, bacon, and twowayfeweights calls. Never-treated
-# units (first_treated == 0) must stay 0: without the != 0 guard, period >= 0 would mark
-# them treated everywhere, the same cohort-recoding trap flagged for sunab below.
-df$treat <- as.integer(df$first_treated != 0 & df$period >= df$first_treated)
+# units (GNAME == 0) must stay 0: without the != 0 guard, TNAME >= 0 would mark them
+# treated everywhere, the same cohort-recoding trap flagged for sunab below.
+df$treat <- as.integer(df[[GNAME]] != 0 & df[[TNAME]] >= df[[GNAME]])
 twfe <- feols(as.formula(paste(YNAME, "~ treat |", IDNAME, "+", TNAME)),
               data = df, cluster = df[[CLUSTER]])
 # sunab treats any cohort value outside the observed periods as never-treated;
@@ -164,9 +165,11 @@ tw <- twowayfeweights(df, YNAME, IDNAME, TNAME, "treat", type = "feTR",
 # Only when you will defend parallel pre-trends over the whole panel.
 # didimputation codes never-treated as 0 or NA (same as did).
 # pretrends = -5:-1 is a placeholder; match your panel.
+# Without cluster_var the call clusters on idname, and the SEs stop being comparable to
+# the other estimators in this file.
 library(didimputation)
 imp <- did_imputation(data = df, yname = YNAME, gname = GNAME,
-                      tname = TNAME, idname = IDNAME,
+                      tname = TNAME, idname = IDNAME, cluster_var = CLUSTER,
                       horizon = TRUE, pretrends = -5:-1)
 
 ## ---- 8. Quasi-random timing (efficient estimator) --------------------------
@@ -211,6 +214,11 @@ plot(sc)
 # (G = 12 gives 4,096), and boottest enumerates them all when B > 2^G. Pick B so
 # alpha * (B + 1) is an integer (9999 or 99999).
 library(fwildclusterboot)
+# boottest has no seed argument. With the default engine = "R" and Rademacher, Webb, or
+# Normal weights, reproducibility comes from dqrng's generator, not base R's, so the
+# set.seed in CONFIG does not cover these two calls. (Use set.seed instead only for
+# engine = "R-lean", Mammen weights, or engine = "WildBootTests.jl".)
+dqrng::dqset.seed(94305)
 wcr <- boottest(twfe, param = "treat", B = 9999, clustid = CLUSTER,
                 type = "rademacher", impose_null = TRUE, bootstrap_type = "fnw11")
 wcr           # p-value and CI to set beside the CV1 and CV3 answers
@@ -226,9 +234,13 @@ wcr33 <- boottest(twfe, param = "treat", B = 9999, clustid = CLUSTER,
 # 10c. CRAN cross-check: CR2 with Satterthwaite dof (clubSandwich 0.7.0). The dof can
 # fall far below G-1; the Imbens-Kolesar variant is inapplicable once cluster FEs are
 # absorbed.
+# clubSandwich has no fixest method, so this block refits the same TWFE spec as a plain
+# lm with factor() fixed effects.
 library(clubSandwich)
-vc2 <- vcovCR(twfe, cluster = df[[CLUSTER]], type = "CR2")
-coef_test(twfe, vcov = vc2, test = "Satterthwaite")
+fml_lm  <- paste0(YNAME, " ~ treat + factor(", IDNAME, ") + factor(", TNAME, ")")
+twfe_lm <- lm(as.formula(fml_lm), data = df)
+vc2 <- vcovCR(twfe_lm, cluster = df[[CLUSTER]], type = "CR2")
+coef_test(twfe_lm, vcov = vc2, test = "Satterthwaite")
 
 # 10d. Few treated (or control) clusters: CV1/CV2 standard errors can be too small by a
 # factor of five or more at G1 = 1; CV3 over-rejects less but still fails when G1 is

--- a/skills/field-experiment/SKILL.md
+++ b/skills/field-experiment/SKILL.md
@@ -59,7 +59,8 @@ Beyond those two, this family declines.
 - Analyze as randomized: stratified designs get within-stratum differences averaged with
   stratum weights, paired designs the across-pair variance, clustered designs the
   cluster-level machinery or Liang-Zeger with small-sample correction (CR2). Ignoring a
-  paired design roughly doubled the standard error in the canon's worked example.
+  paired design raised the standard error by about seventy percent in the canon's worked
+  example.
 - HC2 is the default variance everywhere (it reproduces the Neyman estimator exactly for a
   binary treatment); with a rare treatment arm Eicker-Huber-White (EHW, i.e. HC0) is
   anti-conservative, so use HC2 with Behrens-Fisher/Satterthwaite degrees of freedom.
@@ -187,8 +188,8 @@ Johari et al. 2022 analyzes the bias of one-sided designs).
    benchmark hides an imbalance at p = 0.002); post-attrition imbalance means the analyzed
    sample is no longer the randomized sample, which routes to the Lee block.
 2. Adjusted vs unadjusted side by side: adjustment should barely move the point estimate and
-   shrink the SE by roughly 1 - R2. A large movement signals compromised randomization,
-   attrition, or specification problems, and is never a precision story.
+   shrink the SE by roughly sqrt(1 - R2). A large movement signals compromised
+   randomization, attrition, or specification problems, and is never a precision story.
 3. Design-consistent variance check: the design-aware variance should be weakly smaller than
    the complete-randomization one; larger means the analysis mis-specifies the design.
 4. Both cluster estimands when cluster sizes vary; the gap between them is itself evidence

--- a/skills/field-experiment/references/details.md
+++ b/skills/field-experiment/references/details.md
@@ -13,8 +13,8 @@ Heavy reference content the SKILL.md points into. Current as of 2026-07-28.
 - Stratified: tau-hat = sum_g (N_g/N) tau-hat_g, V-hat = sum_g (N_g/N)^2 V-hat_g; the
   complete-randomization variance is valid but conservative.
 - Paired: use the across-pair variance of pair differences (conservative for the sample ATE,
-  right for the super-population one). Ignoring pairing roughly doubles the SE in the
-  Children's Television Workshop example (4.6 vs 7.8).
+  right for the super-population one). Ignoring pairing raises the SE by about seventy
+  percent in the Children's Television Workshop example (4.6 vs 7.8).
 - Clustered: for the cluster-average estimand, difference in means on cluster means
   (equivalently unit-level WLS with weights 1/N_g); for the unit-average estimand,
   unweighted unit OLS with Liang-Zeger CR (CR2 small-sample correction and Satterthwaite
@@ -167,7 +167,7 @@ log-scale models, and the same three-tier logic applies through the Guo-Basse ro
   assignments (Athey-Eckles-Imbens); no coherent large-network asymptotics, so do not
   substitute clustered SEs for the exact test.
 - Marketing instances: marketplace cannibalization, social-ad spillovers, budget-constrained
-  auctions, referral programs, livestream network effects.
+  auctions, referral programs, two-sided marketplace network effects.
 
 ## Marketing translations
 

--- a/skills/field-experiment/scripts/experiment_template.R
+++ b/skills/field-experiment/scripts/experiment_template.R
@@ -82,8 +82,8 @@ marginaleffects::avg_comparisons(fit, variables = "z",
                                  comparison = "lnoravg", transform = exp)
 # Guo-Basse per-arm imputation with the design-based MSE interval (their own snippet;
 # swap family = poisson for counts -- 45% shorter intervals than linear on their data):
-mu1 <- glm(y ~ pre_y + x1, family = binomial, data = subset(df, z == 1))
-mu0 <- glm(y ~ pre_y + x1, family = binomial, data = subset(df, z == 0))
+mu1 <- glm(y01 ~ pre_y + x1, family = binomial, data = subset(df, z == 1))
+mu0 <- glm(y01 ~ pre_y + x1, family = binomial, data = subset(df, z == 0))
 tau_gob <- mean(predict(mu1, df, "response") - predict(mu0, df, "response"))
 tau_gob + t.test(residuals(mu1, "response"), residuals(mu0, "response"))$conf.int
 # Pre-trust checks: no fitted values hugging 0/1 (separation); per-arm R2 not both

--- a/skills/iv/references/details.md
+++ b/skills/iv/references/details.md
@@ -68,7 +68,7 @@ Shares from two conditional means: pi_a = pr(X=1|Z=0), pi_n = pr(X=0|Z=1),
 pi_c = 1 - pi_a - pi_n. The first-stage ITT on treatment equals the complier share, so the
 first-stage table doubles as the compliance table. The assumptions imply four testable
 inequalities of the form pr(Y=1, X=0 | Z=1) <= pr(Y=1, X=0 | Z=0). Worked flu-encouragement
-numbers (Imbens 2014): left side 30/1389 = 0.0216 vs right side 31/72 = 0.0211, a slight
+numbers (Imbens 2014): left side 30/1389 = 0.0216 vs right side 31/1472 = 0.0211, a slight
 statistically insignificant violation, showing the tests have bite. Violation means at least
 one assumption is false; passing proves nothing (no consistent test exists). Manski natural
 bounds from the same 2x2x2 table travel with the LATE when the ATE was the target: flu ATE

--- a/skills/iv/scripts/iv_template.R
+++ b/skills/iv/scripts/iv_template.R
@@ -166,8 +166,14 @@ ri_p <- function(b) {
   t_cf  <- apply(perm_z - mu, 2, function(zv) mean(zv * (df$y - b * df$d)))
   mean(abs(t_cf) >= abs(t_obs))
 }
-grid <- seq(-2, 2, by = 0.01)             # widen until both endpoints are excluded
-range(grid[sapply(grid, ri_p) > 0.05])    # the RI 95% interval
+STEP <- 0.01
+grid <- seq(-2, 2, by = STEP)             # widen until both endpoints are excluded
+acc  <- grid[sapply(grid, ri_p) > 0.05]   # nulls not rejected at 5%
+if (!length(acc)) stop("RI: no null survives at 5%. Report failed identification.")
+if (acc[1] == grid[1] || acc[length(acc)] == grid[length(grid)])
+  warning("RI: accepted set touches a grid endpoint. It is unbounded, widen the grid.")
+runs <- split(acc, cumsum(c(1, diff(acc) > 1.5 * STEP)))   # contiguous pieces
+lapply(runs, range)                       # the RI 95% set, a union printed as a union
 # 8c. Placebo outcomes (lagged y as outcome) with the same RI machinery test shock
 # exogeneity itself; the balance test only validates the counterfactual specification.
 

--- a/skills/preregister/SKILL.md
+++ b/skills/preregister/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preregister
-description: Draft a registry-ready preregistration or preanalysis plan (AsPredicted, OSF, or AEA RCT Registry) from a study spec or a free-form description, with MUST/SHOULD/MAY flags on every field, [CLARIFY:] placeholders instead of invented content, a stated target N with power basis and stopping rule, and an explicit falsification criterion. TRIGGER on "preregister", "draft a preregistration", "AsPredicted form", "OSF prereg", "AEA RCT registry", "PAP", "preanalysis plan", or before launching a vignette, conjoint, eye-tracking, MTurk/Prolific, or field experiment. Refuses to write a preregistration for analyses already run on data already seen. Writes Markdown for pasting into the web forms, .tex on request.
+description: Draft a registry-ready preregistration or preanalysis plan (AsPredicted, OSF, or AEA RCT Registry) from a study spec or a free-form description, with MUST/SHOULD/MAY flags on every field, [CLARIFY:] placeholders instead of invented content, a stated target N with power basis and stopping rule, and an explicit falsification criterion. TRIGGER on "preregister", "draft a preregistration", "AsPredicted form", "OSF prereg", "AEA RCT registry", "PAP", "preanalysis plan", or before launching a vignette, eye-tracking, MTurk/Prolific, or field experiment. Refuses to write a preregistration for analyses already run on data already seen. Writes Markdown for pasting into the web forms, .tex on request.
 ---
 
 # Preregistration
@@ -55,7 +55,7 @@ If the description has no directional hypothesis, ask once. Do not invent a dire
 | Signal | Style |
 |---|---|
 | Online vignette, MTurk or Prolific study, short lab experiment, 1 to 3 DVs | `aspredicted` |
-| Conjoint, eye-tracking, multi-DV survey experiment, complex or stratified sampling | `osf` |
+| Eye-tracking, multi-DV survey experiment, complex or stratified sampling | `osf` |
 | Field experiment or RCT (livestream pilot, retailer pilot, app A/B test) | `aea-rct` |
 | Observational confirmatory analysis | `osf`, preanalysis-plan variant |
 | Ambiguous | `aspredicted` |

--- a/skills/rdd/SKILL.md
+++ b/skills/rdd/SKILL.md
@@ -100,10 +100,11 @@ The fuzzy estimand is a complier average effect at the cutoff under relevance, e
 monotonicity, so the iv skill's habits transfer:
 
 - Test the first stage inside the bandwidth or window, never on the full sample; the full-sample
-  F overstates strength. The guide's contrast is the anchor: F around 698 in the valid design,
-  F = 1.51 (Fisherian p = 0.32) in the failed one. An in-bandwidth first-stage F that is neither
-  the strong nor the hopeless extreme goes to the iv skill's ladder: read it against the F
-  targets there and report Anderson-Rubin/CLR intervals rather than the 2SLS t.
+  F overstates strength. The guide's contrast is the anchor: F around 698 in the valid design
+  against F = 1.51 in the failed one, where the first-stage effect is 0.15 with a Fisherian
+  p-value of 0.32. An in-bandwidth first-stage F that is neither the strong nor the hopeless
+  extreme goes to the iv skill's ladder: read it against the F targets there and report
+  Anderson-Rubin/CLR intervals rather than the 2SLS t.
 - Argue exclusion qualitatively and concretely: it fails if crossing the cutoff changes behavior
   through anything other than treatment (a low churn score triggering a retention call AND a
   flag another team acts on).

--- a/skills/rdd/references/details.md
+++ b/skills/rdd/references/details.md
@@ -45,7 +45,7 @@ contradiction (ART: 121 vs 2,593 observations).
 ## Fuzzy diagnostics
 
 - First stage inside the bandwidth/window only. Anchors: F about 698 (valid ART design) vs
-  F = 1.51, Fisherian p = 0.32 (failed chemotherapy design).
+  F = 1.51 (failed chemotherapy design, first-stage effect 0.15 with Fisherian p = 0.32).
 - Fuzzy-ratio balance tests: instrument strength amplifies covariate bias.
 - One MSE-optimal bandwidth for the ratio, not separate numerator/denominator bandwidths.
 - Exclusion argued concretely: crossing the cutoff must move the outcome only through

--- a/skills/rdd/scripts/rdd_template.R
+++ b/skills/rdd/scripts/rdd_template.R
@@ -15,6 +15,7 @@ x  <- df$score               # running variable
 d  <- df$takeup              # observed treatment (fuzzy designs only)
 Z  <- as.matrix(df[, c("cov1", "cov2")])   # predetermined covariates
 CUT <- 350                   # the cutoff
+set.seed(94305)
 
 library(rdrobust); library(rddensity); library(rdlocrand); library(rdpower)
 

--- a/skills/synthetic-control/references/details.md
+++ b/skills/synthetic-control/references/details.md
@@ -115,7 +115,7 @@ the two.
 - Regulation: state-level advertising or privacy rules hitting one state (the Prop 99
   template, literally a marketing-regulation outcome).
 - Platform shocks: a policy change hitting one category, region, or creator tier; channel- or
-  streamer-level panels where channels co-move (Twitch-YouTube style data).
+  creator-level panels on a video platform where channels co-move.
 - Anticipation: forward-buying before announced price changes; shift T0 to the
   announcement, not the enactment.
 - Interference: national campaigns contaminate donor markets; drop exposed donors or sign


### PR DESCRIPTION
A review pass over the seven causal skills published in #6, plus the repo docs.

The quickstart was broken for every new user: `cp -R skills/* ~/.claude/skills/` and the `agents` copy both ran before those directories existed, so a fresh install failed at step one. Verified against a scratch `HOME` both before and after.

Six R template defects, each verified by reading the code and, where a package interface was in question, against the current reference manual:

| File | Defect |
|---|---|
| `experiment_template.R` | `family = binomial` fitted to the continuous outcome `y` instead of `y01` |
| `did_template.R` | treatment indicator hard-coded `first_treated`/`period` against the `GNAME`/`TNAME` parameterization |
| `did_template.R` | `clubSandwich::vcovCR` called on a `feols` object; 0.7.0 has no fixest method |
| `did_template.R` | `did_imputation` without `cluster_var`, clustering on `idname` while its neighbours used `CLUSTER` |
| `iv_template.R` | `range()` collapsed a possibly disconnected RI confidence set into one interval |
| three templates | no `set.seed`; `did` additionally needed `dqrng::dqset.seed` for `boottest` |

Three numeric corrections: the SE shrinks by `sqrt(1 - R2)` rather than `1 - R2`, the Balke-Pearl denominator is 1472 rather than 72, and 7.8 against 4.6 is seventy percent rather than double. One citation correction: the RD failed-design F and Fisherian p are two separate statistics in the source, and the p belongs to the first-stage estimate.

Docs: `dplyr` and `knitr` added, an R 4.1 floor stated for the native pipe, the placeholder inventory completed, the bib header updated to describe all six areas, and two examples drawn from an unpublished project replaced with generic ones per fcd2f32.

All six templates parse. The bibliography still holds 155 entries and runs clean under `bibtex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfQJ1JMk1AmoHChKk55UDm