### PR TITLE
Correct what the leave-one-out weight floor actually does

### DIFF
--- a/skills/synthetic-control/scripts/synth_template.R
+++ b/skills/synthetic-control/scripts/synth_template.R
@@ -78,7 +78,9 @@ back |> plot_trends()
 
 ## ---- 5. Leave-one-out on positive-weight donors ------------------------------
 w <- out |> grab_unit_weights()
-# > 0.01 rather than > 0: skip weights that are numerically zero from the optimizer.
+# > 0.01 is a materiality floor, not a numerical-zero guard: it drops donors whose weight is
+# genuinely positive but under 1%. Use > 0 when the donor pool is small or the weights are
+# spread thin, since a 0.5% donor is then still worth leaving out.
 for (dnr in w$unit[w$weight > 0.01]) {
   loo <- df |> dplyr::filter(unit != dnr) |>
     synthetic_control(outcome = y, unit = unit, time = year,


### PR DESCRIPTION
Follow-up to #7. The leave-one-out block filters donors with `w$weight > 0.01` and the comment described that as skipping weights "numerically zero from the optimizer". It is a one percent materiality floor: a donor with a genuine 0.5 percent weight is dropped, so the robustness check covered fewer donors than the comment implied. The comment now says what the threshold does and when to use `> 0` instead.

Keeps the template byte-identical to the private copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfQJ1JMk1AmoHChKk55UDm