### PR TITLE
Add the leniency design to iv, split the skills table, scrub three terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,6 @@ Then read [SETUP.md](SETUP.md): it names every path and helper the skills assume
 | `reading-papers` | Looks up and reads a specific paper from a link, DOI, title, or vague description, across marketing, economics, psychology, and CS venues. |
 | `litreview` | Finds, ranks, and synthesizes the literature on a topic across Semantic Scholar, OpenAlex, and arXiv, then reads the top hits with parallel subagents. |
 | `bibcheck` | Audits a `.bib` file entry by entry against canonical metadata and writes a corrected copy; catches wrong years, mis-cited authors, and hallucinated entries. |
-| `causal-design` | Triages a causal question to the identification strategy the data can actually support, then hands off to the skill that owns it. Carries the selection-on-observables branch itself: overlap, doubly robust estimation, double machine learning, causal forests, sensitivity analysis. |
-| `did` | Runs a difference-in-differences analysis with the heterogeneity-robust estimators, event-study diagnostics, and honest bounds on pre-trend violations. |
-| `synthetic-control` | Builds and validates synthetic control comparisons, including synthetic difference-in-differences, the augmented and penalized variants, and factor-model alternatives. |
-| `rdd` | Runs a regression discontinuity in both the continuity and local-randomization frameworks, with the design gate and the full falsification battery. |
-| `iv` | Estimates instrumental-variables designs with weak-instrument-robust inference, shift-share and formula instruments, and an explicit exclusion-restriction argument. |
-| `field-experiment` | Designs and analyzes randomized experiments: stratified and clustered assignment, randomization inference, power, attrition bounds, and pre-specified heterogeneity. |
-| `preregister` | Drafts a registry-ready preregistration (AsPredicted, OSF, AEA RCT) with clarity flags and placeholders instead of invented content. |
 | `council` | Spawns five independent critic subagents in parallel on any target, then a synthesis pass that ranks findings by how load-bearing they are. |
 | `review-paper` | Runs a simulated referee review of your own draft with six agents in parallel, triaged CRITICAL/MAJOR/MINOR against a named target journal. See the [note of caution](#a-note-of-caution-on-reviewing) below. |
 | `referee-response` | Drafts an R&R response letter where every claimed change is located and read in the manuscript before a location pin is written. |
@@ -47,6 +40,33 @@ Then read [SETUP.md](SETUP.md): it names every path and helper the skills assume
 | `course-site` | Builds the semester course website the lecture decks hang off, and publishes it to GitHub Pages. |
 
 `agents/tikz-reviewer.md` is the adversarial visual critic `tikz-iterate` loops on. `slide-tooling/` holds the machinery the slide skills share: the staging filter, the fit and staging gates, the offline checker, a starter theme, and vendored MathJax and two webfont families; its README documents all of it.
+
+### Causal inference and natural experiments
+
+Seven skills for identification-strategy work. Each one is built on a canon it has actually
+read, so the advice carries the citation that licenses it, and each keeps a
+`references/canon.md` recording what every source settles, which disputes stay open, and where
+the skill departs from the paper. The last column is that canon.
+
+| Skill | What it does | Built on |
+|---|---|---|
+| `causal-design` | Triages a causal question to the identification strategy the data can actually support, then hands off to the skill that owns it. Carries the selection-on-observables branch itself: overlap, doubly robust estimation, double machine learning, causal forests, sensitivity analysis. | [Imbens (2024)](https://doi.org/10.1146/annurev-statistics-033121-114601); [Li et al. (2024)](https://www.ama.org/marketing-news/causal-inference-with-quasi-experimental-data/) |
+| `did` | Runs a difference-in-differences analysis with the heterogeneity-robust estimators, event-study diagnostics, and honest bounds on pre-trend violations. | [Roth et al. (2023)](https://arxiv.org/abs/2201.01194); [Baker et al. (2026)](https://arxiv.org/abs/2503.13323); [Arkhangelsky and Imbens (2024)](https://doi.org/10.1093/ectj/utae014); [Abadie et al. (2025)](https://www.nber.org/papers/w34550); [MacKinnon et al. (2023)](https://doi.org/10.1016/j.jeconom.2022.04.001) |
+| `synthetic-control` | Builds and validates synthetic control comparisons, including synthetic difference-in-differences, the augmented and penalized variants, and factor-model alternatives. | [Abadie (2021)](https://doi.org/10.1257/jel.20191450); [Arkhangelsky and Imbens (2024)](https://doi.org/10.1093/ectj/utae014) |
+| `rdd` | Runs a regression discontinuity in both the continuity and local-randomization frameworks, with the design gate and the full falsification battery. | [Cattaneo and Titiunik (2022)](https://doi.org/10.1146/annurev-economics-051520-021409); [Cattaneo et al. (2023)](https://arxiv.org/abs/2302.07413) |
+| `iv` | Estimates instrumental-variables designs with weak-instrument-robust inference, shift-share and formula instruments, leniency (judge and examiner) designs estimated by UJIVE, and an explicit exclusion-restriction argument. | [Imbens (2014)](https://doi.org/10.1214/14-STS480); [Keane and Neal (2024)](https://doi.org/10.1146/annurev-economics-092123-111021); [Borusyak et al. (2025)](https://doi.org/10.1257/jep.20231370); [Borusyak and Hull (2023)](https://www.nber.org/papers/w27845); [Mogstad et al. (2018)](https://www.nber.org/papers/w23568); [Goldsmith-Pinkham et al. (2026)](https://doi.org/10.1257/jep.20251480) |
+| `field-experiment` | Designs and analyzes randomized experiments: stratified and clustered assignment, randomization inference, power, attrition bounds, and pre-specified heterogeneity. | [Athey and Imbens (2017)](https://arxiv.org/abs/1607.00698); [Freedman (2008)](https://doi.org/10.1214/08-STS262); [Lin (2013)](https://doi.org/10.1214/12-AOAS583); [Guo and Basse (2023)](https://arxiv.org/abs/2004.11615); [Lee (2009)](https://www.nber.org/papers/w11721) |
+| `preregister` | Drafts a registry-ready preregistration (AsPredicted, OSF, AEA RCT) with clarity flags and placeholders instead of invented content. | [Gelman and Carlin (2014)](https://doi.org/10.1177/1745691614551642); [Simonsohn (2014)](https://datacolada.org/17); [Lakens (2017)](https://doi.org/10.1177/1948550617697177); [Abadie et al. (2023)](https://doi.org/10.1093/qje/qjac038) |
+
+Links point at the publisher when the article is free there and at the working paper or
+preprint otherwise, so nothing in that column sits behind a paywall. `preregister` is the one
+exception to the canon convention: it has no `references/canon.md`, and the papers listed are
+the ones it cites inline.
+
+These skills are opinionated. They pick defaults (which estimator, which standard errors, what
+bar an instrument has to clear) and say so, and where the literature genuinely disagrees they
+name both sides instead of quietly picking one. Read the skill's `references/canon.md` before
+adopting a default you would have to defend to a referee.
 
 ### A note of caution on reviewing
 

--- a/skills/causal-design/SKILL.md
+++ b/skills/causal-design/SKILL.md
@@ -44,6 +44,10 @@ references/canon.md as flagged addenda.
      It identifies the LATE for compliers only; the ATE needs substantially stronger
      assumptions, and the complier population is the focus because it is the only one
      identifiable (Imbens).
+   - Cases are routed to decision-makers who differ in strictness (judges, patent examiners,
+     assessors, loan officers, reviewers) and the routing is as good as random within a
+     stratum: iv, which owns the leniency design. The decision-maker identity is the
+     instrument, 2SLS on it is biased, and the estimator is UJIVE.
    - Treatment switches at a threshold on a running variable: rdd (fuzzy RD is IV at the
      cutoff).
    - Treatment switches on over time for some units with untreated comparisons: the panel
@@ -179,6 +183,7 @@ Every claim traces to references/canon.md; keys live in references/causal.bib.
 - synthetic-control: few treated units, long pre-periods; SDID; factor models and matrix
   completion; the augmented/forward DiD and HCW conditions stated above.
 - rdd: thresholds on running variables; the design gate and falsification battery.
-- iv: instruments, shift-share, formula instruments; weak-instrument inference.
+- iv: instruments, shift-share, formula instruments, leniency and examiner designs;
+  weak-instrument inference.
 - preregister: pre-analysis plans once the design is chosen (experiment-first skill;
   quasi-experimental and measurement PAPs adapt its structure).

--- a/skills/causal-design/references/causal.bib
+++ b/skills/causal-design/references/causal.bib
@@ -538,8 +538,11 @@
 }
 
 % ---- iv ----
-% Canon (from reading notes) + primary papers, resolver-verified 2026-07-28.
-% One PREPRINT (jaeger2018shift); everything else VoR.
+% Canon (from reading notes) + primary papers, resolver-verified 2026-07-28; leniency-design
+% additions verified 2026-08-04. Two PREPRINTs (jaeger2018shift, yap2025inference) and one
+% never-published working paper (kolesar2013estimation, the UJIVE origin, no DOI exists).
+% Two entries are advance-online with no volume or issue yet (blandhol2026tsls,
+% frandsen2025cluster); everything else VoR.
 
 % Crossref and OpenAlex omit the page range; 323--358 restored from Project Euclid.
 @article{imbens2014instrumental,
@@ -584,6 +587,19 @@
   number  = {6},
   pages   = {2155--2185},
   doi     = {10.3982/ECTA19367}
+}
+
+% Crossref-verified 2026-08-04 (DOI, volume, issue, pages, print date 2026-08-01).
+% Open version: arXiv 2511.03572; also NBER w34473.
+@article{goldsmithpinkham2026leniency,
+  author  = {Goldsmith-Pinkham, Paul and Hull, Peter and Koles{\'a}r, Michal},
+  title   = {Leniency Designs: An Operator's Manual},
+  journal = {Journal of Economic Perspectives},
+  year    = {2026},
+  volume  = {40},
+  number  = {3},
+  pages   = {213--240},
+  doi     = {10.1257/jep.20251480}
 }
 
 % ---- IV primary papers, alphabetical by key ----
@@ -711,6 +727,20 @@
   doi     = {10.2307/2951662}
 }
 
+% Added 2026-08-04 for the leniency-design material. Crossref-verified (title, all four
+% authors, journal). No longer a working paper: the Review of Economic Studies published it
+% online 2026-05-14 and assigns no volume, issue, or pages yet, so the advance-online
+% convention applies and the NBER w29709 deposit is superseded. Cite it as 2026; the
+% leniency paper's own reference list still has the 2025 working-paper form.
+@article{blandhol2026tsls,
+  author  = {Blandhol, Christine and Bonney, John and Mogstad, Magne and Torgovitsky, Alexander},
+  title   = {When is {TSLS} Actually {LATE}?},
+  journal = {Review of Economic Studies},
+  year    = {2026},
+  note    = {Advance online publication},
+  doi     = {10.1093/restud/rdag029}
+}
+
 % Print year 2022 (online-first 2021, which resolvers stamp).
 @article{borusyak2022quasi,
   author  = {Borusyak, Kirill and Hull, Peter and Jaravel, Xavier},
@@ -747,6 +777,19 @@
   doi     = {10.1257/aer.99.2.1}
 }
 
+% Added 2026-08-04 for the leniency-design material. Crossref-verified 2026-08-04 (DOI,
+% authors, volume, issue, pages, print date 2025-06-01).
+@article{chyn2025examiner,
+  author  = {Chyn, Eric and Frandsen, Brigham and Leslie, Emily},
+  title   = {Examiner and Judge Designs in Economics: A Practitioner's Guide},
+  journal = {Journal of Economic Literature},
+  year    = {2025},
+  volume  = {63},
+  number  = {2},
+  pages   = {401--439},
+  doi     = {10.1257/jel.20241719}
+}
+
 % Crossref stores initials only; full names from the published byline and the NBER deposit (w5052).
 @article{currie1996health,
   author  = {Currie, Janet and Gruber, Jonathan},
@@ -769,6 +812,33 @@
   number  = {6},
   pages   = {1365--1388},
   doi     = {10.2307/2171740}
+}
+
+% Added 2026-08-04 for the leniency-design material. Crossref-verified 2026-08-04 (DOI,
+% authors, volume, issue, pages, print date 2023-01-01).
+@article{frandsen2023judging,
+  author  = {Frandsen, Brigham and Lefgren, Lars and Leslie, Emily},
+  title   = {Judging Judge Fixed Effects},
+  journal = {American Economic Review},
+  year    = {2023},
+  volume  = {113},
+  number  = {1},
+  pages   = {253--277},
+  doi     = {10.1257/aer.20201860}
+}
+
+% Added 2026-08-04 for the leniency-design material. Crossref-verified 2026-08-04 (DOI,
+% authors, title, journal). Cited as "Forthcoming" in Goldsmith-Pinkham, Hull, and
+% Koles{\'a}r (2026); it is in fact already online (2025-05-19) with no volume or issue
+% assigned, so the advance-online convention applies. Crossref's 1--19 page range is the
+% advance-online pagination and is omitted here. Re-check for the print issue.
+@article{frandsen2025cluster,
+  author  = {Frandsen, Brigham and Leslie, Emily and McIntyre, Samuel},
+  title   = {Cluster Jackknife Instrumental Variables Estimation},
+  journal = {Review of Economics and Statistics},
+  year    = {2025},
+  note    = {Advance online publication},
+  doi     = {10.1162/rest.a.263}
 }
 
 @article{goldsmithpinkham2020bartik,
@@ -851,6 +921,20 @@
   doi     = {10.1111/j.1468-0262.2005.00610.x}
 }
 
+% Added 2026-08-04 for the leniency-design material. The paper that introduced UJIVE, cited
+% as its origin in Goldsmith-Pinkham, Hull, and Koles{\'a}r (2026). Never published: no
+% Crossref, OpenAlex, or arXiv record, so no DOI. Fields reproduced from the leniency paper's
+% own bibliography; the URL returns HTTP 200 as of 2026-08-04.
+@techreport{kolesar2013estimation,
+  author      = {Koles{\'a}r, Michal},
+  title       = {Estimation in an Instrumental Variables Model With Treatment Effect Heterogeneity},
+  institution = {Princeton University},
+  type        = {Working paper},
+  year        = {2013},
+  month       = {11},
+  url         = {https://www.princeton.edu/~mkolesar/papers/late_estimation.pdf}
+}
+
 @article{kolesar2015identification,
   author  = {Koles{\'a}r, Michal and Chetty, Raj and Friedman, John and Glaeser, Edward and Imbens, Guido W.},
   title   = {Identification and Inference With Many Invalid Instruments},
@@ -930,6 +1014,19 @@
   doi     = {10.1016/j.jeconom.2019.04.038}
 }
 
+% Added 2026-08-04 for the leniency-design material. Crossref-verified 2026-08-04 (DOI,
+% author, volume, issue, pages, print date 2026-01-01).
+@article{sigstad2026monotonicity,
+  author  = {Sigstad, Henrik},
+  title   = {Monotonicity among Judges: Evidence from Judicial Panels and Consequences for Judge {IV} Designs},
+  journal = {American Economic Review},
+  year    = {2026},
+  volume  = {116},
+  number  = {1},
+  pages   = {189--208},
+  doi     = {10.1257/aer.20231104}
+}
+
 % JSTOR deposit gives only the first page; range from RePEc.
 @article{staiger1997instrumental,
   author  = {Staiger, Douglas and Stock, James H.},
@@ -940,6 +1037,20 @@
   number  = {3},
   pages   = {557--586},
   doi     = {10.2307/2171753}
+}
+
+% Added 2026-08-04 for the leniency-design material. PREPRINT. v3 April 2025; no journal
+% version as of 2026-08-04 (Crossref and OpenAlex show only the arXiv deposit). Title,
+% author, and year verified against the arXiv API and the DataCite record for the arXiv DOI.
+@misc{yap2025inference,
+  author        = {Yap, Luther},
+  title         = {Inference with Many Weak Instruments and Heterogeneity},
+  year          = {2025},
+  note          = {arXiv:2408.11193; v1 August 2024, latest version April 2025},
+  eprint        = {2408.11193},
+  archiveprefix = {arXiv},
+  primaryclass  = {econ.EM},
+  doi           = {10.48550/arXiv.2408.11193}
 }
 
 % Article 104112; no issue number.

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -49,8 +49,8 @@ Spawned as `general-purpose` subagents with inline role-string prefixes. No pers
    the most likely failure mode? Walk back from the failure and name the decision point today at
    which it could have been avoided."
 3. Methodologist. "Challenge identification, measurement, and design. Quant-marketing tuned: DiD,
-   IV, RD, RCT, conjoint, eye-tracking, vignette, field experiment, scraped panel, and
-   GAN/SAE/embedding methods. Are the exclusion restrictions defensible? Is the unit of analysis
+   IV, RD, RCT, discrete choice experiment, eye-tracking, vignette, field experiment, scraped
+   panel, and embedding methods. Are the exclusion restrictions defensible? Is the unit of analysis
    consistent with the unit of treatment? Is the clustering level defensible? For ML or GenAI
    components, is train/test/holdout discipline intact, and does anything leak?"
 4. Academic editor. "Venue fit, narrative tightness, contribution framing. Default targets

--- a/skills/field-experiment/references/canon.md
+++ b/skills/field-experiment/references/canon.md
@@ -16,7 +16,9 @@ Handbook of Economic Field Experiments. Key: `athey2017econometrics`. Read: arXi
   Neyman variance drops an unidentifiable term, so CIs are conservative; HC2 equals the
   Neyman estimator for binary treatment, EHW is anti-conservative with rare arms
   (Behrens-Fisher dof fix); stratify ex ante (weakly dominates complete randomization even
-  small-sample), strata to 2+2, do not pair, re-randomization needs a pre-specified
+  small-sample), strata to 2+2, do not pair (their position, contested by the later
+  matched-pair theory in dispute 1 below, so do not carry it as settled),
+  re-randomization needs a pre-specified
   acceptance rule; clustered designs have two estimands and cluster-level analysis is
   primary; ITT plus LATE and never as-treated or per-protocol; honest sample splitting for
   data-driven heterogeneity (coverage survives, MSE pays); QTEs are marginal-quantile

--- a/skills/iv/SKILL.md
+++ b/skills/iv/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: iv
-description: Design, estimate, validate, and write up an instrumental-variables analysis, covering single-instrument LATE designs, weak-instrument-robust inference, shift-share instruments, and formula/composite instruments that need recentering. Produces advice with citations, R estimation and diagnostics code, and a drafted methods paragraph. TRIGGER on "instrumental variable", "IV", "2SLS", "two-stage least squares", "LATE", "complier", "exclusion restriction", "first stage", "weak instrument", "Anderson-Rubin", "shift-share", "Bartik", "judge design", "examiner leniency", "encouragement design" (field-experiment leads these end to end, including the ITT/LATE analysis; here for the exclusion-restriction discipline and weak-instrument inference when the encouragement serves as an instrument), "price endogeneity", "cost shifter", "Hausman instrument", "simulated eligibility", "recentered instrument", or any setting where treatment is chosen by agents and an incentive or cost shifter moves it. Design triage across methods belongs to causal-design.
+description: Design, estimate, validate, and write up an instrumental-variables analysis, covering single-instrument LATE designs, weak-instrument-robust inference, shift-share instruments, formula/composite instruments that need recentering, and leniency (judge and examiner) designs estimated by UJIVE. Produces advice with citations, R estimation and diagnostics code, and a drafted methods paragraph. TRIGGER on "instrumental variable", "IV", "2SLS", "two-stage least squares", "LATE", "complier", "exclusion restriction", "first stage", "weak instrument", "Anderson-Rubin", "shift-share", "Bartik", "judge design", "examiner design", "examiner leniency", "leniency design", "UJIVE", "jackknife IV", "encouragement design" (field-experiment leads these end to end, including the ITT/LATE analysis; here for the exclusion-restriction discipline and weak-instrument inference when the encouragement is the instrument), "price endogeneity", "cost shifter", "Hausman instrument", "simulated eligibility", "recentered instrument", or any setting where treatment is chosen by agents and an incentive or cost shifter moves it. Design triage across methods belongs to causal-design.
 ---
 
 # Instrumental variables
 
 An opinionated IV workflow grounded in a read canon (references/canon.md, current as of
-2026-07-29): Imbens' Statistical Science perspective for the assumption structure and the LATE
+2026-08-04): Imbens' Statistical Science perspective for the assumption structure and the LATE
 estimand, Keane-Neal's Annual Review guide for the weak-instrument inference regime, the two
-Borusyak-Hull(-Jaravel) papers for shift-share and formula instruments, and
-Mogstad-Santos-Torgovitsky's Econometrica framework for extrapolating beyond the compliers.
+Borusyak-Hull(-Jaravel) papers for shift-share and formula instruments,
+Mogstad-Santos-Torgovitsky's Econometrica framework for extrapolating beyond the compliers, and
+Goldsmith-Pinkham-Hull-Kolesár's JEP operator's manual for leniency designs.
 The deliverable is the identification argument with the citation that justifies each leg, the
 estimation and diagnostics code in R (Stata mirrors noted where the canon is Stata-first), and
 a methods paragraph with the limitation stated in first person at the point of the choice.
@@ -37,9 +38,16 @@ Four assumptions, argued separately because they have different characters (Imbe
    though it cannot change their treatment (draft-lottery never-takers stayed in school; a
    retention-offer trigger that also flags the account for priority support).
 3. Monotonicity (no defiers). Safe when the instrument is a one-directional incentive (letter,
-   subsidy, default). Suspect in examiner and judge designs, where it requires the strict
-   examiner's approvals to nest the lenient examiner's, a strong behavioral claim. One-sided
-   noncompliance buys it for free and turns the LATE into an effect on treated compliers.
+   subsidy, default). Strong in examiner and judge designs: by Vytlacil's theorem it is
+   equivalent to every examiner ranking the cases identically and differing only in where the
+   cutoff falls, which fails whenever examiners weight criteria differently or differ in skill
+   (Chan-Gentzkow-Yu find skill accounts for about 40 percent of the variation in radiologist
+   leniency). A leniency design needs less than this. The operative condition is average
+   monotonicity, no unit a defier on average across pairwise comparisons, which is necessary
+   and sufficient for nonnegative weights and is testable. The leniency section below carries
+   the weakening and the test; do not price a leniency design against the uniform condition.
+   One-sided noncompliance buys the uniform version for free and turns the LATE into an effect
+   on treated compliers.
 4. Relevance, tested with the discipline in the next section, never with a full-sample afterthought.
 
 The estimand under all four is the complier average effect (LATE). Compliers are the focus
@@ -71,7 +79,8 @@ The binding constraint in modern IV practice is inference, and the canon's posit
   not 10. F of 10 only controls two-tailed t size; below roughly 50, 2SLS is quite likely
   farther from the truth than OLS unless endogeneity is severe. The sample-F-to-certified-
   population-F ladder, and when a severe-endogeneity relaxation of this bar is credible, are
-  in references/details.md.
+  in references/details.md. This bar prices 2SLS bias, so it moves with the estimator: it does
+  not transfer to a jackknife estimator in a many-instrument design (see the leniency section).
 - Below F = 3.84 do not run IV at all; the AR interval will be unbounded and rightly so.
 - The reason the t-test dies even at strong F is power asymmetry, a mechanism worth knowing when
   refereeing: the 2SLS standard error is spuriously small exactly when the estimate lands near
@@ -87,6 +96,12 @@ The binding constraint in modern IV practice is inference, and the canon's posit
 - Compute the F heteroskedasticity- or cluster-robust, always; effective F (Montiel
   Olea-Pflueger) when overidentified and non-homoskedastic. Match clustering to the level of
   instrument assignment.
+
+This regime is written for designs with one instrument or a handful. A leniency design has
+hundreds, and three of these rules change there: the F bar stops applying, AR is the wrong
+robust test because the many-instrument versions are not robust to treatment-effect
+heterogeneity, and the clustering reflex has to be re-derived from the assignment mechanism.
+The leniency section below states each replacement.
 
 ## Overidentification and heterogeneity, one rule
 
@@ -153,11 +168,120 @@ significant collapsing to 0.08 insignificant after recentering) are the calibrat
 pure exposure bias can look like an effect. Ordinary controls do not substitute: geography
 absorbing 82 percent of the instrument's variation still left a significant biased estimate.
 
+## Leniency designs: UJIVE and the five checks
+
+Recognition: cases are routed to decision-makers who differ in strictness, and the routing is as
+good as random within a stratum. Judges, patent examiners, disability assessors, loan officers,
+child-protection investigators, radiologists, immigration officers, and any platform review
+queue that assigns by roster. The instrument is the decision-maker identity itself, and keeping
+it that way instead of collapsing it to a constructed leniency number drives everything below
+(Goldsmith-Pinkham-Hull-Kolesár 2026).
+
+Two practices to drop first. Do not build an external leniency measure and plug it into a
+just-identified IV ("manual leniency IV"), because the construction details drive the bias and
+the second-stage standard errors are wrong. Do not read design strength off the variance of a
+constructed leniency measure, because estimation noise inflates it. Pass the examiner dummies in
+directly and let the estimator do the leave-out.
+
+The estimator is UJIVE (Kolesár 2013), which instruments treatment with leave-one-out fitted
+relative leniency: residualize the examiner dummies on the controls first, then fit the first
+stage without observation i. The reason it is the default here is arithmetic. Bias is
+proportional to the trace of the estimator's weighting matrix, and a leniency design is the
+setting that carries many instruments and many controls at once: 2SLS has trace K, so its bias
+scales in the number of examiners; JIVE has trace -L, so its bias scales in the number of
+controls and points the opposite way; UJIVE has trace zero. Bias-corrected 2SLS also has trace
+zero, but only under homoskedasticity. IJIVE does not fully clear the bias, though in practice
+it lands close. The trace algebra is in references/details.md.
+
+The five checks, in their order:
+
+1. Name the controls that buy as-good-as-random assignment, and let the assignment mechanism
+   pick both the estimator and the standard errors. The institutional story is what names the
+   controls, so with no institutional story there is no principled control set. Keep necessary
+   controls (in every specification) separate from precision controls (optional, and in their
+   application these widened the intervals, because the first-stage noise the extra controls
+   introduce outweighed the gain in the outcome equation). E[z|w] has to be linear in the
+   covariates, which is automatic when w is fixed effects and otherwise needs interactions or
+   higher-order terms (sufficient in Kolesár 2013, necessary in Blandhol et al. 2026).
+2. Balance, run as the same UJIVE specification with the covariate as the outcome. This is the
+   step that gets done wrong. Do not regress observables on a constructed leniency measure,
+   which manufactures mechanical correlation and carries errors-in-variables bias even when the
+   measure is leave-out, and do not report the joint F on the examiner dummies, which is invalid
+   with many examiners (Anatolyev-Sølvsten 2023). Running balance as UJIVE puts any imbalance in
+   the same units as the treatment effect, so the two are directly comparable: in their patent
+   reanalysis the balance coefficients came in about ten times smaller than the effects. The
+   same machinery on a post-assignment variable tests exclusion (their instance is months under
+   review).
+3. Estimate by UJIVE and report the alternatives beside it. 2SLS on the examiner dummies landing
+   between OLS and UJIVE is the signature of many-instrument bias pulling toward OLS, and 2SLS
+   standard errors 3 to 4 times tighter than UJIVE's are that same pathology showing up in the
+   variance.
+4. Test monotonicity (below).
+5. Characterize compliers (below).
+
+Inference. Under independent assignment, plain robust standard errors are right, and clustering
+on the examiner is never justified. This reverses the usual reflex, so state it explicitly when
+a referee expects examiner clusters. The argument (Abadie-Athey-Imbens-Wooldridge) is that what
+governs the standard error is the correlation of the product of instrument and residual, and
+under random assignment that product is uncorrelated across units whatever the residuals do.
+Clustering "just in case" buys conservative intervals, and whether it moves the magnitude is no
+evidence it was needed. Cluster only when ASSIGNMENT is clustered (one doctor covers a whole
+shift, one lottery routes a whole filing date), at that level. Clustering also changes the
+estimator: clustered assignment calls for leave-own-cluster-out UJIVE
+(Frandsen-Leslie-McIntyre 2025), so the clustering decision comes before the estimation. Carry
+the caveat that this result is proved for iid assignment with a fixed number of examiners, and
+the extension to many examiners is asserted as natural without being proved.
+
+Strength and the weak-instrument fallback. Do not read the first-stage F against a threshold
+here. UJIVE stays approximately unbiased and consistent even as E[F] approaches one, provided
+sqrt(K) times (E[F] - 1) is large, so that product is the statistic to report. F is also
+mechanically small in these designs because the formula divides by K, so a modest F is
+uninformative about whether leniency moves treatment. The heterogeneity-robust plug-in variance
+absorbs the Bekker many-instrument term, so one standard error covers both. When
+sqrt(K) times (E[F] - 1) is small, the fallback is Yap 2025, which substitutes the null-imposed
+residual into the UJIVE standard error. The many-instrument AR of Mikusheva-Sun 2022 and
+Matsushita-Otsu 2024 do not apply here, since neither survives treatment-effect heterogeneity,
+which a leniency design has by construction.
+
+Monotonicity, weakened and tested. Price the design against average monotonicity
+(Frandsen-Lefgren-Leslie 2023), meaning no unit is a defier on average across pairwise
+comparisons. That condition is necessary and sufficient for nonnegative weights on the
+individual effects, which is what uniform monotonicity was protecting against in the first
+place, and it is strictly weaker. It is not invariant to first-stage misspecification: when
+examiners work across several strata with stratum-specific leniency, an additive first stage can
+break average monotonicity where the true relative leniency satisfies it. Check robustness to
+interacting examiner assignment with the stratum fixed effects, and expect that flexibility to
+cost precision.
+
+The test: pick a v determined before assignment, replace the outcome with v times treatment,
+hold the treatment, instruments, and controls fixed, and run UJIVE. The estimate is a convex
+weighted average of v under the same weights as the headline estimate, so for binary v it has to
+land in [0, 1]. Outside those bounds something in the LATE theorem has failed. Two limits to
+state when reporting it: the null is joint across assignment, exclusion, and monotonicity, so a
+rejection does not localize; and it catches only gross violations, since on-average defiers have
+to be both common and unlike the compliers to push a weighted average out of [0, 1]. What it
+buys over testing the stronger condition is that its rejections bear directly on sign reversals,
+and it needs neither bounded outcomes nor a small number of decision-makers. Sigstad 2026 is the
+calibration for how much to worry: monotonicity is often violated in judicial panels, and the
+disagreements are too small to move leniency IV estimates much.
+
+Compliers and external validity. The same trick with non-binary v identifies complier means of
+any pre-assignment characteristic under the headline weights. Put the complier mean beside the
+sample mean covariate by covariate and let the gaps carry the external-validity claim. Untreated
+compliers come from using one minus the treatment. To pool the two, run UJIVE of v times (2x - 1)
+on (2x - 1). This doubles as a monotonicity check, since a complier mean outside logical bounds
+rejects. Do not carry the MST extrapolation ladder into a leniency design without flagging it:
+neither the MTE-curve approach nor MST has been formalized for many decision-makers or controls.
+
+Chyn-Frandsen-Leslie 2025 (JEL 63(2)) is the companion practitioner's guide. Read both when the
+design is the whole paper.
+
 ## Diagnostics battery
 
 1. Robust first-stage F, computed at the level the design lives at: in-bandwidth for fuzzy RD
    (that skill), shift-level for shift-share, cluster-robust at the assignment level otherwise.
-   Read it against the ladder in references/details.md, not against 10.
+   Read it against the ladder in references/details.md, not against 10. Leniency designs are
+   the exception: report sqrt(K) times (E[F] - 1) and skip the threshold entirely.
 2. Compliance-share table (binary instrument): pi_a, pi_n, pi_c. A thin complier slice means
    wide intervals and honest extrapolation language.
 3. Balke-Pearl inequality checks (binary Y, X, Z): four testable inequalities implied by the
@@ -172,6 +296,10 @@ absorbing 82 percent of the instrument's variation still left a significant bias
 7. TSLS-LIML divergence in overidentified designs as a cheap weak/many-instrument alarm.
 8. Placebo outcomes: lagged outcomes as the dependent variable, RI-based for recentered
    designs (sharp null sidesteps the RI-with-heterogeneity complication).
+9b. Leniency designs run the battery in their own section instead: UJIVE balance regressions on
+   the covariates and on a post-assignment variable, the [0, 1] monotonicity test, and the
+   complier table. Item 7 is replaced there by reporting UJIVE next to OLS, 2SLS, and JIVE,
+   where 2SLS sitting between OLS and UJIVE is the many-instrument alarm.
 9. MST feasibility tests, two cheap re-solves of the extrapolation LP
    (Mogstad-Santos-Torgovitsky 2018): restrict the MTR pairs to zero average selection bias
    and re-solve, then to zero selection on gains. Infeasibility rejects that behavioral
@@ -208,7 +336,10 @@ ivDiag(data = df, Y = "y", D = "x", Z = "z",
 
 Shift-share: ShiftShareSE (reg_ss / ivreg_ss, AKM and AKM0) and the shift-level equivalent
 regression via ssaggregate. Recentering is a hand-coded permutation loop (no package needed;
-the template has it). Package index with versions, links, and traps in references/details.md.
+the template has it). Leniency: ManyIV, the authors' own package, which returns OLS, 2SLS,
+UJIVE, IJIVE, and JIVE from one call with heterogeneity-robust standard errors, and which the
+paper's own tables were produced with. Package index with versions, links, and traps in
+references/details.md.
 
 ## Methods paragraph template
 
@@ -235,6 +366,38 @@ the template has it). Package index with versions, links, and traps in reference
 > extrapolation grows, which is the price of asking about individuals the instrument did not
 > move.
 
+A leniency design shares almost none of that structure, so it gets its own template:
+
+> Cases here are assigned to [decision-makers] who differ in strictness, and assignment is
+> [randomized / as good as random conditional on the [stratum] fixed effects that
+> [institution]'s routing rule makes necessary]. We instrument [treatment] with the full set of
+> [decision-maker] indicators and estimate by UJIVE (Kolesár 2013), which instruments with a
+> leave-one-out estimate of covariate-residualized leniency and stays unbiased with many
+> decision-makers and many controls at once, where 2SLS and JIVE do not (Goldsmith-Pinkham,
+> Hull, and Kolesár 2026). We report OLS, 2SLS on the indicators, and JIVE alongside.
+> [If assignment is independent across units:] Because assignment is independent across
+> [units], we report heteroskedasticity-robust standard errors and do not cluster on
+> [decision-makers], following Goldsmith-Pinkham, Hull, and Kolesár (2026). [If assignment is
+> clustered:] Because a single [decision-maker] covers an entire [shift], we cluster at the
+> [shift] level and use the corresponding leave-own-cluster-out estimator. Instrument strength
+> is sqrt(K)(E[F] - 1) = [value] across K = [number] [decision-makers]. We do not report the
+> first-stage F against a threshold, because it divides by K and is small here even when
+> leniency moves treatment substantially. We assess assignment by running the same UJIVE
+> specification with each pre-assignment covariate as the outcome, which puts any imbalance in
+> treatment-effect units: the coefficients are [magnitude] times smaller than the estimated
+> effects. We assess exclusion the same way, using [post-assignment variable] as the outcome.
+> The estimand is a convex weighted average of individual treatment effects under average
+> monotonicity (Frandsen, Lefgren, and Leslie 2023), which is weaker than the usual no-defiers
+> condition and is necessary and sufficient for the weights to be nonnegative. We test it by
+> re-running the specification with [binary pre-assignment variable] times treatment as the
+> outcome, where the estimate must lie in [0, 1]: we obtain [value]. A limitation of this test
+> is that it detects only gross violations, since on-average defiers have to be both common and
+> unlike the compliers to move a weighted average outside those bounds, and its null is joint
+> across assignment, exclusion, and monotonicity, so a rejection would not tell us which failed.
+> Compliers resemble the full sample on [characteristics], which is the basis for reading the
+> estimate as informative beyond the marginal cases. We do not extrapolate further, because the
+> frameworks for doing so have not been formalized for designs with many decision-makers.
+
 Every claim traces to references/canon.md; keys live in causal-design/references/causal.bib.
 
 ## Handoffs
@@ -248,5 +411,7 @@ Every claim traces to references/canon.md; keys live in causal-design/references
 - field-experiment: randomized encouragement designs end to end (including the ITT/LATE
   analysis) and randomization inference on a simple physically randomized instrument;
   recentered and formula instruments keep their RI machinery here.
+- causal-unstructured: the perceived-treatment design (actual feature instruments the perceived
+  feature) arrives here; the exclusion and weak-instrument discipline apply unchanged.
 - preregister: pre-specifying the instrument, specification, and weak-IV fallback before
   outcomes are seen (experiment-first skill; adapt its structure for quasi-experimental PAPs).

--- a/skills/iv/references/canon.md
+++ b/skills/iv/references/canon.md
@@ -1,8 +1,11 @@
 # IV canon
 
-Current as of 2026-07-29. These sources are hand-picked; nothing enters this file without
-explicit human approval. BibTeX keys point into ../../causal-design/references/causal.bib.
-Refresh: litreview on the method since the date above, results proposed as flagged addenda.
+Current as of 2026-08-04. These sources are hand-picked; nothing enters this file without
+explicit human approval. Goldsmith-Pinkham, Hull, and Kolesár is an approved addendum
+(2026-08-04) covering the leniency design, which the other five sources reach only in
+passing. BibTeX keys point into
+../../causal-design/references/causal.bib. Refresh: litreview on the method since the date
+above, results proposed as flagged addenda.
 
 ## Imbens (2014)
 
@@ -129,6 +132,56 @@ Econometrica 86(5): 1589-1619. Key: `mogstad2018using`.
   package (Shea-Torgovitsky 2023, `shea2023ivmte`), package row and solver traps in
   references/details.md, optional template block in scripts/iv_template.R.
 
+## Goldsmith-Pinkham, Hull, and Kolesár (2026)
+
+Journal of Economic Perspectives 40(3): 213-240. Key: `goldsmithpinkham2026leniency`. Open
+version arXiv 2511.03572. User-supplied addendum, read 2026-08-04.
+
+- Role: the leniency design (judge, examiner, caseworker, assessor) end to end. Which estimator,
+  which standard errors, and the five checks that make the design credible. The one canon paper
+  here that is about a design rather than about IV in general.
+- Settles: UJIVE (Kolesár 2013) is the estimator for these designs, because it is the only
+  candidate whose bias trace is zero, and leniency designs are exactly the setting with many
+  instruments and many controls at once (2SLS carries many-instrument bias scaling in K, JIVE
+  carries many-covariate bias scaling in the number of controls L and with the opposite sign,
+  bias-corrected 2SLS has trace zero but only under homoskedasticity, IJIVE is close in
+  practice); UJIVE instruments with leave-one-out fitted relative leniency, the examiner dummies
+  residualized on the controls first; manual leniency IV (build an external leniency measure,
+  plug it into a just-identified IV) is out, because construction details drive the bias and the
+  second-stage standard errors are wrong; the variance of a constructed leniency measure is not
+  a reading of design strength, since estimation noise inflates it; balance is tested by running
+  the same UJIVE specification with the covariate as the outcome, which puts any imbalance in
+  treatment-effect units and is immune to the mechanical correlation a constructed-leniency
+  balance regression manufactures; the joint F on the examiner dummies is invalid with many
+  examiners; the same machinery on a post-assignment variable tests exclusion; average
+  monotonicity (Frandsen-Lefgren-Leslie 2023) is the operative condition, weaker than
+  Imbens-Angrist uniform monotonicity and necessary and sufficient for nonnegative weights, but
+  it is not invariant to first-stage misspecification; average monotonicity is testable, by
+  running UJIVE on v_i times treatment for a pre-assignment binary v_i and checking the estimate
+  lands in [0, 1]; the same trick with non-binary v_i characterizes compliers and probes external
+  validity; the first-stage F is the wrong strength diagnostic for UJIVE, which stays
+  approximately unbiased as E[F] goes to one provided sqrt(K) times (E[F] - 1) is large; the
+  heterogeneity-robust plug-in variance also absorbs the Bekker many-instrument term; under
+  independent assignment plain robust standard errors suffice and clustering by examiner is never
+  justified; clustered assignment changes the estimator as well as the standard error, requiring
+  leave-own-cluster-out UJIVE.
+- Binds when: any design where cases are assigned to decision-makers who differ in strictness and
+  the assignment is as good as random within a stratum. Judges, patent examiners, disability
+  assessors, loan officers, child-protection investigators, radiologists, immigration officers,
+  content moderators, and platform review queues that route by roster.
+- Scope limits: the clustering argument (Abadie-Athey-Imbens-Wooldridge) is proved for iid
+  assignment with a fixed number of examiners, and the extension to many examiners is asserted as
+  natural rather than proved (their words). MST-style extrapolation has not been formalized for
+  many decision-makers or controls, so do not carry the extrapolation ladder into a leniency
+  design without saying so.
+- Implement: the authors' own R package ManyIV (github.com/kolesarm/ManyIV), row in
+  references/details.md, template block in scripts/iv_template.R. Chyn-Frandsen-Leslie 2025
+  (JEL 63(2): 401-439) is the companion practitioner's guide the paper positions itself against.
+- Quote: "small first-stage F statistics need not worry a researcher using UJIVE"; on clustering,
+  "this line of reasoning would never justify clustering on examiners (as is sometimes done in
+  practice)"; on the many-dummy 2SLS standard errors in their reanalysis, "a difference that
+  reflects statistical pathology rather than efficiency gains."
+
 ## Named disputes the skill carries
 
 1. Just-identified t-test: Keane-Neal (abandon it; power asymmetry is the binding problem) vs
@@ -138,6 +191,18 @@ Econometrica 86(5): 1589-1619. Key: `mogstad2018using`.
 2. Overid rejections: invalidity vs heterogeneity (both canon papers, plus
    Mogstad-Torgovitsky-Walters 2021). Not a dispute between authors but a fork in
    interpretation the skill refuses to collapse.
+3. Instrument-strength standard: Keane-Neal's robust-F-about-50 bar governs 2SLS bias in
+   few-instrument designs, while Goldsmith-Pinkham-Hull-Kolesár 2026 hold that F is the wrong
+   statistic for UJIVE in a many-examiner design, where the quantity that matters is sqrt(K)
+   times (E[F] - 1) and UJIVE stays approximately unbiased as E[F] approaches one. The two
+   papers do not cite each other, so this is a scope boundary the skill draws, not an argument
+   either set of authors picked. Default: the F-50 bar everywhere outside a leniency design,
+   the sqrt(K)(E[F] - 1) reading inside one, and name the estimator either way, since the bar
+   is a statement about 2SLS and not about IV in general.
+4. Weak-instrument fallback in leniency designs: the skill's general default is AR/CLR, but
+   Goldsmith-Pinkham-Hull-Kolesár flag that the many-instrument AR of Mikusheva-Sun 2022 and
+   Matsushita-Otsu 2024 are not robust to treatment-effect heterogeneity, which a leniency
+   design has by construction. Inside a leniency design the fallback is Yap 2025 instead.
 
 ## Primary papers cited through the canon
 
@@ -156,3 +221,12 @@ Goldsmith-Pinkham-Sorkin-Swift 2020 (the three shift-share pillars); Mogstad-Tor
 Walters 2021 (heterogeneity and multiple instruments); Autor-Dorn-Hanson 2013, Card 2009,
 Bartik 1991, Currie-Gruber 1996, Angrist-Krueger 1991 (worked designs);
 Jaeger-Ruist-Stuhler 2018 (dynamic shift-share caveat).
+
+Added with the leniency addendum (2026-08-04): Kolesár 2013 (UJIVE's origin);
+Frandsen-Lefgren-Leslie 2023 (average monotonicity, and their own test of the stronger
+condition); Sigstad 2026 (monotonicity is often violated in judicial panels, and the
+disagreements are too small to bias the estimates much); Chyn-Frandsen-Leslie 2025 (the
+companion examiner-design practitioner's guide in JEL); Blandhol et al. 2026 (linearity of
+E[z|w] in the covariates as a necessary condition); Yap 2025 (many-weak-instrument inference
+that survives treatment-effect heterogeneity); Frandsen-Leslie-McIntyre 2025 (cluster jackknife
+IV, the leave-own-cluster-out route under clustered assignment).

--- a/skills/iv/references/details.md
+++ b/skills/iv/references/details.md
@@ -1,6 +1,6 @@
 # IV lookup details
 
-Heavy reference content the SKILL.md points into. Current as of 2026-07-28.
+Heavy reference content the SKILL.md points into. Current as of 2026-08-04.
 
 ## The F ladder (Keane-Neal Table 1)
 
@@ -123,6 +123,67 @@ elasticity -1.08 (0.46); TSLS with the trivalued instrument -1.014 (0.384), LIML
 (0.384). OLS understates the demand elasticity by half. A supply shifter identifies demand and
 a demand shifter identifies supply; without one side's shifter, that side stays unidentified.
 
+## Leniency designs: the trace algebra and the worked numbers (GHK 2026)
+
+Goldsmith-Pinkham, Hull, and Kolesár 2026 (`goldsmith2026leniency`); their own software is the
+ManyIV row in the package index below.
+
+Every estimator built on a relative leniency measure Gx, i.e. betahat_G = y'Gx / x'Gx with
+Gx = ltilde + G nu, has approximate bias under homoskedastic errors
+
+    E[betahat_G] - beta ~= tr(G) / (K(E[F] - 1) + tr(G)) * cov(eps_i, nu_i) / var(nu_i),
+
+using the identity sum_i ltilde_i^2 / var(nu_i) = K(E[F] - 1) = n R^2 / (1 - R^2). The trace
+carries the whole comparison, with H the projection on the residualized instruments, M the
+covariate annihilator, L the number of controls, and K the number of decision-makers:
+
+| Estimator | G | tr(G) | Approximate bias |
+|---|---|---|---|
+| OLS | M | n - L | (1 - R^2) cov/var |
+| 2SLS | H | K | (1/E[F]) cov/var, i.e. 1/((1 - R^2) E[F]) of the OLS bias |
+| JIVE1 | M(I - D_Q)^-1 (H_Q - D_Q) | -L | -L/(K(E[F] - 1) - L) cov/var, the 2SLS bias times -E[F]/(K(E[F] - 1)/L - 1) |
+| IJIVE | M(I - diag(H))^-1 (H - diag(H))M | sum_i H_ii(1 - M_ii)/(1 - H_ii) | small in practice, so IJIVE tracks UJIVE |
+| UJIVE | H - diag(H_ii/(M_ii - H_ii))(M - H) | 0 | 0 |
+
+JIVE's residualized leniency subtracts the cell's overall grant rate, which itself depends on
+i's own treatment, so own-observation bias returns with the opposite sign to 2SLS. The JIVE
+bias is negligible when L is far below K, and UJIVE and JIVE coincide when there are no
+controls beyond a constant. The formula also gives the one-step implementation: UJIVE needs only the
+two projection diagonals, the fitted values Hx, and the residuals (M - H)x, all obtained from
+regressing x on the residualized instruments and on (z, w) separately.
+
+Delta-method standard errors survive weak instruments more often than the textbook worry
+suggests. Angrist-Kolesár (2024) show that delta-method inference turns overly optimistic only
+when the correlation between the numerator and the denominator of the estimator,
+
+    rho = (Sigma_12 - Sigma_22 beta*) / sqrt(Sigma_22(Sigma_11 - 2 beta* Sigma_12 + beta*^2 Sigma_22)),
+
+is high. As long as |rho| < 0.76, rejection rates for nominal 5 percent tests stay below 10
+percent at any instrument strength. GHK extend this to UJIVE with many instruments and
+controls, where rho no longer maps to the endogeneity parameter (Sigma picks up extra terms),
+but Sigma is consistently estimable, so rho can be plugged in for any particular null.
+
+Reanalysis of Farre-Mensa, Hegde, and Ljungqvist (2020) on patent examiners and startup
+outcomes: 32,514 first-time applications, art unit by year fixed effects, approval rate 0.649.
+Standard errors in parentheses. Column 2 uses their constructed approval-rate leniency
+measure, column 3 the full examiner dummy set.
+
+| Outcome | UJIVE | 2SLS, FMHL leniency | 2SLS, examiner dummies | OLS |
+|---|---|---|---|---|
+| any subsequent application | 0.173 (0.055) | 0.265 (0.023) | 0.232 (0.016) | 0.234 (0.006) |
+| log(1 + subsequent applications) | 0.323 (0.100) | 0.456 (0.037) | 0.374 (0.027) | 0.357 (0.009) |
+| any citation to subsequent patents | 0.183 (0.049) | 0.210 (0.020) | 0.173 (0.014) | 0.164 (0.005) |
+
+The many-dummy 2SLS standard errors are 3 to 4 times smaller than UJIVE's (0.055/0.016 = 3.4,
+0.100/0.027 = 3.7, 0.049/0.014 = 3.5), which the paper calls "statistical pathology rather than
+efficiency gains": overfitting pulls the 2SLS estimate toward OLS and shrinks its standard
+error at the same time, so the estimator mimics OLS in both. The examiner-dummy 2SLS estimates
+sit between OLS and UJIVE, the predicted signature. The 2SLS estimates on the constructed
+leniency measure run larger than UJIVE, which GHK read as many-covariate bias because that
+construction resembles JIVE. Balance coefficients in their Table 2 run about 10 times smaller
+than the treatment effects (venture capital funding: -0.024 with a standard error of 0.035),
+which is the magnitude comparison that makes a balance table informative.
+
 ## Shift-share checklists (BHJ 2025, worked examples attached)
 
 Shift path (worked on Autor-Dorn-Hanson 2013):
@@ -218,7 +279,8 @@ check aimed at that assumption.
 - Distance instruments (store, warehouse, delivery coverage): condition on generic distance,
   instrument with the specific version (the McClellan-Newhouse trick).
 
-## Package index (verified against package docs 2026-07-28; the ivmte row on 2026-07-29)
+## Package index (verified against package docs 2026-07-28; the ivmte row on 2026-07-29;
+the ManyIV row against the cloned source and a live run on its `fhl` data on 2026-08-04)
 
 | Package | Version | Role | Traps |
 |---|---|---|---|
@@ -229,7 +291,7 @@ check aimed at that assumption.
 | ShiftShareSE | 1.1.0 (CRAN, Kolesar) | reg_ss / ivreg_ss with method = "akm" / "akm0" (AKM0 = null-imposed, better small-K coverage); sector_cvar clusters shocks | X is the aggregated shift-share vector, shares go in W, the instrument never appears in the formula; the akm0 "se" is a normalized CI length, never a t-stat input |
 | ssaggregate | GitHub kylebutts/ssaggregate (0.0.0.9000, pushed 2025-11) | BHJ shock-level aggregation for the equivalent shift-level regression and the exposure-robust F | dev version, no CRAN release or visible tests; n/s/l/t are strings while vars/controls are formulas; template keeps a hand-coded fallback |
 | bpbounds | 0.1.8 (CRAN) | Balke-Pearl inequality checks and ACE bounds (binary Y, X; Z with 2-3 categories) | xtabs order is positional treatment-outcome-instrument with margin = 3 on the instrument |
-| ManyIV | GitHub kolesarm/ManyIV (0.0.2.9000) | many-instrument SEs (Kolesár 2018 minimum distance, JoE 204(1):86-100, distinct from Kolesár-Rothe 2018 on discrete running variables in the rdd skill), JIVE/UJIVE, Sargan + modified Cragg-Donald overid | rough dev API (man pages carry TODOs); for single-endogenous LIML/Fuller use ivmodel instead |
+| ManyIV | GitHub kolesarm/ManyIV (0.0.2.9000, HEAD 0b82852 dated 2025-06-17; source read and run 2026-08-04) | the leniency-design workhorse and the package `goldsmith2026leniency` uses for its own checklist: `ujive(formula, data, subset, na.action, tol = 1e-8, dropleverage = TRUE)` with formula `y ~ d + controls \| instruments`, returning class `IVResults` whose `$estimate` is a data frame with rows ols / tsls / ujive / "old ujive" / ijive1 / jive1 and columns `estimate`, `se_text` (textbook robust), `se_hte` (heteroskedasticity- and treatment-effect-heterogeneity-robust, the column the paper's tables report, and it absorbs the Bekker many-instrument term), plus `$IVData$F` (homoskedastic first-stage F), `$IVData$k` (instruments after collinear drops), `$IVData$l` (controls), `$IVData$n`, `$drop_obs`. Also `IVreg(..., inference = "standard"/"md")` for Kolesár 2018 minimum-distance many-instrument SEs (JoE 204(1):86-100, distinct from Kolesár-Rothe 2018 on discrete running variables in the rdd skill) and `IVoverid()` for Sargan + modified Cragg-Donald | the endogenous variable must be the FIRST right-hand term (put it second and another regressor is silently treated as endogenous, verified by running both orders); NO cluster argument, so the leave-own-cluster-out UJIVE that clustered assignment requires has to be hand-coded; no null-imposed SE, so the Yap (2025) weak-IV test is hand-coded too; `dropleverage = TRUE` silently drops leverage-one and singleton-dummy rows, `FALSE` returns NaN for UJIVE with a warning; no weights argument; rough dev API (man pages still carry TODOs); for single-endogenous LIML/Fuller use ivmodel |
 | AER | 1.2-17 (CRAN) | legacy ivreg (two-part formula only), kept for compatibility notes | superseded by the ivreg package |
 | ivmte | 1.4.0 (CRAN, 2021-09-17; GitHub jkcshea/ivmte slightly ahead, last commit 2024-08-27) | MST bounds and extrapolation, single entry point ivmte(): target 'ate'/'att'/'atu'/'late'/'genlate' with genlate.lb/.ub the u-interval (the alpha dial) or custom target.weight0/1; MTR space via m0/m1 formulas with uSpline(degree, knots, intercept); ivlike list of regression formulas as the estimands; shape flags m0/m1/mte .lb/.ub/.inc/.dec enforced on the audit grid (initgrid.nx/.nu, audit.nx/.nu); bootstraps for inference; cite `shea2023ivmte` | needs one of gurobi/cplexapi/rmosek/lpsolveapi; the only fully free solver (lpSolveAPI) is roughly an order of magnitude slower and cannot run the regression-based direct criterion (QCQP, Gurobi or MOSEK only), so with it always supply ivlike moments; point = TRUE forces GMM and silently ignores every shape constraint; the unobservable in m0/m1 must match uname (default u); m0/m1 bounds default to the observed outcome range, which is the bounded-outcome assumption |
 

--- a/skills/iv/scripts/iv_template.R
+++ b/skills/iv/scripts/iv_template.R
@@ -1,7 +1,8 @@
 # IV analysis template. Runnable end to end; every call signature verified against package
 # documentation on 2026-07-28 (fixest 0.14.2, ivreg 0.6-8, ivmodel 1.9.1, ivDiag 1.0.6,
-# ShiftShareSE 1.1.0, bpbounds 0.1.8, all CRAN; ssaggregate and ManyIV from GitHub; ivmte
-# 1.4.0, CRAN, verified 2026-07-29). Adapt the CONFIG block and run section by section.
+# ShiftShareSE 1.1.0, bpbounds 0.1.8, all CRAN; ssaggregate from GitHub; ivmte
+# 1.4.0, CRAN, verified 2026-07-29; ManyIV 0.0.2.9000 from GitHub, verified against the
+# source and run on its own fhl data 2026-08-04). Adapt CONFIG and run section by section.
 #
 # API traps older tutorials get wrong:
 #   - fixest: the IV part (endo ~ inst) must be the LAST formula element, after fixed effects
@@ -14,12 +15,16 @@
 #     excluded instruments; the three-part form (y ~ ex | en | in) avoids this
 #   - ivmte: point = TRUE silently ignores every shape constraint; the only fully free solver
 #     (lpSolveAPI) cannot run the regression-based direct criterion, so pass ivlike moments
+#   - ManyIV::ujive: the endogenous variable must be the FIRST right-hand term, before the
+#     controls; put it second and the package silently treats another variable as endogenous
 
 ## ---- CONFIG ----------------------------------------------------------------
 df <- your_data              # replace
 # y  = outcome; d = endogenous treatment; z = instrument(s); x1, x2 = exogenous controls;
 # cl = cluster id at the level of INSTRUMENT assignment (Imbens 2014's flu example:
 # physicians were randomized, so cluster on physician, not patient).
+# Section 6 adds two: examiner = decision-maker id (factor), cell = the strata within
+# which assignment is as good as random (factor, e.g. art unit by year).
 set.seed(94305)
 
 library(fixest); library(ivmodel); library(ivDiag)
@@ -89,29 +94,173 @@ summary(fit, diagnostics = TRUE)   # Weak instruments, Wu-Hausman, Sargan rows
 # reliable CUE, so use LIML with heteroSE = TRUE and report the Stata route
 # (ivreg2, cue + weakiv) when it matters. Interpret a Sargan/J rejection under the
 # heterogeneity rule (SKILL.md): divergent instruments may move different compliers.
-# Many instruments: JIVE/UJIVE and many-instrument-valid SEs (Kolesár 2018 minimum
-# distance, JoE 204(1):86-100; a different paper from Kolesár-Rothe 2018 on discrete
-# running variables, which belongs to rdd) live in
-# remotes::install_github("kolesarm/ManyIV"): IVreg(y ~ d + x1 | z1 + z2, data = df,
-# inference = "standard"), then IVoverid() -- dev-version API, check before relying on it.
+# Many instruments: many-instrument-valid SEs (Kolesár 2018 minimum distance, JoE
+# 204(1):86-100; a different paper from Kolesár-Rothe 2018 on discrete running variables,
+# which belongs to rdd) live in remotes::install_github("kolesarm/ManyIV"):
+# IVreg(y ~ d + x1 | z1 + z2, data = df, inference = "standard"), then IVoverid() --
+# dev-version API, check before relying on it. When the many instruments are
+# decision-maker dummies, go to section 6 instead: the estimator changes to UJIVE.
 
-## ---- 6. Shift-share, shift path (BHJ 2025) -----------------------------------
+## ---- 6. Leniency / examiner / judge designs (UJIVE) --------------------------
+# Trigger: treatment is decided by a decision-maker (examiner, judge, doctor, reviewer,
+# content moderator) assigned as good as randomly within a cell, and the K decision-maker
+# dummies are the instruments. K is large and so is the control count L (the cell fixed
+# effects). That combination is what breaks 2SLS.
+# UJIVE is the estimator (Goldsmith-Pinkham, Hull, and Kolesár 2026). It instruments d
+# with a leave-one-out estimate of covariate-residualized ("relative") leniency, in matrix
+# form Gd with G = H - diag(H_ii/(M_ii - H_ii))(M - H), and tr(G) = 0 is the unbiasedness
+# condition. 2SLS carries a bias that scales in K and points at OLS. JIVE1 carries a
+# many-covariate bias that scales in L. UJIVE removes both. Trace algebra and the paper's
+# empirical numbers are in references/details.md.
+library(ManyIV)   # remotes::install_github("kolesarm/ManyIV"), the paper's own package
+# API verified against the source at commit 0b82852 (2025-06-17) and run on the package's
+# own fhl data on 2026-08-04:
+#   ujive(formula, data, subset, na.action, tol = 1e-8, dropleverage = TRUE)
+#   formula is y ~ d + controls | instruments, and d MUST come first on the right.
+#   Returns class "IVResults". $estimate is a data frame with rows ols, tsls, ujive,
+#   "old ujive", ijive1, jive1 and columns estimate, se_text, se_hte. se_hte is the
+#   heteroskedasticity- and treatment-effect-heterogeneity-robust SE and is the one the
+#   paper's tables report; it also absorbs the Bekker many-instrument term. se_text is the
+#   textbook robust column and is too small in this design, so do not report it.
+#   $IVData holds F (the homoskedastic first-stage F), k (instrument count AFTER collinear
+#   drops), l (control count), n. $drop_obs holds the row indices dropped for leverage one
+#   or singleton dummies. dropleverage = FALSE keeps them and returns NaN for UJIVE.
+#   Factors go in raw: | examiner expands to the full dummy set, collinear columns dropped
+#   with a message. There is no weights argument.
+uj <- function(lhs, rhs = "d") stats::as.formula(   # one spec, reused by every step below
+  paste0(lhs, " ~ ", rhs, " + cell | examiner"))
+
+## 6a. Step 1: controls, estimator, and the SE decision, all before any regression.
+# Controls are whatever institutional knowledge says makes assignment as good as random,
+# and nothing more: in the patent setting, art unit by year, because the examiner pool
+# within an art unit changes slowly. Both counts matter, K = examiners and L = controls.
+# CLUSTERING RULE: cluster at the level at which ASSIGNMENT varies, not at the level at
+# which residuals correlate. Under the random-instrument view (Abadie et al. 2020, 2023)
+# what has to be uncorrelated is the product (relative leniency x error), so independent
+# case-by-case assignment needs only robust SEs, and clustering "just in case" buys overly
+# conservative inference. Cluster when a block is assigned together, e.g. one doctor covers
+# a whole shift: then cluster on shift. This argument never justifies clustering on the
+# examiner. Applied work sometimes does it anyway.
+# CONSEQUENCE IF YOU DO CLUSTER: the ESTIMATOR changes as well as the SE, because
+# leave-one-out leniency has to become leave-own-cluster-out. Otherwise within-
+# cluster correlation between d_i and eps_j puts the mechanical bias back. ujive() has NO
+# cluster argument (formals are formula, data, subset, na.action, tol, dropleverage), so
+# ManyIV cannot do this. Hand-code the leave-own-cluster-out version (Frandsen, Leslie, and
+# McIntyre 2025; Kolesár, Min, et al. 2026) and do not paste clustered SEs onto this fit.
+
+## 6b. Step 2: balance, as the SAME UJIVE specification with the covariate as the outcome.
+covs <- c("w1", "w2", "w3")               # predetermined covariates, one row each
+bal <- t(sapply(covs, function(v)
+  unlist(ujive(uj(v), data = df)$estimate["ujive", c("estimate", "se_hte")])))
+cbind(bal, t = bal[, 1] / bal[, 2])
+# The balance regression is the treatment specification with the covariate swapped in as
+# the outcome, still instrumenting d with the examiner dummies. So an imbalance coefficient
+# sits on the same scale as the treatment effect and reads directly as the bias it would
+# cause. Do NOT run the reduced form of the covariate on the instrument in its place.
+# Two more WRONG alternatives the paper rules out: (i) regressing observables on a
+# constructed leniency measure, which manufactures a mechanical correlation, and which even
+# in leave-out form suffers errors-in-variables bias from estimation noise in the measure;
+# (ii) the joint F on the full examiner dummy set, whose default distribution is invalid
+# with many examiners (Anatolyev and Sølvsten 2023).
+# Read the magnitudes and do not stop at the stars. In the paper's reanalysis the balance
+# coefficients run about 10x smaller than the treatment effects, and that gap is what makes
+# the design credible.
+# Sample trap: the dropped rows depend on the controls and instruments, so they are common
+# across outcomes, but NAs in one covariate shrink that row's sample. Compare $drop_obs
+# lengths across rows, or subset to complete cases once up front.
+
+## 6c. Step 2b: exclusion check, same machinery on a POST-assignment variable.
+ujive(uj("months_under_review"), data = df)$estimate["ujive", ]
+# Their instance is months under review: an examiner moves outcomes through decision speed
+# as well as through approval. A significant coefficient says the design does not recover
+# the effect of the named treatment. The fix is a second treatment (or approval interacted
+# with discretized review time), both instrumented by the same dummies in one UJIVE call.
+
+## 6d. Step 3: estimate by UJIVE, and read the alternatives as diagnostics.
+fit <- ujive(uj("y"), data = df)
+fit                                       # prints all six rows plus F, n, K, L
+fit$estimate["ujive", c("estimate", "se_hte")]         # the headline pair
+# The tsls row (examiner dummies) lands between ols and ujive exactly when the
+# many-instrument bias bites, and its SE is the tell: in the paper's reanalysis the
+# many-dummy 2SLS SEs come out 3 to 4 times smaller than UJIVE's, which is the same
+# overfitting that pulls the point estimate toward OLS. A large ujive-to-tsls SE ratio
+# confirms the diagnosis and is never a cost of using UJIVE. jive1 next to ujive prices the
+# many-covariate bias. ijive1 usually lands near ujive.
+# Do NOT build a leniency measure by hand and plug it into a just-identified IV. The
+# construction choices (leave-out or not, which cases enter) drive the bias, and the
+# second-stage SEs ignore estimation error in the measure. For the same reason, do not read
+# design strength off the variance of a constructed leniency measure: estimation noise in
+# the measure inflates it. The UJIVE standard error is the power statistic.
+
+## 6e. Strength: the first-stage F is the WRONG diagnostic here.
+K <- fit$IVData$k                          # post-collinearity-drop instrument count
+sqrt(K) * (fit$IVData$F - 1)               # the statistic to report, in place of F
+# UJIVE stays approximately unbiased and consistent even when instruments are weak enough
+# that E[F] converges to one, so long as sqrt(K) * (E[F] - 1) is large. That product is the
+# signal-to-noise ratio of the estimator's denominator, which is what the delta-method
+# normal approximation needs. An F of 1.2 with K = 750 examiners gives sqrt(750) * 0.2 =
+# 5.5, so a first stage barely above one is no alarm in a design this wide.
+# The paper states no cutoff for sqrt(K) * (E[F] - 1), so report the number and run 6f when
+# it is small. Do not import the Keane-Neal ladder from section 3, which is about 2SLS.
+
+## 6f. Weak-instrument fallback when sqrt(K) * (E[F] - 1) is small: Yap (2025).
+# To test H0: beta = b0, compute eps_i0, the residual from projecting y - d * b0 on the
+# covariates, then compute the UJIVE standard error exactly as usual but with eps_i0 in
+# place of the UJIVE residual, and check whether UJIVE differs significantly from b0.
+# Invert over a grid of b0 for the interval.
+# NOT AVAILABLE in ManyIV: ujive() returns only the unrestricted se_hte and has no
+# null-imposed option. Hand-code it from ManyIV:::ujive.fit, whose HTE numerator is
+# sum((GY * MD + epD)^2): put eps_i0 where (YtW - DtW * beta) enters epD and where
+# (Y - D * beta) enters GYujive, keeping the same denominator. $IVData$Y/$D/$Z/$W return
+# the cleaned matrices to rebuild it on.
+# Do NOT substitute the Mikusheva-Sun (2022) many-instrument AR or Matsushita-Otsu (2024):
+# neither is robust to treatment-effect heterogeneity. Yap (2025) is.
+
+## 6g. Step 4: average monotonicity (their test, built on Abadie 2002 and Kitagawa 2015).
+# Keep the treatment, instruments, and controls, and replace the outcome with ytilde =
+# v * d for any v determined BEFORE assignment. UJIVE then estimates a convex weighted
+# average of v under exactly the weights of the main estimate. If v is BINARY that average
+# must lie in [0, 1]. Landing outside [0, 1] rejects.
+df$v <- as.numeric(df$y == 0)             # binary v: an indicator for one outcome value
+ujive(uj("I(v * d)"), data = df)$estimate["ujive", c("estimate", "se_hte")]
+# The condition at stake is average monotonicity (Frandsen, Lefgren, and Leslie 2023),
+# which is weaker than Imbens-Angrist uniform monotonicity and is necessary and sufficient
+# for the LATE weights to be nonnegative. Their Figure 1 sweeps v over indicators for every
+# outcome value, so loop over the support and plot estimates with 95% intervals. This test
+# catches gross violations only: pushing a weighted average outside [0, 1] takes
+# on-average defiers who are both numerous and unlike the average complier.
+
+## 6h. Step 5: characterize compliers for external validity, same trick with v not binary.
+# v * d as the outcome gives TREATED compliers. Putting one minus the treatment in as the
+# treatment gives UNTREATED compliers, which random assignment says should agree. Pool them
+# efficiently (Angrist, Hull, and Walters 2023) with dt = 2 * d - 1, taking values in
+# {-1, 1}: run UJIVE of v * dt on dt, keeping the controls and the examiner instruments.
+df$dt <- 2 * df$d - 1
+comp <- t(sapply(covs, function(v)
+  unlist(ujive(uj(paste0("I(", v, " * dt)"), "dt"),
+               data = df)$estimate["ujive", c("estimate", "se_hte")])))
+cbind(comp, sample_mean = sapply(covs, function(v) mean(df[[v]], na.rm = TRUE)))
+# The complier-vs-sample gap is the external-validity statement the LATE licenses. Small
+# gaps let you say the LATE approximates the population effect. Complier means outside the
+# logical range of v are a second reading of the monotonicity test.
+
+## ---- 7. Shift-share, shift path (BHJ 2025) -----------------------------------
 # Objects: S = N x K share matrix (rows = units, cols = shocks/sectors), gk = length-K
 # shock vector, z_ss = as.vector(S %*% gk) the unit-level instrument.
-# 6a. Effective number of shifts, the pre-test design diagnostic:
+# 7a. Effective number of shifts, the pre-test design diagnostic:
 sk <- colMeans(S); sk <- sk / sum(sk)      # importance weights (weight rows if design is)
 1 / sum(sk^2)                              # report next to N; small = no asymptotics protect you
-# 6b. Incomplete shares: if rowSums(S) is not 1 for everyone, CONTROL the sum of shares
+# 7b. Incomplete shares: if rowSums(S) is not 1 for everyone, CONTROL the sum of shares
 # (interacted with period FE in stacked designs); do not renormalize.
 df$sum_shares <- rowSums(S)
-# 6c. Exposure-robust inference (AKM / AKM0), Kolesar's ShiftShareSE:
+# 7c. Exposure-robust inference (AKM / AKM0), Kolesar's ShiftShareSE:
 library(ShiftShareSE)
 ivreg_ss(y ~ x1 + sum_shares | d, X = z_ss, data = df, W = S,
          method = c("ehw", "akm", "akm0"))
 # reg_ss(y ~ x1 + sum_shares, X = z_ss, data = df, W = S, method = c("akm", "akm0"))
 # gives the reduced form; sector_cvar= clusters shocks. AKM0 inverts the null-imposed
 # test and has better coverage with few effective shifts.
-# 6d. Equivalent shift-level regression (BHJ): reproduces the unit-level coefficient
+# 7d. Equivalent shift-level regression (BHJ): reproduces the unit-level coefficient
 # exactly and delivers the honest exposure-robust first-stage F. R port of ssaggregate:
 # remotes::install_github("kylebutts/ssaggregate")  (dev version; hand-code if in doubt)
 # library(ssaggregate)
@@ -120,10 +269,10 @@ ivreg_ss(y ~ x1 + sum_shares | d, X = z_ss, data = df, W = S,
 # ind <- merge(ind, shocks, by = "sector")
 # sl  <- feols(y ~ 1 | d ~ g, data = ind, weights = ~s_n, vcov = ~shock_cluster)
 # fitstat(sl, ~ ivf1)                      # the exposure-robust F to report
-# 6e. Balance: g_k on shock-level confounder proxies (shift-level regression), and
+# 7e. Balance: g_k on shock-level confounder proxies (shift-level regression), and
 # predetermined unit covariates on z_ss with the akm SEs above.
 
-## ---- 7. Shift-share, share path (GPSS 2020) ----------------------------------
+## ---- 8. Shift-share, share path (GPSS 2020) ----------------------------------
 # Rotemberg weights: which shares carry the design. Hand-coded from the GPSS
 # just-identified decomposition (reference implementation: github.com/paulgp/bartik-weight,
 # Stata and R); this block is OUR implementation, label it as such:
@@ -139,7 +288,7 @@ sort(alpha_k, decreasing = TRUE)[1:5]     # weights sum to 1, some may be negati
 # Many shares: TSLS is biased toward OLS; use JIVE (ManyIV), LIML/Fuller (ivmodel),
 # or HFUL, and read dispersion across pooling schemes under the heterogeneity rule.
 
-## ---- 8. Formula instruments: recenter or control (Borusyak-Hull 2023) --------
+## ---- 9. Formula instruments: recenter or control (Borusyak-Hull 2023) --------
 # Trigger: treatment/instrument = known formula f(shocks g; exposure w). Shock
 # exogeneity is NOT enough; compute the expected instrument and recenter.
 S_draws <- 1999
@@ -152,13 +301,13 @@ df$z_re <- df$z_formula - mu
 rec <- feols(y ~ x1 | d ~ z_re, data = df, vcov = ~cl)   # or control for mu instead:
 # feols(y ~ x1 + mu | d ~ z_formula, ...); in natural experiments prefer controlling
 # for SEVERAL candidate mu's from different guessed assignment processes (double robust).
-# 8a. RI balance test: regress z_re on predetermined covariates; joint p from the
+# 9a. RI balance test: regress z_re on predetermined covariates; joint p from the
 # sum-of-squared-fitted-values statistic across draws:
 Tstat <- function(zv) { f <- fitted(feols(zv ~ x1 + x2, data = df)); sum(f^2) }
 T_obs  <- Tstat(df$z_re)
 T_null <- apply(perm_z - mu, 2, Tstat)
 mean(T_null >= T_obs)                     # RI joint balance p-value
-# 8b. RI confidence interval by Hodges-Lehmann inversion (NEVER the distribution of
+# 9b. RI confidence interval by Hodges-Lehmann inversion (NEVER the distribution of
 # the estimator across re-randomized shocks: that instrument has a true first stage
 # of zero). T(b) = mean(z_re * (y - b * d)):
 ri_p <- function(b) {
@@ -174,10 +323,10 @@ if (acc[1] == grid[1] || acc[length(acc)] == grid[length(grid)])
   warning("RI: accepted set touches a grid endpoint. It is unbounded, widen the grid.")
 runs <- split(acc, cumsum(c(1, diff(acc) > 1.5 * STEP)))   # contiguous pieces
 lapply(runs, range)                       # the RI 95% set, a union printed as a union
-# 8c. Placebo outcomes (lagged y as outcome) with the same RI machinery test shock
+# 9c. Placebo outcomes (lagged y as outcome) with the same RI machinery test shock
 # exogeneity itself; the balance test only validates the counterfactual specification.
 
-## ---- 9. OPTIONAL: beyond-LATE extrapolation bounds (MST 2018, ivmte) ---------
+## ---- 10. OPTIONAL: beyond-LATE extrapolation bounds (MST 2018, ivmte) --------
 # When the policy question is a rollout or an incentive change, the target is a PRTE, not the
 # LATE: bound a generalized LATE extrapolated alpha beyond the complier interval, anchored by
 # the IV-like estimands under stated MTR restrictions (Mogstad-Santos-Torgovitsky 2018,
@@ -232,6 +381,7 @@ if (requireNamespace("ivmte", quietly = TRUE) && have_solver) {
 ## ---- Session ----------------------------------------------------------------
 # Pin: fixest >= 0.14 (IV formula order), ivreg >= 0.6 (three-part formula),
 # ivmodel 1.9.1 (KClass capitalization), ivDiag >= 1.0.6 (F_stat vector incl.
-# F.effective), ShiftShareSE 1.1.0 (X-vs-W roles), bpbounds >= 0.1.8; optional
-# ivmte 1.4.0 plus an LP solver (section 9).
+# F.effective), ShiftShareSE 1.1.0 (X-vs-W roles), bpbounds >= 0.1.8, ManyIV
+# 0.0.2.9000 (GitHub only, se_hte column and no cluster argument, section 6);
+# optional ivmte 1.4.0 plus an LP solver (section 10).
 sessionInfo()

--- a/skills/litreview/SKILL.md
+++ b/skills/litreview/SKILL.md
@@ -46,7 +46,7 @@ whenever you are going to process the results (it carries abstracts, which is wh
 on); the plain text form is for showing the user.
 
 Write two or three query strings, not one. Strip filler, keep substantive nouns, expand acronyms
-(SAE becomes "sparse autoencoder"), and vary the vocabulary across fields: economists write
+(DiD becomes "difference-in-differences"), and vary the vocabulary across fields: economists write
 "algorithmic collusion", computer scientists write "multi-agent reinforcement learning pricing".
 Run the variants as parallel Bash calls in a single message.
 

--- a/skills/synthetic-control/scripts/synth_template.R
+++ b/skills/synthetic-control/scripts/synth_template.R
@@ -138,6 +138,9 @@ plot(asyn)
 ## ---- 9. Factor-model / matrix-completion robustness (fect) -------------------
 library(fect)
 # nboots = 200 in both calls is a quick-run value; raise to 2000 or more for publication.
+# r = c(0, 5) is the CV search range for the number of latent factors, min then max, and 5 is
+# fect's own default ceiling rather than a reduced setting. Read fout$r.cv afterwards: if the
+# selected count comes back at 5 the ceiling bound the search, so raise the max and refit.
 fout <- fect(y ~ treated + income, data = df, index = c("unit", "year"),
              method = "ife", CV = TRUE, r = c(0, 5),
              se = TRUE, vartype = "bootstrap", nboots = 200)


### PR DESCRIPTION
Folds Goldsmith-Pinkham, Hull, and Kolesár (2026), ["Leniency Designs: An Operator's Manual"](https://doi.org/10.1257/jep.20251480) (JEP 40(3):213-240), into the `iv` skill, and restructures the README skills table on request.

## The paper

New `iv` section covering UJIVE and the paper's five checks, plus the canon entry, eight bib keys, and a template section verified by running the authors' own `ManyIV` package.

It corrects three things the skill already said:

- **Monotonicity.** The skill priced examiner designs against uniform monotonicity. The operative condition is average monotonicity (Frandsen-Lefgren-Leslie 2023), strictly weaker and necessary and sufficient for nonnegative weights, and it is now testable.
- **Instrument strength.** The Keane-Neal F-about-50 bar prices 2SLS bias and does not transfer to a jackknife estimator. In a leniency design the statistic is `sqrt(K)(E[F] - 1)`.
- **Clustering.** Clustering on the examiner is never justified under independent assignment, and clustered assignment changes the *estimator* (leave-own-cluster-out UJIVE), not only the standard error.

The first two are recorded as disputes in `canon.md`, flagged as scope boundaries the skill draws, since Keane-Neal and the leniency paper do not cite each other.

`causal-design` had no triage route to a leniency design, so the new section would have been unreachable except by direct trigger. Added.

## README

The single skills table splits into 13 generic research skills and a seven-row causal table carrying a "Built on" column of short-form citations. Links go to the publisher where the article is free there and to the working paper or preprint otherwise. All 25 checked: the 403s are Cloudflare blocking curl at AEA, OUP, Annual Reviews, and Sage, and each of those DOIs 302s to the right article page.

`preregister` has no `references/canon.md`, so its row lists the four papers it cites inline, and the note under the table says so.

## Also

- `synth_template.R`: label `fect r = c(0, 5)`. It is fect's own default CV ceiling (verified in fect 2.4.5 `R/default.R`), not a reduced quick-run setting, and the template now says to check `fout$r.cv` for the ceiling binding.
- `field-experiment/references/canon.md:20`: the compressed "do not pair" line read as settled when the dispute sits 100 lines below. Qualified inline.
- `council` and `litreview`: drop `conjoint`, `GAN/SAE/embedding methods`, and the SAE acronym example.

## Verification

- bibtex 0.99e parses the bib clean, 163 entries, zero warnings
- all six R templates parse and are byte-identical to the working copies
- 20 skills, no leak terms
- one undocumented `ManyIV` trap found by running it: `ujive()` takes the endogenous variable as the first RHS term, and getting the order wrong changes the estimate silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)