### PR TITLE
Move the reviewing caution above the causal inference section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Then read [SETUP.md](SETUP.md): it names every path and helper the skills assume
 
 `agents/tikz-reviewer.md` is the adversarial visual critic `tikz-iterate` loops on. `slide-tooling/` holds the machinery the slide skills share: the staging filter, the fit and staging gates, the offline checker, a starter theme, and vendored MathJax and two webfont families; its README documents all of it.
 
+### A note of caution on reviewing
+
+`review-paper` is built for your own manuscripts: a pre-submission check on a draft before you send it out, to be run only on work you wrote. Do not use it, or any generative AI tool, to review other people's submissions. Journals are explicit about this: [Management Science's submission guidelines](https://pubsonline.informs.org/page/mnsc/submission-guidelines) tell the review team directly that they "should not upload any part of a manuscript submitted to *Management Science* into a generative AI tool such that it might compromise confidentiality and/or copyright", and JMR's [submission guidelines](https://journals.sagepub.com/author-instructions/mrj) defer to Sage's [ChatGPT and generative AI policy](https://www.sagepub.com/en-us/nam/chatgpt-and-generative-ai), which reserves the right to take action when a reviewer breaches peer-review confidentiality with GenAI tools. If you referee, check the journal's AI policy before involving any tool at all.
+
 ### Causal inference and natural experiments
 
 Seven skills for identification-strategy work. Each one is built on a canon it has actually
@@ -67,10 +71,6 @@ These skills are opinionated. They pick defaults (which estimator, which standar
 bar an instrument has to clear) and say so, and where the literature genuinely disagrees they
 name both sides instead of quietly picking one. Read the skill's `references/canon.md` before
 adopting a default you would have to defend to a referee.
-
-### A note of caution on reviewing
-
-`review-paper` is built for your own manuscripts: a pre-submission check on a draft before you send it out, to be run only on work you wrote. Do not use it, or any generative AI tool, to review other people's submissions. Journals are explicit about this: [Management Science's submission guidelines](https://pubsonline.informs.org/page/mnsc/submission-guidelines) tell the review team directly that they "should not upload any part of a manuscript submitted to *Management Science* into a generative AI tool such that it might compromise confidentiality and/or copyright", and JMR's [submission guidelines](https://journals.sagepub.com/author-instructions/mrj) defer to Sage's [ChatGPT and generative AI policy](https://www.sagepub.com/en-us/nam/chatgpt-and-generative-ai), which reserves the right to take action when a reviewer breaches peer-review confidentiality with GenAI tools. If you referee, check the journal's AI policy before involving any tool at all.
 
 ## Quarto for slides
 


### PR DESCRIPTION
Moves `### A note of caution on reviewing` so it sits directly after the skills table and above `### Causal inference and natural experiments`, rather than between that section and Quarto.

Pure reordering. The two blocks are swapped with no edits to either: the file is the same length and the same multiset of lines. The heading text is unchanged, so the `#a-note-of-caution-on-reviewing` anchor in the `review-paper` table row still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Upy6BW2EWf1wNX3EcqSgcH