### PR TITLE
Add the Rambachan-Roth design-based entry so did cites it by key

### DIFF
--- a/skills/causal-design/references/causal.bib
+++ b/skills/causal-design/references/causal.bib
@@ -2160,3 +2160,19 @@
   year    = {2007},
   doi     = {10.1007/s11129-007-9024-6}
 }
+
+% VoR
+% Crossref-verified 2026-08-05. The design-based-uncertainty paper, distinct from
+% rambachan2023credible (the HonestDiD sensitivity paper). Cited in did for the clustering
+% rule and named by abadie2023clustering as the extension to other sampling and assignment
+% processes. Note the year: it was a working paper for years and is now JASA 2025.
+@article{rambachan2025design,
+  author  = {Rambachan, Ashesh and Roth, Jonathan},
+  title   = {Design-Based Uncertainty for Quasi-Experiments},
+  journal = {Journal of the American Statistical Association},
+  year    = {2025},
+  volume  = {121},
+  number  = {553},
+  pages   = {477--491},
+  doi     = {10.1080/01621459.2025.2526700}
+}

--- a/skills/did/SKILL.md
+++ b/skills/did/SKILL.md
@@ -194,7 +194,8 @@ Poisson, or an extensive/intensive margin split.
 ## Inference
 
 Cluster at the level at which treatment is independently assigned (state policies: state). This
-is the design-based rule (Rambachan-Roth, the DiD instance of Abadie-Athey-Imbens-Wooldridge),
+is the design-based rule (`rambachan2025design`, the DiD instance of
+`abadie2023clustering`),
 and group fixed effects do not get you out of it: adding them "allows for group-specific linear
 trends in the underlying potential outcomes series but does not change the answer to the
 question whether one needs to adjust for clustering" (AAIW, on the common-timing case, which


### PR DESCRIPTION
The design-based-uncertainty paper was cited in prose in `did` with no bib entry. It is now published: JASA 121(553): 477-491, doi 10.1080/01621459.2025.2526700, Crossref-verified. Kept distinct from `rambachan2023credible`, the HonestDiD sensitivity paper, which `did` also cites for a different purpose.

Every backticked key in every public skill resolves; no private-skill names anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfQJ1JMk1AmoHChKk55UDm