### PR TITLE
README: eight causal skills, not seven

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Then read [SETUP.md](SETUP.md): it names every path and helper the skills assume
 
 ### Causal inference and natural experiments
 
-Seven skills for identification-strategy work. Each one is built on a canon it has actually
+Eight skills for identification-strategy work. Each one is built on a canon it has actually
 read, so the advice carries the citation that licenses it, and each keeps a
 `references/canon.md` recording what every source settles, which disputes stay open, and where
 the skill departs from the paper. The last column is that canon.


### PR DESCRIPTION
The causal inference section's intro still said "Seven skills for identification-strategy work" while the table below it lists eight after `conjoint` was added. One-word count fix, nothing else changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Upy6BW2EWf1wNX3EcqSgcH