### PR TITLE
Swap the local daily driver to qwen3.8:27b

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ While Claude is working on something long, `/btw` asks a quick question without 
 
 Not many people know this one. If you need to work with material that is confidential, unpublished, or covered by an agreement about where data may go, or you need to work with no network at all on a flight or a bus ride, you can run a language model on your own computer. [Ollama](https://ollama.com) is the easiest way in: a free, open-source tool that downloads and runs open-weight models locally, so prompts and documents are processed on your machine and never transmitted to any cloud service or company. It is a separate tool from Claude Code, and the models it serves are open-weight ones from other labs; many of them are now performant enough for real work, though the larger ones want capable hardware. Setup is on the [download page](https://ollama.com/download), and the [project repository](https://github.com/ollama/ollama) has the rest.
 
-On a 48 GB Apple Silicon machine the set I keep installed is `qwen3.6:35b` for reasoning and coding, `gemma4:12b` when I want a fast answer, and `glm-ocr` for pulling tables and equations out of scanned PDFs, with audio handled separately by `mlx-whisper` since Ollama accepts text and images but not sound; pull the plain tags rather than the `-mlx` ones, which are faster but silently ignore images.
+On a 48 GB Apple Silicon machine the set I keep installed is `qwen3.8:27b` for reasoning and coding, `gemma4:12b` when I want a fast answer, and `glm-ocr` for pulling tables and equations out of scanned PDFs, with audio handled separately by `mlx-whisper` since Ollama accepts text and images but not sound; pull the plain tags rather than the `-mlx` ones, which are faster but silently ignore images.
 
 ## License and credit
 


### PR DESCRIPTION
Qwen3.8-27B (released 14 Aug 2026, Apache 2.0) replaces `qwen3.6:35b` in the local-models sentence.

Measured head-to-head, same prompts, temperature 0, same Ollama version, one model resident at a time:

| | qwen3.6:35b | qwen3.8:27b |
|---|---|---|
| Architecture | MoE 36.0B (~3B active) | Dense 27.3B |
| Disk | 23 GB | 17 GB |
| Text | 83.0 tok/s | 33.1 tok/s |
| Vision | 88.3 tok/s | 21.6 tok/s |
| R code on a staggered-DiD question | fabricated `csdid()` | correct `att_gt()` + `sunab()` |
| Journal figure | correct, vague on ranges | correct, exact axis ranges |

Both models diagnosed the Goodman-Bacon negative-weighting problem correctly. The split is what they wrote next: 3.6 called `csdid()`, which is a Stata module and not a function in the R `did` package, and attributed `did_multiplegt()` to `did` when it belongs to DIDmultiplegt. Reproduced three weeks apart, so not a sampling artifact. 3.8's two errors were minor (`cluster.var` for `clustervars`, and `summary()` where `aggte()` is needed).

Requires Ollama 0.32.12 or newer; 0.32.7 returns a 412 on pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wuLf6bstJpDpKUsKkRzr7