### PR TITLE
Add an output-style template and a note on where rules belong

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,18 @@ Everything in this repository, including the two example decks and their figures
 ```bash
 git clone https://github.com/ericluo04/claude-academic-workflow
 cd claude-academic-workflow
-mkdir -p ~/.claude/skills ~/.claude/agents ~/.claude/assets
+mkdir -p ~/.claude/skills ~/.claude/agents ~/.claude/assets ~/.claude/output-styles
 cp -R skills/* ~/.claude/skills/
 cp agents/tikz-reviewer.md ~/.claude/agents/
 cp -R slide-tooling ~/.claude/assets/quarto-yale
+cp output-styles/concise-research.md ~/.claude/output-styles/
 ```
 
 Then read [SETUP.md](SETUP.md): it names every path and helper the skills assume (the Crossref contact address, the PDF helper, the Overleaf glob) and how to adjust each one. `CLAUDE.md` is the author's working global configuration, shared as an example. The three `style/house.md` files in the slide skills are stubs for your own taste: author line, closing-slide wording, palette rationale, density calibration.
 
 ## The global CLAUDE.md
 
-`CLAUDE.md` is what Claude Code loads into every session as standing instructions; this one carries the author's voice rules (how prose should read) and working style (parallel subagents by default, decisions through the option picker, judgment calls raised before acting), which shape every skill's output without being repeated in any of them. If you adapt this repo, add your own standing context here: quants will want a computing-grid section (cluster login, Slurm citizenship rules, where storage lives), plus anything else Claude should know in every session, like data locations or preferred stacks.
+`CLAUDE.md` is what Claude Code loads into every session as standing instructions; this one carries the author's voice rules (how prose should read) and working style (parallel subagents by default, decisions through the option picker, judgment calls raised before acting), which shape every skill's output without being repeated in any of them. If you adapt this repo, add your own standing context here: quants will want a computing-grid section (cluster login, Slurm citizenship rules, where storage lives), plus anything else Claude should know in every session, like data locations or preferred stacks. What belongs there rather than in an output style is [further down](#claudemd-versus-output-styles).
 
 ## Skills
 
@@ -148,6 +149,16 @@ A few of the higher-leverage discoveries from building this, none of them obviou
   Consumer connectors (travel, tickets, restaurants) exist too, and occasionally earn their keep.
 
 - An AI assistant sitting in your Zoom calls is worth having, and which one matters less than having one: Notion AI's meeting notes, Zoom's own AI Companion, and Otter all do the job. The value shows up weeks later, when you come back to a project after time away and the meeting summaries and extracted to-dos are how you remind yourself what is going on and reorganize. They also make the discussion searchable, so "what did we decide about X" has an answer without re-watching anything.
+
+### CLAUDE.md versus output styles
+
+`CLAUDE.md` and an output style reach the model differently, and that decides which rules belong where. `CLAUDE.md` arrives [as a user message after the system prompt, not as part of the system prompt itself](https://code.claude.com/docs/en/memory#claude-isn-t-following-my-claude-md), with "no guarantee of strict compliance". It survives compaction by being [re-read from disk and re-injected](https://code.claude.com/docs/en/memory#instructions-seem-lost-after-compact), and it reaches [every subagent except the built-in Explore and Plan agents](https://code.claude.com/docs/en/sub-agents#what-loads-at-startup). An output style is appended to the end of the system prompt, passes through compaction ["unchanged; not part of message history"](https://code.claude.com/docs/en/context-window#what-survives-compaction), and ["all output styles trigger reminders for Claude to adhere to the output style instructions during the conversation"](https://code.claude.com/docs/en/output-styles#how-output-styles-work). It governs the main conversation only, because subagents run their own system prompt.
+
+So rules about how Claude talks to you (answer first, response length, when to ask, how to report) go in the style, where placement and reminders are strongest. Rules about how the work gets done (research conventions, tooling, project facts) go in `CLAUDE.md`, which subagents also see. Voice and prose rules that have to govern subagent-written documents stay in `CLAUDE.md` for the same reason. A style never reaches a subagent.
+
+Custom styles live in `~/.claude/output-styles/` or a project's `.claude/output-styles/`, with [frontmatter](https://code.claude.com/docs/en/output-styles#frontmatter) `name`, `description`, and `keep-coding-instructions`. That last key defaults to false and silently drops Claude Code's built-in software engineering instructions, so set it true when you are changing how Claude talks but still want it to write code. Select a style with [`"outputStyle": "<name>"`](https://code.claude.com/docs/en/settings-reference#outputstyle) in `settings.json`. `/config` sets it too, but writes to project-local `.claude/settings.local.json`, which overrides the global key for that project. `/output-style` was removed in v2.1.91, and a change applies only after `/clear` or in a new session.
+
+The built-in styles are Default, Concise, Explanatory, Learning, and Proactive. Concise "leads with the result, skips preamble and narration, and keeps responses short by default", and needs v2.1.237 or newer. Alongside it, `"spinnerTipsEnabled": false` and `"awaySummaryEnabled": false` quiet the terminal further ([settings reference](https://code.claude.com/docs/en/settings-reference)), and `verbose` already defaults to false. `output-styles/concise-research.md` here is a starting point for research work.
 
 ### API keys
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -15,10 +15,11 @@ Everything here was extracted from one researcher's working configuration, so th
 ## Install
 
 ```bash
-mkdir -p ~/.claude/skills ~/.claude/agents ~/.claude/assets
+mkdir -p ~/.claude/skills ~/.claude/agents ~/.claude/assets ~/.claude/output-styles
 cp -R skills/* ~/.claude/skills/
 cp agents/tikz-reviewer.md ~/.claude/agents/
 cp -R slide-tooling ~/.claude/assets/quarto-yale
+cp output-styles/concise-research.md ~/.claude/output-styles/
 ```
 
 The skills refer to the slide tooling at `~/.claude/assets/quarto-yale/`, which is why the copy keeps that name. A new deck then starts with `quarto add ~/.claude/assets/quarto-yale --no-prompt` and `cp -R ~/.claude/assets/quarto-yale/{mathjax,fonts} .`, and uses `format: starter-revealjs`.
@@ -28,6 +29,7 @@ The skills refer to the slide tooling at `~/.claude/assets/quarto-yale/`, which 
 - The `you@example.edu` placeholder, in three files. `skills/bibcheck/SKILL.md` and `skills/reading-papers/scripts/paper.py` use it as the Crossref and OpenAlex contact address; set a real one (or export `SCHOLAR_MAILTO`). The polite pools these APIs run for real contacts are faster and more reliable. `skills/research-talk/assets/starter-template.qmd` uses it on the closing contact slide.
 - API keys. `paper.py` and the Zotero launcher source `~/.claude/secrets/scholar.env` if it exists, with `S2_API_KEY`, `OPENALEX_API_KEY`, and optional `ZOTERO_API_KEY`/`ZOTERO_LIBRARY_ID`. All are optional; the tools degrade to the public pools without them.
 - House style. `skills/research-talk/style/house.md`, `skills/teaching-lecture/style/house.md`, and `skills/slide-review/style/house.md` are stubs: your author line, closing-slide wording, palette rationale, and density calibration go there. The slide skills read those files for values.
+- The output style. Copying `output-styles/concise-research.md` installs it, and nothing selects it until you set `"outputStyle": "concise-research"` in `~/.claude/settings.json` and start a new session. The README says what belongs in a style rather than in `CLAUDE.md`.
 - Your theme. `slide-tooling/starter-theme.scss` is deliberately plain and comments mark where taste goes; the example decks under `docs/` are that theme rendered as-is, so what you see is the starting point and the look is yours to build.
 
 ## Machine assumptions to know about

--- a/output-styles/concise-research.md
+++ b/output-styles/concise-research.md
@@ -1,0 +1,25 @@
+---
+name: concise-research
+description: Answer first, minimum necessary detail, verified claims, decisions raised through the option picker.
+keep-coding-instructions: true
+---
+
+These rules are about the message you write to me, every turn, for the whole session. How to do the work is in `CLAUDE.md`.
+
+Open with the answer, the number, the thing that is wrong, or the decision I have to make. The reasoning follows it. No "Great question", no restating my request, no closing summary paragraph. One line saying what you are about to do is fine when a task will take several tool calls, never a paragraph. End when the substance ends.
+
+When I ask a question, answer it before touching a tool. If it needs diagnosis, run at most three commands, then stop and tell me what you found, your best hypothesis, and what you want to run next. If I say go, do the deeper dig in a subagent that returns a short summary. When I ask why we are not doing something simpler, that is a question: answer it in one line, and if the simpler thing is right, do it and stop. Never build both so I can choose.
+
+Tell me what you did, whether it worked, and what I do now. Only return what is necessary. When I ask for detail, an explanation, or a deliverable, give it in full, and never trim error output or a confirmation for a destructive action. When I ask you to check, review, or confirm something, report what is wrong and what to do about it, then stop: no walking me through the items that came back fine. When nothing is wrong, one line says so. Keep paths, commands, and numbers exact.
+
+When the work is finished and no decisions remain, end with one flat line: "All done, no decisions left." Otherwise name what is still open.
+
+Raise major judgment calls with me before acting: anything of real importance or expensive to undo. Small, low-stakes calls you decide yourself. Whenever you put something to me, use the AskUserQuestion picker: concrete labeled options, the tradeoff in each description, your recommendation first. Never park a decision in a file and send me to read it. Text I type into the picker is a question like any other: answer it in the final message of the turn. A picker answer settles only the question asked, never the implementation that follows.
+
+Do not assert what you have not verified. Claims about Claude Code, the operating system, or any third-party tool get checked against official documentation before you state them. "X does not exist" needs a citation. Without one, say you did not find it and have not confirmed it is absent. A job's status, a file's contents, a number in a table, or a subagent's report is a claim until you have looked: say what you checked and how, and mark the rest unconfirmed.
+
+Any threshold, default, or parameter you pick for me carries its one-line reason. When it is arbitrary, say so and ask.
+
+Make the minimum change that satisfies the request. When I give a numeric target, say up front if a constraint prevents hitting it instead of delivering less and letting me find out.
+
+Voice and prose rules are not repeated here. They live in the Voice section of `CLAUDE.md`, because an output style never reaches a subagent and documents get written by subagents.


### PR DESCRIPTION
Adds a `### CLAUDE.md versus output styles` subsection under "Things you may not know" and a generic `output-styles/concise-research.md` that installs alongside the skills.

The subsection says how each one reaches the model (CLAUDE.md as a user message after the system prompt, the style appended to the end of it), what each does through compaction, and that a style never reaches a subagent, then draws the division: talk rules in the style, work rules and voice rules in CLAUDE.md. Every claim carries its docs link. The frontmatter note flags `keep-coding-instructions`, which defaults to false and drops the built-in coding instructions.

The Quickstart and SETUP install blocks now copy the template, and SETUP says nothing selects it until `"outputStyle"` is set in settings.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAEmqdvP8eicnSRgtic2Ar