### PR TITLE
Update the five causal skills from the Mixtape pass

### DIFF
--- a/skills/causal-design/SKILL.md
+++ b/skills/causal-design/SKILL.md
@@ -1,26 +1,28 @@
 ---
 name: causal-design
-description: Triage any causal question to the identification strategy the data can support, then hand off to the owning method skill; owns the selection-on-observables branch (overlap, doubly robust estimation, double ML, causal forests, policy learning, sensitivity analysis) and the inference rules shared across designs. Produces the design recommendation with the assumption that licenses it, the estimand and its subpopulation, R estimation code for the observables branch, and a drafted taxonomy paragraph. TRIGGER on "causal inference", "identification strategy", "which method", "research design", "endogeneity", "quasi-experiment", "natural experiment", "observational study", "selection on observables", "unconfoundedness", "conditional ignorability", "matching", "propensity score", "doubly robust", "AIPW", "double machine learning", "DML", "causal forest", "CATE", "policy learning", "targeting", "sensitivity analysis", "omitted variable bias", "Oster bounds", "coefficient stability", "overlap", "trimming", "marketplace experiment", "surrogate index", "mediation", "mediation analysis", "indirect effect", "conjoint", "AMCE", or any "how do I estimate the effect of X on Y" question with no design chosen yet. Once a design is chosen, the method skills own it: field-experiment, did, synthetic-control, rdd, iv, conjoint.
+description: Triage any causal question to the identification strategy the data can support, then hand off to the owning method skill; owns the selection-on-observables branch (overlap, doubly robust estimation, double ML, causal forests, policy learning, sensitivity analysis) and the inference rules shared across designs. Produces the design recommendation with the assumption that licenses it, the estimand and its subpopulation, R estimation code for the observables branch, and a drafted taxonomy paragraph. TRIGGER on "causal inference", "identification strategy", "which method", "research design", "endogeneity", "quasi-experiment", "natural experiment", "observational study", "selection on observables", "unconfoundedness", "conditional ignorability", "matching", "propensity score", "doubly robust", "AIPW", "double machine learning", "DML", "causal forest", "CATE", "policy learning", "targeting", "sensitivity analysis", "omitted variable bias", "Oster bounds", "coefficient stability", "overlap", "trimming", "panel fixed effects", "within estimator", "strict exogeneity", "marketplace experiment", "surrogate index", "mediation", "mediation analysis", "indirect effect", "conjoint", "AMCE", or any "how do I estimate the effect of X on Y" question with no design chosen yet. Once a design is chosen, the method skills own it: field-experiment, did, synthetic-control, rdd, iv, causal-unstructured, sae, sae-image, conjoint, steering.
 ---
 
 # Causal design triage
 
-The router of the family, grounded in a read canon of two hand-picked reviews
+The router of the family, grounded in a read canon of three user-picked reviews
 (references/canon.md, current as of 2026-07-28): Imbens (2024) supplies the assumption axis
-(what licenses identification), and Li, Luo, and Pattabhiramaiah (2024, hereafter AMA) the
+(what licenses identification), Li, Luo, and Pattabhiramaiah (2024, hereafter AMA) the
 marketing data-shape axis (how many treated units, how many pre-periods, how rich the
-covariates). The deliverable is a design recommendation carrying four things: the assumption
-that licenses it, the estimand it actually identifies WITH its subpopulation named, the
-handoff to the owning skill, and, for the one branch no method skill owns (selection on
-observables), estimation code and a methods paragraph. Marketing's framing throughout:
-randomization is the gold standard, and quasi-experimental work substitutes statistical rigor
-for design rigor (AMA); a design that fails its gate is a verdict, not an obstacle.
+covariates), and Feder et al. (2022) the text-role axis (which role unstructured data plays
+in the graph). The deliverable is a design
+recommendation carrying four things: the assumption that licenses it, the estimand it
+actually identifies WITH its subpopulation named, the handoff to the owning skill, and, for
+the one branch no method skill owns (selection on observables), estimation code and a methods
+paragraph. Marketing's framing throughout: randomization is the gold standard, and
+quasi-experimental work substitutes statistical rigor for design rigor (AMA); a design that
+fails its gate is a verdict, not an obstacle.
 
 Refresh path: the panel-methods corner moves fastest. To update, run the litreview skill on
 quasi-experimental methods in marketing since the canon date and fold results into
 references/canon.md as flagged addenda.
 
-## The triage: three questions in order
+## The triage: four questions in order
 
 1. Was assignment randomized, or as good as (lottery, randomized rollout)? Yes:
    field-experiment. Two cautions at this gate: naive sample means from adaptive/bandit
@@ -55,6 +57,8 @@ references/canon.md as flagged addenda.
      cutoff).
    - Treatment switches on over time for some units with untreated comparisons: the panel
      branch below, routed by data shape between did and synthetic-control.
+   - Treatment switches on and off within unit, with no untreated comparisons and no
+     adoption date: plain panel fixed effects, the section below.
    - No structure at all: bounds and sensitivity analysis (the ladder below), or advise
      against the causal claim. Estimate under the best defensible conditioning anyway and
      report how much calibrated confounding overturns it, or report Manski bounds alone;
@@ -63,6 +67,12 @@ references/canon.md as flagged addenda.
      copulas; the third leaf of the AMA figure) sit outside this family's coverage: the iv
      skill's exclusion and relevance discipline is the nearest relative, and copula
      identification rests on distributional assumptions that need their own defense.
+4. Does unstructured data (text, image, audio, video) appear anywhere in the graph, and in
+   which role: confounder, outcome, treatment, or machine-coded measurement?
+   causal-unstructured, with the role warnings below. Unknown-concept discovery and
+   model-internals measurement: sae. Steering a model's internals (steered stimuli,
+   steered model-respondents, dose-response manipulations) is instrument practice owned by
+   steering; the design around it still routes through the questions above.
 
 ## The panel branch: routing by data shape
 
@@ -97,6 +107,53 @@ taxonomy (data type, frame shape, assignment mechanism; did skill):
   instead (Li and Sonnier 2023, via AMA); unit AND time reweighting wanted: synthetic DiD;
   the inference-procedure-by-data-shape rules live in synthetic-control.
 
+## Plain panel fixed effects: no comparison group, no adoption date
+
+The within estimator on Y_it = delta D_it + u_i + eps_it is licensed by strict exogeneity
+conditional on the unit effect, E[eps_it | D_i1, ..., D_iT, u_i] = 0 for every t (Wooldridge
+2010 for the unobserved-effects model and the assumption). It buys every time-invariant
+confounder, observed or not, and lets D_it be arbitrarily correlated with u_i. It buys
+nothing against a time-varying unobservable, feedback from past outcomes to current
+treatment, or simultaneity. Feedback is what fires in marketing panels: last period's sales
+set this period's promotion, last quarter's churn sets this quarter's retention spend. The
+Mixtape's own 5% price premium on unprotected sex holds "under the assumption of strict
+exogeneity", and the condom decision is settled inside the session alongside the price, so a
+session-level shock moving both is the violation it rests on being absent. Reverse causality
+and simultaneity defeat the estimator outright: Cornwell and Trumbull (1994) put crime on
+police in North Carolina counties and the within estimate is 0.413 (0.027), the wrong sign
+against Becker's (1968) prediction, because Y -> D was there all along. Exits: iv under
+feedback or simultaneity, did when an adoption date and clean untreated or not-yet-treated
+comparisons exist. The design needs within-unit variation in D and identifies no
+time-invariant covariate's effect (the Mixtape's Table 8.3 shows the column of exact zeros
+with (.) standard errors).
+
+The Mixtape (Cunningham, Causal Inference: The Remix, panel-data chapter) presents columns 3
+and 4 of its Table 8.2, from Cornwell and Rupert (1997), which add job tenure and then
+quadratics in years married and walk the marriage premium from the column 1 FGLS 0.083 to
+0.033, as evidence about time-varying unobserved heterogeneity; under this skill's rule
+those columns are inadmissible, because years married and job tenure are plausibly
+consequences of marriage, so they condition on descendants of the treatment, which is
+verbatim the error Imbens (2024) calls the most common one. The chapter assumes constant
+effects and declares that scope. A non-absorbing time-varying treatment with heterogeneous
+effects has left it, the implicit weighting is live, and the dCDH weight diagnostic in did
+applies. Random effects, Mundlak-Chamberlain devices, and dynamic panel estimators stay out,
+and Wooldridge (2010) is the shelf for them.
+
+```r
+library(fixest)                     # panel: one row per unit-period, unit = the panel id
+## Within-variation check first: units with no variation in d contribute nothing to the
+## within estimate and every FE routine drops them silently (singletons return NA here).
+nv <- tapply(panel$d, panel$unit, function(z) var(z, na.rm = TRUE))
+c(no_within_variation = sum(is.na(nv) | nv == 0), units = length(nv))
+pols   <- feols(y ~ d, data = panel, cluster = ~unit)   # u_i left in the composite error
+within <- feols(y ~ d | unit, data = panel, cluster = ~unit)
+etable(pols, within)                # side by side: the gap is the unit effects at work, and
+                                    # no time-invariant covariate enters the within column.
+## Stata FE standard errors instead (argument-name trap in references/details.md):
+# estimatr::lm_robust(y ~ d, data = panel, fixed_effects = ~unit, clusters = unit,
+#                     se_type = "stata")
+```
+
 ## Selection on observables (the branch this skill owns)
 
 - Overlap before estimation, always: estimate the propensity score and look at its
@@ -119,7 +176,8 @@ taxonomy (data type, frame shape, assignment mechanism; did skill):
 - Heterogeneity has two different goals: describing CATEs (causal forest, Wager and Athey
   2018, honest inference without prespecified subgroups) and deciding WHO to treat, which
   is policy learning (Athey and Wager 2021; policytree), where the complexity of the
-  policy class is the key choice. Do not answer a targeting question with a CATE map.
+  policy class is the key choice. Do not answer a targeting question with a CATE
+  map.
 - Sensitivity analysis is mandatory, because unconfoundedness is untestable. The graded
   ladder (details in references/details.md): Manski bounds (assumption-free, honest,
   usually uninformative); calibrated confounder models (Rosenbaum and Rubin 1983, Imbens
@@ -149,7 +207,10 @@ taxonomy (data type, frame shape, assignment mechanism; did skill):
   One half of this decision is untestable and the skill states it rather than estimating it:
   the sample "is not informative" about what fraction of clusters was sampled, so "information
   about the need to adjust for clustered sampling must come from outside the sample," while the
-  sample IS informative about clustered assignment. Say which of the two you are invoking.
+  sample IS informative about clustered assignment. The Mixtape's rationale for clustering
+  by panel unit, "to allow for correlation in the eps_it's for the same person i over time,"
+  is the one reason AAIW rule out, and the answer often coincides only because panel units
+  in a survey are genuinely the sampling clusters. Say which of the two you are invoking.
   Two further facts to carry. Robust standard errors are conservative rather than exact when
   the sample is a large share of the population and effects are heterogeneous (the Neyman
   finite-sample correction; `abadie2020sampling` buys the precision back if unit attributes
@@ -177,8 +238,8 @@ taxonomy (data type, frame shape, assignment mechanism; did skill):
   STAGES of a staged design: fixed-sequence gatekeeping. Preregister the order, test each
   stage's primary hypothesis at full alpha, stop at the first failure. It costs no alpha, and
   the price accepted in advance is that nothing downstream of a failed gate is confirmatory.
-  Worked instantiations: field-experiment (subgroups and multiple outcomes), conjoint (AMCE
-  families).
+  Worked instantiations: sae (screens over a latent dictionary), field-experiment (subgroups
+  and multiple outcomes), conjoint (AMCE families).
 - Interference routing, by structure (designs, estimators, and diagnostics live in
   field-experiment): clustered interference routes to two-stage randomization (Hudgens
   and Halloran 2008, Crepon et al. 2013); network interference to exposure mappings
@@ -191,11 +252,25 @@ taxonomy (data type, frame shape, assignment mechanism; did skill):
   2026). The family ships no estimation template for the surrogate index; Athey, Chetty,
   Imbens, and Kang's own empirical implementation is the recipe to follow, and the
   router's deliverable stops at the validity argument.
+- Text-role warnings at handoff (Feder): as confounder, ignorability over text aspects is
+  untestable, argue it from domain knowledge, and audit positivity (a representation that
+  nearly encodes the treatment leaves no counterfactual); as outcome or discovered
+  treatment, never train the measurement function on the estimation sample (split-sample,
+  via Egami; the authoritative rule lives in causal-unstructured); as treatment,
+  disentangle the named aspect from correlated aspects, and random assignment of texts
+  leaves reader-side confounding. Any machine-coded variable in any design gets the PPI
+  rectifier logic before it enters a regression (causal-unstructured). One revision the
+  family makes to Feder: his supervised text-as-confounder route (fine-tuned causally
+  sufficient embeddings, Veitch 2020) is superseded; the GPI results say never fit the
+  inference-time propensity on a representation learned with a treatment-prediction loss
+  (on GPI's own simulation evidence; causal-unstructured carries the dispute and owns the
+  replacement).
 - Mediation (process evidence, treatment affecting the outcome through a mediator, natural
   direct and indirect effects) has NO route in this family: sequential ignorability is an
   assumption regime none of the family's skills carries. Where to go: Imai, Keele, and
   Tingley (2010) for identification and sensitivity analysis, Pieters (2017) for the
-  marketing-native statement of what a mediation claim requires.
+  marketing-native statement of what a mediation claim requires. causal-unstructured's
+  note that Fong-Grimmer treatment discovery is not mediation remains authoritative there.
 
 ## Implementation
 
@@ -225,13 +300,20 @@ Every claim traces to references/canon.md; keys live in references/causal.bib.
 
 - field-experiment: anything randomized, prospective experimental design, interference
   analysis, power.
-- did: many treated units with timing variation; parallel-trends machinery.
+- conjoint: profile experiments with multiple randomized attributes (AMCEs, marginal
+  means, measurement-error and multiple-testing corrections, HB partworths and WTP).
+- did: many treated units with timing variation; parallel-trends machinery; it sends
+  plain-FE cases with no comparison group back to the plain panel fixed effects section.
 - synthetic-control: few treated units, long pre-periods; SDID; factor models and matrix
   completion; the augmented/forward DiD and HCW conditions stated above.
 - rdd: thresholds on running variables; the design gate and falsification battery.
-- conjoint: profile experiments with multiple randomized attributes (AMCEs, marginal means,
-  measurement-error and multiple-testing corrections, HB partworths and WTP).
 - iv: instruments, shift-share, formula instruments, leniency and examiner designs;
   weak-instrument inference.
+- causal-unstructured: any text/image/audio/video role in the graph; PPI for machine-coded
+  variables; GPI for internal-state adjustment; the split-sample rule.
+- sae: unknown-concept discovery in text; model-internals measurement instruments.
+- steering: activation-steering practice for steered stimuli and model-respondents
+  (instrument choice, strength calibration, damage audits); the surrounding design stays
+  with the owning method skill.
 - preregister: pre-analysis plans once the design is chosen (experiment-first skill;
   quasi-experimental and measurement PAPs adapt its structure).

--- a/skills/causal-design/references/canon.md
+++ b/skills/causal-design/references/canon.md
@@ -1,13 +1,15 @@
 # Router canon
 
-Current as of 2026-08-05. These three sources are the only canon of the causal-design skill,
-hand-picked, and nothing enters this file without explicit human approval. BibTeX keys
-point into ./causal.bib, which is the one shared bib for the whole skill family. The
-router also leans on `arkhangelsky2024causal` (the three-axis panel taxonomy), a
-cross-reference owned by the did canon. The family-wide clustering statement is owned by this
-skill's own SKILL.md, whose frontmatter claims the shared inference rules, while method skills
-carry design-specific instances. Refresh: run litreview on the moving corner (panel estimators)
-since the canon date. Any addendum needs explicit human approval.
+Current as of 2026-08-05. Four sources: three hand-picked and a fourth,
+`abadie2023clustering`, approved on 2026-08-05, which was promoted from a cross-reference to
+a full entry because five skills lean on it. Nothing enters this file without explicit human
+approval. BibTeX keys point into ./causal.bib, which is the
+one shared bib for the whole skill family. The router also leans on `arkhangelsky2024causal`
+(the three-axis panel taxonomy), a cross-reference owned by the did canon. The family-wide
+clustering statement is owned by this skill's own SKILL.md, whose frontmatter claims the shared
+inference rules, while method skills carry design-specific instances. Refresh:
+run litreview on the moving corners (panel estimators, text-causal) since the canon date;
+any addendum needs explicit human approval.
 
 ## Imbens (2024)
 
@@ -33,7 +35,7 @@ Annual Review of Statistics and Its Application 11:123-152. Key: `imbens2024caus
 - Binds when: every triage; the selection-on-observables branch end to end; any
   sensitivity-analysis request.
 - Scope limits: names no software at all; explicitly excludes dynamic treatment regimes
-  (Robins tradition).
+  (Robins tradition); no treatment of text or unstructured data.
 - Quote (verbatim in SKILL.md): "In practice, using variables causally affected by the
   treatment or outcome is the most common mistake in choosing variables to condition on in
   estimating average treatment effects using unconfoundedness approaches."
@@ -54,17 +56,17 @@ Key: `li2024quasiexperimental`.
   SC-family best practices, stated as a gate ("only using the methods that satisfy both
   best practices"): pretreatment-fit plot and backdating (the family's adjudication adds a
   strict-exogeneity caveat to backdating and hands the final verdict to synthetic-control's
-  fuller feasibility gate; SKILL.md carries it); the data-shape fan-out within the panel
-  branch: convex-hull failure -> augmented DiD (Li-Van den Bulte), outcome in range but
-  too few pre-periods -> forward DiD (Li), controls far fewer than pre-periods -> HCW OLS
-  (Hsiao-Ching-Wan), many treated units or short panels -> generalized synthetic control /
-  matrix completion, unit and time reweighting both wanted -> SDID with inference
-  procedure chosen by data shape; PSM "called into question," replaced by AIPW, double ML,
-  causal forests; unconfoundedness often defensible in marketing because targeting rules
-  are known and observable; the Li-Sonnier result that the gsynth parametric bootstrap
-  yields biased CIs ("false precision or false imprecision... lead to incorrect business
-  decisions"); the field vocabulary (design rigor vs statistical rigor, ATT-first, clean
-  controls).
+  fuller feasibility gate; SKILL.md carries it); the data-shape fan-out within
+  the panel branch: convex-hull failure -> augmented DiD (Li-Van den Bulte), outcome in
+  range but too few pre-periods -> forward DiD (Li), controls far fewer than pre-periods
+  -> HCW OLS (Hsiao-Ching-Wan), many treated units or short panels -> generalized
+  synthetic control / matrix completion, unit and time reweighting both wanted -> SDID
+  with inference procedure chosen by data shape; PSM "called into question," replaced by
+  AIPW, double ML, causal forests; unconfoundedness often defensible in marketing because
+  targeting rules are known and observable; the Li-Sonnier result that the gsynth
+  parametric bootstrap yields biased CIs ("false precision or false imprecision... lead to
+  incorrect business decisions"); the field vocabulary (design rigor vs statistical rigor,
+  ATT-first, clean controls).
 - Binds when: routing within the panel branch; arguing a method is accepted marketing
   practice; writing for marketing reviewers.
 - Caveats: read via WebFetch extraction, so re-verify any quotation against the live page
@@ -73,16 +75,42 @@ Key: `li2024quasiexperimental`.
   methods independently; silent on RDD and nearly silent on IV, so it never covers the
   confounded-observational branch beyond panel methods. Figure 1 ("Overview of Design
   Choices in Quasi-Experimental Settings") was read against the article text on
-  2026-07-28. The figure is coarser than the article text (it lumps augmented DiD under
-  too-few-pre-periods where the text gives it the convex-hull condition; HCW and matrix
-  completion appear only in the text); where they differ, this skill follows the text.
+  2026-07-28. The figure is coarser than the article text (it lumps augmented DiD
+  under too-few-pre-periods where the text gives it the convex-hull condition; HCW and
+  matrix completion appear only in the text); where they differ, this skill follows the
+  text.
+
+## Feder et al. (2022)
+
+Transactions of the Association for Computational Linguistics 10:1138-1158. Key:
+`feder2022causal`.
+
+- Role: the text-role triage question. Any causal analysis where unstructured data appears
+  gets asked: which role does it play (confounder, outcome, treatment)? Each role has its
+  own assumption failures; the router states the question and the warnings, then hands off
+  to causal-unstructured.
+- Settles: ignorability over text aspects is untestable and must be argued from domain
+  knowledge; positivity is generically fragile in high dimensions (a representation that
+  nearly encodes the treatment leaves no conceivable counterfactual); consistency fails
+  through the measurement model when it was trained on the estimation data, and the fix is
+  split-sample measurement (via Egami et al.); invariance and sensitivity test batteries
+  for any NLP measure feeding a causal pipeline; there are no real-world ground-truth
+  causal text benchmarks, so semi-synthetic wins are never validation of a real estimate.
+- Binds when: any unstructured data in the causal graph; the router's role question.
+- REVISED WITHIN THE FAMILY: Feder's supervised text-as-confounder route (fine-tuned
+  causally sufficient embeddings, Veitch et al. 2020) is superseded by the GPI results, on
+  GPI's own simulation evidence; causal-unstructured carries the dispute and the
+  replacement route. The router cites Feder for the role triage and the assumption
+  failures, never for the Veitch route.
+- Version note: read as the arXiv accepted version; cite with TACL pagination (1138-1158).
 
 ## Abadie, Athey, Imbens, and Wooldridge (2023)
 
 QJE 138(1): 1-35. Key: `abadie2023clustering`. Read: the latest arXiv e-print (1710.02926),
 which cites Rambachan-Roth 2022 and so postdates the 2017 posting; the QJE PDF is
 Cloudflare-blocked and the NBER copy is the 2017 vintage, so the version of record is
-unverified in detail. Appendix regularity conditions and proofs not read. Promoted from a header cross-reference because several skills lean on it.
+unverified in detail. Appendix regularity conditions and proofs not read. Promoted from a
+header cross-reference on 2026-08-05 because five skills lean on it.
 
 - Role: the family-wide clustering rule, and the reason it is a design question. Replaces "are
   my errors correlated within clusters" with "how were the data sampled and how was treatment
@@ -137,9 +165,18 @@ published REStud July 2026, no longer the NBER WP), the sensitivity ladder
 (`manski1990nonparametric`, `rosenbaum1983assessing`, `imbens2003sensitivity`,
 `oster2019unobservable`, `cinelli2020making`, `rosenbaum2002observational`), and the AMA
 panel family (`hsiao2012panel`, `li2020inference`, `li2023augmented`, `li2024forward`,
-`li2023statistical` for Li-Sonnier). Already in the bib from method skills and reused
-here: `crump2009dealing`, `wager2018estimation`, `chernozhukov2018double`,
-`xu2017generalized`, `athey2021matrix`, `crepon2013labor`, `hudgens2008toward`,
-`athey2018exact`, the did/rdd/synth canons. New with the mediation decline:
-`imai2010general` and `pieters2017meaningful`, decline pointers only, NOT canon (the
-router declines mediation and points to them; no skill carries the route).
+`li2023statistical` for Li-Sonnier). Already in the bib from
+method skills and reused here: `crump2009dealing`, `wager2018estimation`,
+`chernozhukov2018double`, `xu2017generalized`, `athey2021matrix`, `crepon2013labor`,
+`hudgens2008toward`, `athey2018exact`, `egami2022make`, the did/rdd/synth canons. New with
+the mediation decline: `imai2010general` and `pieters2017meaningful`, decline pointers
+only, NOT canon (the router declines mediation and points to them; no skill carries the
+route).
+
+Reference shelf, not canon: `wooldridge2010econometric` (Econometric Analysis of Cross
+Section and Panel Data, 2nd ed., MIT Press), the citation for the unobserved-effects model
+and strict exogeneity in SKILL.md's plain-panel-fixed-effects section, and the pointer for
+the panel methods that section leaves out, random effects among them. Added 2026-08-26 from
+the reference list of Cunningham's "Causal Inference: The Remix" panel-data chapter, whose
+footnote 1 names it for the same purpose. A textbook, so it carries no reading notes and
+does not sit alongside the four read sources above.

--- a/skills/causal-design/references/causal.bib
+++ b/skills/causal-design/references/causal.bib
@@ -2314,3 +2314,554 @@
   pages   = {477--491},
   doi     = {10.1080/01621459.2025.2526700}
 }
+
+% ---- Added 2026-08-26 from the Mixtape (Causal Inference: The Remix) pass over rdd, iv, did,
+% synthetic-control: canon additions and exemplar-row keys. Fields verified against Crossref
+% unless a line carries a '% unverified' comment.
+
+@article{imbens2012optimal,
+  author  = {Imbens, Guido W. and Kalyanaraman, Karthik},
+  title   = {Optimal Bandwidth Choice for the Regression Discontinuity Estimator},
+  journal = {The Review of Economic Studies},
+  year    = {2012},
+  volume  = {79},
+  number  = {3},
+  pages   = {933--959},
+  doi     = {10.1093/restud/rdr043}
+}
+
+@article{lee2008specification,
+  author  = {Lee, David S. and Card, David},
+  title   = {Regression Discontinuity Inference with Specification Error},
+  journal = {Journal of Econometrics},
+  year    = {2008},
+  volume  = {142},
+  number  = {2},
+  pages   = {655--674},
+  doi     = {10.1016/j.jeconom.2007.05.003}
+}
+
+% Crossref prints the title as "Rdrobust: Software for Regression-discontinuity
+% Designs"; the AER-style form used here matches the journal's own PDF and the
+% rdpackages site. The Mixtape's reference list misspells it "Regrssion".
+
+@article{calonico2017rdrobust,
+  author  = {Calonico, Sebastian and Cattaneo, Matias D. and Farrell, Max H. and Titiunik, Roc{\'i}o},
+  title   = {rdrobust: Software for Regression Discontinuity Designs},
+  journal = {The Stata Journal},
+  year    = {2017},
+  volume  = {17},
+  number  = {2},
+  pages   = {372--404},
+  doi     = {10.1177/1536867X1701700208}
+}
+
+% ---------------------------------------------------------------------------
+% Exemplar rows from the SKILL.md recognition table and details.md "Canonical
+% cases", staged 2026-08-26. Every field below was checked against Crossref
+% (api.crossref.org/works) unless a line carries a "% unverified" comment.
+% Key convention follows causal.bib: firstauthor + year + first substantive word
+% of the title, skipping a leading article and a leading "Do"/"Does" where that
+% word would carry nothing.
+% ---------------------------------------------------------------------------
+
+@article{card2008impact,
+  author  = {Card, David and Dobkin, Carlos and Maestas, Nicole},
+  title   = {The Impact of Nearly Universal Insurance Coverage on Health Care Utilization: Evidence from {Medicare}},
+  journal = {American Economic Review},
+  year    = {2008},
+  volume  = {98},
+  number  = {5},
+  pages   = {2242--2258},
+  doi     = {10.1257/aer.98.5.2242}
+}
+
+@article{hansen2015punishment,
+  author  = {Hansen, Benjamin},
+  title   = {Punishment and Deterrence: Evidence from Drunk Driving},
+  journal = {American Economic Review},
+  year    = {2015},
+  volume  = {105},
+  number  = {4},
+  pages   = {1581--1617},
+  doi     = {10.1257/aer.20130189}
+}
+
+% Crossref appends a footnote marker to the title; stripped here. Doyle's suffix is
+% in the BibTeX Last, Jr, First form, matching the Crossref family field "Doyle, Jr.".
+
+@article{almond2010estimating,
+  author  = {Almond, Douglas and {Doyle, Jr.}, Joseph J. and Kowalski, Amanda E. and Williams, Heidi},
+  title   = {Estimating Marginal Returns to Medical Care: Evidence from At-Risk Newborns},
+  journal = {Quarterly Journal of Economics},
+  year    = {2010},
+  volume  = {125},
+  number  = {2},
+  pages   = {591--634},
+  doi     = {10.1162/qjec.2010.125.2.591}
+}
+
+% Title kept in the sentence case Crossref and OpenAlex both register for this record.
+% Crossref stores the authors as initials (A. I. Barreca, M. Guldi, J. M. Lindo,
+% G. R. Waddell); the given names come from the OpenAlex record for the same DOI.
+
+@article{barreca2011saving,
+  author  = {Barreca, Alan I. and Guldi, Melanie and Lindo, Jason M. and Waddell, Glen R.},
+  title   = {Saving Babies? Revisiting the effect of very low birth weight classification},
+  journal = {Quarterly Journal of Economics},
+  year    = {2011},
+  volume  = {126},
+  number  = {4},
+  pages   = {2117--2123},
+  doi     = {10.1093/qje/qjr042}
+}
+
+% Year is the Crossref published-print date (2016-01); the issued date is the
+% 2015-05-22 online-first posting. Wiley registers the title in all caps; the
+% casing here is the one Crossref registers for the NBER version (10.3386/w17408).
+
+@article{barreca2016heaping,
+  author  = {Barreca, Alan I. and Lindo, Jason M. and Waddell, Glen R.},
+  title   = {Heaping-Induced Bias in Regression-Discontinuity Designs},
+  journal = {Economic Inquiry},
+  year    = {2016},
+  volume  = {54},
+  number  = {1},
+  pages   = {268--293},
+  doi     = {10.1111/ecin.12225}
+}
+
+% Crossref stores the authors as D. S. Lee, E. Moretti, M. J. Butler; given names
+% from the OpenAlex record for the same DOI. Crossref prints the title with a space
+% in "U. S."; closed up and brace-protected here, as in lee2008randomized.
+
+@article{lee2004voters,
+  author  = {Lee, David S. and Moretti, Enrico and Butler, Matthew J.},
+  title   = {Do Voters Affect or Elect Policies? Evidence from the {U.S.} House},
+  journal = {Quarterly Journal of Economics},
+  year    = {2004},
+  volume  = {119},
+  number  = {3},
+  pages   = {807--859},
+  doi     = {10.1162/0033553041502153}
+}
+
+@article{hoekstra2009effect,
+  author  = {Hoekstra, Mark},
+  title   = {The Effect of Attending the Flagship State University on Earnings: A Discontinuity-Based Approach},
+  journal = {Review of Economics and Statistics},
+  year    = {2009},
+  volume  = {91},
+  number  = {4},
+  pages   = {717--724},
+  doi     = {10.1162/rest.91.4.717}
+}
+
+% Crossref stores the author as S. E. Black; given name from the OpenAlex record
+% for the same DOI.
+
+@article{black1999schools,
+  author  = {Black, Sandra E.},
+  title   = {Do Better Schools Matter? Parental Valuation of Elementary Education},
+  journal = {Quarterly Journal of Economics},
+  year    = {1999},
+  volume  = {114},
+  number  = {2},
+  pages   = {577--599},
+  doi     = {10.1162/003355399556070}
+}
+
+@article{angrist2000interpretation,
+  author  = {Angrist, Joshua D. and Graddy, Kathryn and Imbens, Guido W.},
+  title   = {The Interpretation of Instrumental Variables Estimators in Simultaneous Equations Models with an Application to the Demand for Fish},
+  journal = {Review of Economic Studies},
+  year    = {2000},
+  volume  = {67},
+  number  = {3},
+  pages   = {499--527},
+  doi     = {10.1111/1467-937X.00141}
+}
+
+@article{angrist2001instrumental,
+  author  = {Angrist, Joshua D. and Krueger, Alan B.},
+  title   = {Instrumental Variables and the Search for Identification: From Supply and Demand to Natural Experiments},
+  journal = {Journal of Economic Perspectives},
+  year    = {2001},
+  volume  = {15},
+  number  = {4},
+  pages   = {69--85},
+  doi     = {10.1257/jep.15.4.69}
+}
+
+% ---------------------------------------------------------------------------
+% Exemplar rows from the SKILL.md recognition table and the details.md "six
+% designs" table, staged 2026-08-26. Every field was checked against Crossref
+% unless a line carries a "% unverified" comment. Bartik 1991 (bartik1991who),
+% Autor-Dorn-Hanson 2013 (autor2013china), and Borusyak-Hull 2023
+% (borusyak2023nonrandom) already have keys in causal.bib and are not restaged.
+% ---------------------------------------------------------------------------
+
+% Crossref strips the trailing footnote asterisk from the QJE title. The ninth
+% author is the corporate Oregon Health Study Group, as in the Crossref record.
+
+@article{finkelstein2012oregon,
+  author  = {Finkelstein, Amy and Taubman, Sarah and Wright, Bill and Bernstein, Mira and Gruber, Jonathan and Newhouse, Joseph P. and Allen, Heidi and Baicker, Katherine and {Oregon Health Study Group}},
+  title   = {The {Oregon} Health Insurance Experiment: Evidence from the First Year},
+  journal = {Quarterly Journal of Economics},
+  year    = {2012},
+  volume  = {127},
+  number  = {3},
+  pages   = {1057--1106},
+  doi     = {10.1093/qje/qjs020}
+}
+
+% The registered NEJM title carries an em dash, reproduced here as the LaTeX ---
+% because causal.bib is ASCII throughout. Crossref gives Zaslavsky's given name as
+% Alan M.; the Mixtape's reference list prints "Alam Zaslavsky", which is wrong.
+
+@article{baicker2013oregon,
+  author  = {Baicker, Katherine and Taubman, Sarah L. and Allen, Heidi L. and Bernstein, Mira and Gruber, Jonathan H. and Newhouse, Joseph P. and Schneider, Eric C. and Wright, Bill J. and Zaslavsky, Alan M. and Finkelstein, Amy N.},
+  title   = {The {Oregon} Experiment --- Effects of {Medicaid} on Clinical Outcomes},
+  journal = {New England Journal of Medicine},
+  year    = {2013},
+  volume  = {368},
+  number  = {18},
+  pages   = {1713--1722},
+  doi     = {10.1056/NEJMsa1212321}
+}
+
+% The Crossref record for this DOI registers no volume, issue, or pages, and the
+% OpenAlex record for the same DOI is empty on all three. The three lines flagged
+% below come from the Mixtape's reference list and are not resolver-verified.
+
+@article{stevenson2018distortion,
+  author  = {Stevenson, Megan T.},
+  title   = {Distortion of Justice: How the Inability to Pay Bail Affects Case Outcomes},
+  journal = {The Journal of Law, Economics, and Organization},
+  year    = {2018},
+  volume  = {34},   % unverified
+  number  = {4},    % unverified
+  pages   = {511--542},  % unverified
+  doi     = {10.1093/jleo/ewy019}
+}
+
+% Crossref has no record for the 1928 book itself. Author and title are confirmed by
+% the Crossref record for Alsberg's 1930 review of it in the Journal of Political
+% Economy (10.1086/254144), which prints the byline as Philip G. Wright. Publisher
+% and year come from the Mixtape's reference list.
+
+@book{wright1928tariff,
+  author    = {Wright, Philip G.},
+  title     = {The Tariff on Animal and Vegetable Oils},
+  publisher = {The Macmillan Company},  % unverified
+  year      = {1928}   % unverified
+}
+
+% "Markets:" is the JEP feature-series prefix and part of the registered title.
+
+@article{graddy2006fulton,
+  author  = {Graddy, Kathryn},
+  title   = {Markets: The {Fulton} Fish Market},
+  journal = {Journal of Economic Perspectives},
+  year    = {2006},
+  volume  = {20},
+  number  = {2},
+  pages   = {207--220},
+  doi     = {10.1257/jep.20.2.207}
+}
+
+% The SKILL.md row names no year; this is the 1994 JAMA paper that introduced the
+% differential-distance instrument. The Crossref record for the JAMA DOI carries only
+% the first author and a title without its subtitle; the coauthors' initials and the
+% full title come from the Crossref record for the Survey of Anesthesiology reprint
+% (10.1097/00132586-199506000-00003). Neither resolver expands McNeil's or Newhouse's
+% given names on this article, so the initials stand. Crossref and OpenAlex both give
+% 859 as the only page.
+
+@article{mcclellan1994intensive,
+  author  = {McClellan, Mark and McNeil, B. J. and Newhouse, J. P.},
+  title   = {Does More Intensive Treatment of Acute Myocardial Infarction in the Elderly Reduce Mortality? Analysis Using Instrumental Variables},
+  journal = {JAMA},
+  year    = {1994},
+  volume  = {272},
+  number  = {11},
+  pages   = {859},   % unverified end page; both resolvers give 859 as first and last
+  doi     = {10.1001/jama.1994.03520110039026}
+}
+
+@article{roth2026interpreting,
+  author  = {Roth, Jonathan},
+  title   = {Interpreting event-studies from recent difference-in-differences methods},
+  journal = {The Japanese Economic Review},
+  year    = {2026},
+  volume  = {77},
+  number  = {2},
+  pages   = {275--288},
+  doi     = {10.1007/s42973-026-00235-x}
+}
+% Crossref: published online 2026-02-03, print issue 2026-04. The Mixtape cites the 2024
+% working paper version; this is the published record and the skill cites it as Roth (2026).
+
+@article{olden2022triple,
+  author  = {Olden, Andreas and M{\o}en, Jarle},
+  title   = {The triple difference estimator},
+  journal = {The Econometrics Journal},
+  year    = {2022},
+  volume  = {25},
+  number  = {3},
+  pages   = {531--553},
+  doi     = {10.1093/ectj/utac010}
+}
+
+@article{marx2024parallel,
+  author  = {Marx, Philip and Tamer, Elie and Tang, Xun},
+  title   = {Parallel Trends and Dynamic Choices},
+  journal = {Journal of Political Economy Microeconomics},
+  year    = {2024},
+  volume  = {2},
+  number  = {1},
+  pages   = {129--171},
+  doi     = {10.1086/727363}
+}
+
+@article{santanna2026compositional,
+  author  = {Sant'Anna, Pedro H. C. and Xu, Qi},
+  title   = {Difference-in-Differences with compositional changes},
+  journal = {Journal of Econometrics},
+  year    = {2026},
+  volume  = {253},
+  pages   = {106147},
+  doi     = {10.1016/j.jeconom.2025.106147}
+}
+% Crossref gives volume 253, article number 106147, issue date 2026-01, and no issue number.
+% Supersedes the 2023 working paper the Mixtape cites as Sant'Anna and Xu (2023).
+
+@article{kahnlang2019promise,
+  author  = {Kahn-Lang, Ariella and Lang, Kevin},
+  title   = {The Promise and Pitfalls of Differences-in-Differences: Reflections on
+             `16 and Pregnant' and Other Applications},
+  journal = {Journal of Business \& Economic Statistics},
+  year    = {2019},
+  volume  = {38},
+  number  = {3},
+  pages   = {613--620},
+  doi     = {10.1080/07350015.2018.1546591}
+}
+% Crossref: online 2019-04-02, print issue 2020-07. Cited everywhere (including the Mixtape)
+% as 2019; year kept at 2019 to match. The Mixtape's page range "1--14" is the online-first
+% pagination and is wrong for the issue; 613--620 is the record.
+
+@article{hong2013napster,
+  author  = {Hong, Seung-Hyun},
+  title   = {Measuring the Effect of Napster on Recorded Music Sales:
+             Difference-in-Differences Estimates Under Compositional Changes},
+  journal = {Journal of Applied Econometrics},
+  year    = {2013},
+  volume  = {28},
+  number  = {2},
+  pages   = {297--324},
+  doi     = {10.1002/jae.1269}
+}
+% Crossref: online 2011-10-05, print issue 2013-03. Title is in full caps in the Crossref
+% record; title-cased here to match the rest of the bib.
+
+@techreport{callaway2024continuous,
+  author      = {Callaway, Brantly and Goodman-Bacon, Andrew and Sant'Anna, Pedro H. C.},
+  title       = {Difference-in-Differences with a Continuous Treatment},
+  institution = {National Bureau of Economic Research},
+  type        = {NBER Working Paper},
+  number      = {32117},
+  year        = {2024},
+  doi         = {10.3386/w32117}
+}
+% Preprint: no journal version on Crossref as of 2026-08-26. Also circulates as SSRN 4716682.
+% Companion R package contdid 0.1.1 (CRAN, 2026-07-21). Re-check with bibcheck at manuscript
+% time.
+
+% ---------------------------------------------------------------------------
+% Exemplar rows from the SKILL.md recognition table and the details.md "Exemplar
+% designs" section, staged 2026-08-26. Checked against Crossref unless a line
+% carries a "% unverified" comment. Baker et al. 2026 (baker2026did), Winkler et al.
+% 2026 (winkler2026tiktok) already have keys in causal.bib, and Hong 2013
+% (hong2013napster) is staged above, so none of the three is restaged here.
+% Key convention follows causal.bib: firstauthor + year + first substantive word of
+% the title, skipping a leading article.
+% ---------------------------------------------------------------------------
+
+% Crossref registers Wherry's given name as "Laura R" with no period; the period is
+% added here. Oxford's registered title capitalizes "From" mid-title; kept verbatim.
+
+@article{miller2021medicaid,
+  author  = {Miller, Sarah and Johnson, Norman and Wherry, Laura R.},
+  title   = {{Medicaid} and Mortality: New Evidence From Linked Survey and Administrative Data},
+  journal = {Quarterly Journal of Economics},
+  year    = {2021},
+  volume  = {136},
+  number  = {3},
+  pages   = {1783--1829},
+  doi     = {10.1093/qje/qjab004}
+}
+
+% The AER record prints Levy's given name with a typographic apostrophe (Ro’ee);
+% written with a straight apostrophe here because causal.bib is ASCII throughout.
+
+@article{braghieri2022social,
+  author  = {Braghieri, Luca and Levy, Ro'ee and Makarin, Alexey},
+  title   = {Social Media and Mental Health},
+  journal = {American Economic Review},
+  year    = {2022},
+  volume  = {112},
+  number  = {11},
+  pages   = {3660--3693},
+  doi     = {10.1257/aer.20211218}
+}
+
+% No Crossref record: the AEA did not register DOIs for 1994 AER articles, and the
+% JSTOR DOI 10.2307/2118071 does not resolve on Crossref either. Journal, volume,
+% issue, pages, and year are verified instead against the PubMed record for this
+% article (PMID 10134748), which gives "The American economic review" 84(3): 622-41,
+% June 1994. PubMed stores the title in sentence case; title-cased here to match the
+% rest of the bib and the AER's own styling. Confirmed by OpenAlex W1528109329, whose
+% only locations for this article are that PubMed record and RePEc.
+
+@article{gruber1994incidence,
+  author  = {Gruber, Jonathan},
+  title   = {The Incidence of Mandated Maternity Benefits},
+  journal = {American Economic Review},
+  year    = {1994},
+  volume  = {84},
+  number  = {3},
+  pages   = {622--641}
+}
+
+% No Crossref, OpenAlex, or PubMed record for the 1994 AER article itself. Authors and
+% the hyphenated published title are confirmed by two Crossref records that quote it:
+% the 2000 AER Comment (10.1257/aer.90.5.1362) and Card and Krueger's own 2000 Reply
+% (10.1257/aer.90.5.1397), both of which append a subtitle to this exact string. The
+% NBER working paper (10.3386/w4509) confirms the authorship with "Fast Food"
+% unhyphenated. Journal, volume, and pages come from the Mixtape's reference list and
+% are flagged below. The Mixtape gives no issue number and no resolver supplies one,
+% so the number field is omitted rather than guessed.
+
+@article{card1994minimum,
+  author  = {Card, David and Krueger, Alan B.},
+  title   = {Minimum Wages and Employment: A Case Study of the Fast-Food Industry in {New Jersey} and {Pennsylvania}},
+  journal = {American Economic Review},  % unverified
+  year    = {1994},
+  volume  = {84},        % unverified
+  pages   = {772--793}   % unverified
+}
+
+@article{ferman2020cherry,
+  author  = {Ferman, Bruno and Pinto, Cristine and Possebom, Vitor},
+  title   = {Cherry Picking with Synthetic Controls},
+  journal = {Journal of Policy Analysis and Management},
+  year    = {2020},
+  volume  = {39},
+  number  = {2},
+  pages   = {510--532},
+  doi     = {10.1002/pam.22206}
+}
+
+% Article 110874; Economics Letters gives no issue number. Published version, not a working
+% paper: Crossref registers the journal article (10.1016/j.econlet.2022.110874) alongside an
+% earlier SSRN posting (10.2139/ssrn.4015931). Code at
+% github.com/zachporreca/staggered_adoption_synthdid.
+
+@article{porreca2022synthetic,
+  author  = {Porreca, Zachary},
+  title   = {Synthetic Difference-in-Differences Estimation with Staggered Treatment Timing},
+  journal = {Economics Letters},
+  year    = {2022},
+  volume  = {220},
+  pages   = {110874},
+  doi     = {10.1016/j.econlet.2022.110874}
+}
+
+% AUTHOR ORDER: Crossref and the published Stata Journal article list Clarke, Pailanir, Athey,
+% Imbens. The Mixtape's reference list gives it as "Athey, Susan, Damian Clarke, Guido W.
+% Imbens, and Daniel Pailanir. 2024", which is wrong. The entry below follows Crossref.
+% Pailanir carries a tilde (Pailanir -> Paila{\~n}ir) in the published byline.
+
+@article{clarke2024synthetic,
+  author  = {Clarke, Damian and Paila{\~n}ir, Daniel and Athey, Susan and Imbens, Guido W.},
+  title   = {On Synthetic Difference-in-Differences and Related Estimation Methods in Stata},
+  journal = {The Stata Journal},
+  year    = {2024},
+  volume  = {24},
+  number  = {4},
+  pages   = {557--598},
+  doi     = {10.1177/1536867X241297914}
+}
+
+% ---------------------------------------------------------------------------
+% Exemplar rows from the SKILL.md recognition table and the details.md "Worked
+% precedents" table, staged 2026-08-26, Crossref-verified. Abadie-Gardeazabal 2003
+% (abadie2003economic), Abadie-Diamond-Hainmueller 2010 (abadie2010synthetic) and
+% 2015 (abadie2015comparative) already have keys in causal.bib and are not restaged.
+% The Texas prison row is the Mixtape's own data exercise and has no paper to cite.
+% ---------------------------------------------------------------------------
+
+% Two Crossref records exist for this article. The JSTOR one (10.2307/2523702) keeps
+% the 1990 journal name, Industrial and Labor Relations Review, but gives only the
+% first page. The SAGE one used here gives the full page range under the journal's
+% current name, ILR Review. Journal field follows the 1990 name.
+
+@article{card1990impact,
+  author  = {Card, David},
+  title   = {The Impact of the {Mariel} Boatlift on the {Miami} Labor Market},
+  journal = {Industrial and Labor Relations Review},
+  year    = {1990},
+  volume  = {43},
+  number  = {2},
+  pages   = {245--257},
+  doi     = {10.1177/001979399004300205}
+}
+
+% Year is the Crossref published-print date (2019); the issued date is the 2018-01-30
+% online posting. Crossref and OpenAlex both register the published title without the
+% subtitle "Synthetic Control Method Meets the Mariel Boatlift" that the working-paper
+% versions and the Mixtape's reference list carry, so it is omitted here.
+
+@article{peri2019labor,
+  author  = {Peri, Giovanni and Yasenov, Vasil},
+  title   = {The Labor Market Effects of a Refugee Wave},
+  journal = {Journal of Human Resources},
+  year    = {2019},
+  volume  = {54},
+  number  = {2},
+  pages   = {267--309},
+  doi     = {10.3368/jhr.54.2.0217.8561r1}
+}
+
+% ---- Keys newly cited by the causal-design canon in this pass; entries carried over
+% from the shared bib unchanged.
+
+@article{egami2022make,
+  author  = {Egami, Naoki and Fong, Christian J. and Grimmer, Justin and Roberts, Margaret E. and Stewart, Brandon M.},
+  title   = {How to make causal inferences using texts},
+  journal = {Science Advances},
+  year    = {2022},
+  volume  = {8},
+  number  = {42},
+  pages   = {eabg2652},
+  doi     = {10.1126/sciadv.abg2652}
+}
+
+@article{feder2022causal,
+  author  = {Feder, Amir and Keith, Katherine A. and Manzoor, Emaad and Pryzant, Reid and Sridhar, Dhanya and Wood-Doughty, Zach and Eisenstein, Jacob and Grimmer, Justin and Reichart, Roi and Roberts, Margaret E. and Stewart, Brandon M. and Veitch, Victor and Yang, Diyi},
+  title   = {Causal Inference in Natural Language Processing: Estimation, Prediction, Interpretation and Beyond},
+  journal = {Transactions of the Association for Computational Linguistics},
+  year    = {2022},
+  volume  = {10},
+  pages   = {1138--1158},
+  doi     = {10.1162/tacl_a_00511}
+}
+
+@book{wooldridge2010econometric,
+  author    = {Wooldridge, Jeffrey M.},
+  title     = {Econometric Analysis of Cross Section and Panel Data},
+  edition   = {2},
+  publisher = {MIT Press},
+  year      = {2010}
+}

--- a/skills/causal-design/references/details.md
+++ b/skills/causal-design/references/details.md
@@ -111,18 +111,42 @@ Designs, estimators, and diagnostics live in field-experiment.
   outcomes) and no hidden treatment versions; justified by "logical argumentation based on
   institutional knowledge."
 
-## Package index (verified against docs/source 2026-07-28; the observables branch only, method skills carry their own)
+## Text-role warnings (Feder; detail behind the fourth triage question)
+
+- Confounder: conditional ignorability becomes "the NLP model measured all confounding
+  aspects of the text," untestable, argued from domain expertise. Positivity audit: if the
+  representation predicts treatment nearly perfectly, overlap has failed; narrow the
+  estimand or re-specify. The family's revision: the banned part of Feder's recommended
+  Veitch-style fine-tuning is the treatment-prediction loss (GPI's own deconfounder trains
+  on the outcome loss); the dispute, the replacement, and the TI-estimator carve-out live
+  in causal-unstructured.
+- Outcome: consistency fails when the measurement model was trained on all the data (each
+  unit's inferred outcome then depends on other units' treatments); split-sample
+  measurement is the fix (egami2022make; this is Feder's consistency framing of the rule
+  whose authoritative statement, the FPCILV, lives in causal-unstructured). Randomizing
+  treatment fixes ignorability and positivity here, not consistency.
+- Treatment: treatment discovery vs prespecified latent aspects; disentangle the aspect
+  from correlated aspects of the same text; random assignment of texts leaves reader-side
+  confounding.
+- No real-world ground-truth causal benchmarks exist for text; semi-synthetic benchmark
+  wins never validate a real estimate.
+- Deployment shift tests (invariance: perturb what should not matter, predictions must not
+  move; sensitivity: minimal label-flipping edits, predictions must move) now live in
+  causal-unstructured's diagnostics battery; this line is a pointer.
+
+## Package index (verified against docs/source 2026-07-28, CRAN versions re-checked 2026-08-26; the observables and plain-FE branches only, method skills carry their own)
 
 | Tool | Version | Role | Traps |
 |---|---|---|---|
 | grf | 2.6.1 | causal_forest + average_treatment_effect (AIPW default, TMLE binary-only option); best_linear_projection (HC3); rank_average_treatment_effect; policy scores | treatment argument is W; clusters= at FIT time is what makes ATE SEs cluster-robust; target.sample="overlap" = Li-Morgan-Zaslavsky ATO, the documented poor-overlap fallback; RATE priorities need a held-out forest; hist(cf$W.hat) is the documented overlap check (pinned also in field-experiment's details; update the two pins together on refresh) |
-| policytree | 1.2.4 | double_robust_scores(forest) -> policy_tree(X, Gamma, depth = 2) | Gamma columns = actions in order (1 control, 2 treated); predict returns the column index, not 0/1; exact search exponential in depth |
+| policytree | 1.2.5 | double_robust_scores(forest) -> policy_tree(X, Gamma, depth = 2) | Gamma columns = actions in order (1 control, 2 treated); predict returns the column index, not 0/1; exact search exponential in depth |
 | sensemakr | 0.1.6 | Cinelli-Hazlett sensitivity: robustness values, benchmark bounds, ovb_minimal_reporting (latex/html) | treatment looked up by coefficient name, so factor treatments FAIL (undocumented, in source): code treatment numeric 0/1; kd defaults to 1, pass kd = 1:3 for the standard table; lm objects (fixest method on GitHub) |
-| WeightIt | 1.7.0 | balancing weights, estimand = "ATO" for overlap weights (method = "glm") | ATO not available for every method (check ?method_<name>); downstream is lm_weightit/glm_weightit + marginaleffects::avg_comparisons (M-estimation SEs account for estimated weights); plain lm + vcovCL treats weights as fixed; keep.mparts=TRUE default enables the M-estimation SEs |
+| WeightIt | 2.0.0 | balancing weights, estimand = "ATO" for overlap weights (method = "glm") | ATO not available for every method (check ?method_<name>); downstream is lm_weightit/glm_weightit + marginaleffects::avg_comparisons (M-estimation SEs account for estimated weights); plain lm + vcovCL treats weights as fixed; keep.mparts=TRUE default enables the M-estimation SEs |
 | marginaleffects | 0.32.0 | g-computation/contrasts on weightit fits (native support) | no grf support; use grf's own estimators for forests (pinned also in field-experiment's details; update the two pins together on refresh) |
 | DoubleML | 1.0.2 | explicit double/debiased ML when nuisance-learner control is wanted (mlr3) | heavier setup; the grf route covers the default DR case |
 | MatchIt | 4.7.2 | matching as preprocessing when a matched design is wanted | same author ecosystem as WeightIt; matching never fully efficient (Imbens), prefer DR estimation after |
-| estimatr | 1.0.6 | lm_robust with HC/CR SEs (shared with field-experiment) | design-based defaults; already the family's experiment workhorse (pinned also in field-experiment's details; update the two pins together on refresh) |
+| estimatr | 1.0.6 | lm_robust with HC/CR SEs (shared with field-experiment); lm_robust(y ~ d, fixed_effects = ~unit, clusters = unit, se_type = "stata") is the within fit with Stata's FE standard errors, the Mixtape's own route | design-based defaults; already the family's experiment workhorse (pinned also in field-experiment's details; update the two pins together on refresh); the argument is fixed_effectS, and the Mixtape's `fixed_effect = ~id` runs only because lm_robust has no dots and R partial-matches the name; clusters takes a BARE unquoted name while fixed_effects takes a right-sided formula; se_type = "stata" means HC1 when clusters is absent and Stata's cluster-robust variant when it is present, so it matches xtreg, fe only with clusters supplied (the default is HC2 without clusters and CR2 with) |
+| fixest | 0.14.2 | feols for the within estimator on a time-varying treatment: feols(y ~ d \| unit, cluster = ~unit); etable() prints pooled OLS and within side by side (the plain-panel-fixed-effects section of SKILL.md) | the bar separates fixed effects from regressors, so the treatment stays to its left; cluster takes a formula (~unit), unlike estimatr's bare name; units with no within variation in d are absorbed and dropped without a message, which is why that section runs the zero-variance count first |
 
 Docs: grf-labs.github.io/grf, grf-labs.github.io/policytree, carloscinelli.com/sensemakr,
 ngreifer.github.io/WeightIt, marginaleffects.com.

--- a/skills/did/SKILL.md
+++ b/skills/did/SKILL.md
@@ -16,14 +16,34 @@ Refresh path: this literature moved fast in 2018-2024 and is still moving. To up
 litreview skill on "difference-in-differences" since the canon date and fold results into
 references/canon.md as flagged addenda.
 
+## Exemplar designs
+
+Seven shapes worth recognizing on sight. Find the one your data looks like before writing a
+specification; what each one teaches is in references/details.md.
+
+| Design shape | Canonical case | Marketing analogue | What kills it |
+|---|---|---|---|
+| Never-treated comparison with the full evidence battery | Miller, Johnson, and Wherry (2021) | a feature launched in some markets and withheld in others, with take-up data | a control group quietly exposed to the treatment |
+| Staggered rollout across institutions, adoption dates rebuilt from an archive | Braghieri, Levy, and Makarin (2022) | a platform reaching accounts, regions, or partners on its own schedule | adoption dates that are wrong, or dated to enforcement when behavior moved at announcement |
+| Forward engineering from estimand to estimator | Baker et al. (2026) Medicaid | any panel whose units differ enormously in size | reporting the weighted and the unweighted ATT as a robustness pair |
+| Estimand first on a heavy-tailed outcome | Winkler et al. (2026) UMG-TikTok | streams, revenue, views, sessions | a log taken for convenience |
+| Compositional change in repeated cross-sections | Hong (2013) Napster | brand trackers and refreshed survey panels | who is sampled moves with treatment timing |
+| Triple differences | Gruber (1994) | an ineligible segment inside the same treated markets | reading the placebo DiD as a test that has to return zero |
+| The idea, not the inference | Card and Krueger (1994) | a two-region holdout test | G = 2 with one treated cluster |
+
 ## Triage: three questions before anything else
 
 From Roth, Sant'Anna, Bilinski, and Poe (2023), the most condensed decision object in the
 literature:
 
-1. **Is everyone treated at the same time?** Yes: TWFE is fine, static or dynamic; nothing new
-   is needed. No (staggered): default to a heterogeneity-robust estimator; TWFE only if you will
-   defend effect homogeneity.
+1. **Is everyone treated at the same time?** Yes: TWFE is fine, static or dynamic, without
+   covariates; with covariates see Covariates below. For two groups and two periods the
+   estimator is interaction OLS or the long difference, clustered at the level of assignment.
+   The identity of interaction OLS, TWFE, and the long difference holds exactly only in that
+   2x2 with no covariates, and it is what makes people reach for TWFE-with-controls, where it
+   no longer holds. Everything else in this skill still applies to a 2x2. No (staggered):
+   default to a heterogeneity-robust estimator; TWFE only if you will defend effect
+   homogeneity.
 2. **Are you sure about parallel trends, and on which scale?** Justify levels vs logs (PT is
    functional-form dependent and generally cannot hold in both) and name the estimand the
    scale targets (Functional form below). If PT is plausible only conditional on
@@ -50,6 +70,28 @@ causal-design; a failed gate is a verdict. If treatment timing is quasi-random, 
 but inefficient; use the efficient random-timing estimators (R package staggered,
 Roth-Sant'Anna).
 
+## Assumptions and treatment dating
+
+Parallel trends is the assumption this skill argues about. Two others get stated and forgotten,
+and both fail silently.
+
+No anticipation: the treated group's outcome is Y(0) until treatment happens. An already-treated
+baseline attenuates the estimate and nothing in the diagnostics battery flags it. In the
+Mixtape's simulation (Cunningham, Causal Inference: The Remix, ch. 9) a contaminated baseline
+returns 0.017 against a true ATT of 10 under constant effects and 15.017 against a true 20 under
+dynamic effects. Make the baseline clean. When announcement precedes enforcement and behavior
+can respond (pre-announced price changes, regulatory effective dates published
+months ahead), date treatment to the announcement and state the two prices: the
+ATT now averages over a longer post window including announced-but-unenforced periods, and
+parallel trends is now stated against a different baseline.
+
+SUTVA: no interference between units, and the treatment is the same thing for every treated
+unit. Panel threats are spillover to adjacent control markets, substitution across one firm's
+own units, and the announcement-versus-enforcement gap, which makes "announced" and "announced
+and enforced" two treatments. Interference contaminates the control group's Y(0), so the
+comparison understates the effect or reverses its sign. Buffer or drop adjacent controls, or
+model exposure and make the exposure the treatment.
+
 ## Estimand before estimator
 
 Weights define the target parameter, not the specification (Baker et al. 2026). An unweighted
@@ -61,6 +103,12 @@ question and, if you report both, report them as different estimands.
 
 Write the target in potential-outcomes notation before touching code: which ATT(g,t) cells, and
 which aggregation (event-time, calendar-time, overall; cohort-share or population weights).
+Callaway-Sant'Anna aggregates the same building blocks four ways: simple, one average over all
+feasible group-times; group, ATT(g), the effect on each cohort; calendar, ATT(t), the effect in
+each period, which is the target when the question is about a season, a platform change, or a
+macro shock; and dynamic, ATT(l), the event study. Those are four parameters, not four
+robustness checks, and the feasible (g,t) set shrinks at long horizons, so each covers a
+different slice of the data.
 
 Functional form and weights are estimand choices too (Winkler, Hotz-Behofsits, Wlömert, Papies,
 and Liaukonytė 2026). Three parameters get reported as if they were one: the typical-unit
@@ -87,11 +135,23 @@ Three variants under staggered adoption, with the estimator crosswalk:
 | PT-NYT | not-yet-treated | no | Callaway-Sant'Anna (NYT), dCDH instantaneous | `did::att_gt(control_group="notyettreated")` |
 | PT-all | all groups, all periods | yes (testable, and baked in) | BJS/Gardner/LWX imputation, Wooldridge ETWFE | `didimputation`, `did2s`, `etwfe` |
 
+Sun-Abraham sits under PT-Nev for a reason worth naming at the point of use: its cohort 2x2s use
+the last-treated cohort or the never-treated, never the not-yet-treated. Against a CS-NYT default
+the `sunab` cross-check in the template therefore compares two assumptions, and neither agreement
+nor divergence is a robustness result.
+
 Default: **Callaway-Sant'Anna with not-yet-treated controls**, Baker et al.'s own choice for
-their application. Move to never-treated when the not-yet-treateds' timing plausibly responded
+their application. That default is licensed by no anticipation among the not-yet-treated: if
+their behavior already responds to the treatment they are about to get, they are not clean
+controls. Move to never-treated when the not-yet-treateds' timing plausibly responded
 to recent outcomes; move to imputation (PT-all) when you will defend parallel pre-trends over
 the whole panel and errors are near-serially-uncorrelated, where it buys real efficiency
-(Roth et al. 2023). If Y(0) is close to a random walk, the CS last-pre-period baseline is the
+(Roth et al. 2023). A long covariate list is a further reason to move to imputation or
+Wooldridge ETWFE, since the CS propensity score is estimated per cohort and with fifty
+covariates common support gets hard to assess and harder to defend. The price is that imputation
+event-study plots are not comparable to CS or TWFE plots, because fitting the counterfactual on
+the whole pre-period puts a mechanical kink at t = -1, so do not overlay them. If Y(0) is close
+to a random walk, the CS last-pre-period baseline is the
 efficient choice and imputation's pre-period averaging buys nothing (Harmon's caveat: averaging
 is not guaranteed more precise). If PT is implausible for one specific cohort, drop that cohort
 rather than average over it.
@@ -102,7 +162,16 @@ comparison, and drop units treated in the first period.
 
 ## The TWFE question, stated honestly
 
-The canon disagrees, and the skill's position is a default with named dissent:
+The same regression is two designs. With an adoption date and units that are never or not-yet
+treated, `y ~ treat | unit + period` is a DiD and the assumption is parallel trends. With a
+treatment that varies within unit over time and no comparison group at all, the identical
+regression is the within estimator and the assumption is strict exogeneity conditional on the
+unit effect, non-nested with parallel trends and failing differently (feedback from past
+outcomes to current treatment). The Mixtape (Cunningham, Causal Inference: The Remix, ch. 8)
+teaches that they are the same thing, true as algebra and false as design. Route the second case
+to causal-design's plain-panel-fixed-effects section; nothing below applies to it.
+
+For the first case the canon disagrees, and the skill's position is a default with named dissent:
 
 - Baker et al. (2026): TWFE under staggered adoption has "well-understood, potentially serious,
   and easily remedied problems, and we do not recommend using it."
@@ -120,6 +189,23 @@ have been fine is to run the robust estimator anyway, at which point you report 
 al.). Run the building-block heterogeneity scan (2x2 DiDs by cohort, gap, and time since
 adoption, Arkhangelsky-Imbens) rather than trusting any single robust estimator blindly.
 
+The weights do something the negative-weight framing hides. Goodman-Bacon weights combine a
+sample share and the treatment-timing variance Dbar(1 - Dbar), which peaks at 0.25 for a cohort
+treated at the panel midpoint, so TWFE upweights mid-panel cohorts and extending or truncating
+the panel moves the estimate through the weights alone. Under constant effects TWFE is unbiased
+for the variance-weighted ATT and not for the simple ATT. That also reconciles bacondecomp's
+all-positive weights, which sit on 2x2 comparisons, with TwoWayFEWeights' negative ones, which
+sit on unit-level treatment effects: both are right, and all-positive Bacon weights do not
+license TWFE.
+
+The Mixtape (ch. 10) rejects stacking estimators on one event-study plot: "These estimators all
+have slightly different assumptions and should not be considered robustness checks for one
+another." Two practices are in play. Reporting TWFE beside one robust estimator is asymmetric,
+because TWFE is the estimator whose bias the exercise bounds, so agreement or divergence is
+information about heterogeneity. Stacking four heterogeneity-robust estimators is symmetric,
+they impose different PT variants and use different comparison groups, and the objection lands
+there: choose ex ante by design, and if you genuinely cannot, pre-commit to reporting all.
+
 ## Event-study mechanics
 
 Hard rules, mostly from Abadie, Angrist, Frandsen, and Pischke (2025):
@@ -128,11 +214,24 @@ Hard rules, mostly from Abadie, Angrist, Frandsen, and Pischke (2025):
   lead m = max c(s) - 1. Here s indexes treatment cohorts and c(s) is cohort s's adoption
   period. The formulas assume periods renumbered 1..T, so calendar years must be reindexed
   first.
-- Always omit event time -1. With never-treated units that single normalization identifies
-  everything. Without them, a second lead or lag must be omitted, the linear component of the
-  effect path is unidentified, and different second choices rotate the whole path around -1.
-  Choose deliberately, never let the software's default drop decide, and show the path under at
-  least two normalizations before interpreting dynamics.
+- Always omit event time -1. The Mixtape (ch. 9) gives the reason, that no anticipation requires
+  an untreated baseline, and stops there; with never-treated units that single normalization
+  identifies everything, and without them a second lead or lag must also be omitted, the linear
+  component of the effect path is unidentified, and different second choices rotate the whole
+  path around -1. Choose deliberately, never let the software's default drop decide, and show
+  the path under at least two normalizations before interpreting dynamics.
+- Short gaps versus long differences, a hard rule. OLS event studies mechanically use a
+  universal baseline, so every coefficient is a long difference against t = -1.
+  Callaway-Sant'Anna and dCDH can produce either, and a rolling baseline gives short gaps, which
+  estimate a different quantity (Roth 2026). Stata's `csdid` defaults to short gaps and needs
+  `long2`, `csdid2` defaults to long differences, R's `did` needs `base_period = "universal"`.
+  Reader-side tell in someone else's paper: a confidence interval at t = -1 means a rolling
+  baseline, since t = -1 cannot be its own baseline, and the leads top out one period earlier.
+- Reading the coefficients out loud. A lead of +1.5 means the treated group's change from that
+  period to the omitted baseline ran 1.5 outcome units above the control group's. A lag is the
+  ATT for that period, valid only under PT from the baseline to it, no anticipation, and an
+  untreated comparison group. Plot disconnected points with whiskers: connecting the bands makes
+  the intervals appear to narrow toward the omitted period, where nothing was estimated.
 - Bin leads and lags beyond the horizon where only a few units identify the coefficient (AAFP
   use +/-15 with 41 periods). Clustered SEs fail at long horizons through leverage: a lone late
   adopter can identify the longest leads, and coverage collapses.
@@ -156,9 +255,14 @@ do not imply parallel post-trends.
 
 The canon splits on pretesting itself. Roth (2022) shows conditioning on passing adds selection
 bias; AAFP's cost-benefit analysis concludes "the bias-mitigation benefits of pretesting are
-likely to outweigh the risks" and prescribes a sup-t joint test of the leads. Default here: run
-the sup-t pretest and report it, but never let a pass substitute for the sensitivity analysis,
-and report the test's power against economically relevant violations (R package pretrends).
+likely to outweigh the risks" and prescribes a sup-t joint test of the leads. The Mixtape (ch.
+10) is a third position, nearer Roth than AAFP: "event studies were always only falsifications.
+They weren't true tests", parallel trends is untestable, and honest DiD is not a test of it
+either. Default here: run the sup-t pretest and report it, but never let a pass substitute for
+the sensitivity analysis, and report the test's power against economically relevant violations
+(R package pretrends). That pretest is not a claim that parallel trends is testable. It is a
+claim that a joint test with a reported power curve is a better-calibrated version of the
+eyeball heuristic everyone runs anyway.
 
 Mandatory companion to every event study: Rambachan-Roth honest inference (HonestDiD), in one
 or both of its restrictions, a universality that is this family's own hardening of the canon's
@@ -172,20 +276,54 @@ M-bar = 2 is strong in a calm period and weak if treatment coincided with a shoc
 anything pre-treatment. Worked template numbers (Baker et al.): largest one-period pre-trend 4,
 identified set -2.6 +/- 4 = [-6.6, 1.4], robust CI [-11.1, 5.1].
 
+## Why these units were treated
+
+Answer that before reading the pre-trend picture. The assignment mechanism is learned outside
+the dataset, from institutional detail, and it decides how the picture should be read (Ghanem,
+Sant'Anna, and Wüthrich; Marx, Tamer, and Tang 2024, via the Mixtape ch. 9). Five mechanisms are
+compatible with parallel trends: a common constant trend in Y(0), under which PT cannot be
+violated however units were selected; selection on baseline Y(0); selection on fixed effects;
+selection on observables, which is conditional PT and sends you to Covariates below; and
+selection under imperfect foresight. One breaks PT: selection on realized gains, where units
+take the treatment because they correctly infer it will help them. The table in
+references/details.md separates what each does to pre-trends from what it does to PT.
+
+Selection on baseline Y(0) is the case that misleads. Enrolling everyone below a threshold on
+baseline Y does not violate PT and does break pre-trends mechanically, because the baseline is
+both the selection point and the omitted category, which manufactures a dip for the treated
+group at t = -1. There is no fix because there is no problem, and re-basing to t = -2 to make
+the picture look right breaks PT, which held from the original baseline.
+
+That collides with the HonestDiD mandate, and the resolution here is the skill's own judgment.
+Relative magnitudes bounds post-treatment violations by M-bar times the largest pre-treatment
+violation, so under a documented selection-on-baseline-outcome mechanism the anchor is inflated
+by an artifact of the assignment rule and the skill would otherwise drive you to call a valid
+design fragile. Prefer the smoothness restriction there, or compute the anchor from the
+pre-treatment periods excluding the selection period, and say which you did. The reverse case is
+worse: under selection on realized gains, clean pre-trends are no comfort at all.
+
 ## Covariates
 
 Never bare TWFE-with-controls: even in the 2x2 it identifies the ATT only under constant effects
 across covariate strata, weights strata non-convexly, and adds three misspecification bias terms
 (Caetano-Callaway, via Baker et al. 2026). Choose covariates from theory (determinants of
-untreated trends or of selection), check they are unaffected by treatment (a time-varying
-covariate is fine only if its whole path is unaffected), then use:
+untreated trends or of selection), and ask domain experts what ordinarily drives untreated
+trends in this outcome, since that is the arm of the DAG nobody guesses well. If you select
+covariates from the data, run the selection on untreated units only, so only Y(0) informs it
+(Borgschulte and Vogler 2020). State the covariate list before you see results: the choice can
+swing the estimate and a DAG does not protect against specification search. Check the covariates
+are unaffected by treatment (a time-varying covariate is fine only if its whole path is
+unaffected), then use:
 
 - **Doubly robust (default)**: `did::att_gt(est_method="dr")`, Sant'Anna-Zhao. Consistent if
   either the outcome-change model or the propensity model is right.
 - Regression adjustment when overlap is weak (extrapolates the outcome model; say so).
 - IPW when you understand selection better than outcome dynamics; noisy as control propensity
-  scores approach 1. The did/DRDID packages trim above 0.995 by default; keep the trim and plot
-  the propensity distributions by group first.
+  scores approach 1. Histograms and kernel densities do not reveal explosive weights, so count
+  the control units with a propensity score near 1 directly. In the Mixtape's CAPS data (ch. 10)
+  one control municipality scores 0.999971, which is a weight of p/(1-p) = 34,481, and eleven
+  control units sit above 0.995. Trim at 0.995 and keep the trim. R's did trims automatically
+  and not every package does, so check what yours does before trusting the estimate.
 
 Conditioning on lagged outcomes changes the identifying assumption from PT to unconfoundedness.
 The two are non-nested; matching on lagged outcomes can create mean-reversion bias when groups
@@ -193,6 +331,21 @@ differ in levels but genuinely trend in parallel (Daw-Hatfield, via Roth et al. 
 disagree, the bracketing result bounds the truth: under unconfoundedness with treated-group
 pre-treatment dominance, TWFE underestimates and lagged-outcome adjustment overestimates
 (Arkhangelsky-Imbens 2024). Report both and say which selection story you believe.
+
+## Triple differences
+
+A design, not a falsification. DDD identifies the ATT when the non-parallel-trends bias of the
+main DiD equals that of the placebo-group DiD (Olden and Møen 2022). Two consequences change
+practice: the placebo DiD does not have to be zero, so a nonzero one is no reason to discard the
+design; and if it is zero the main DiD was unbiased all along, DDD was never needed, and
+presenting the placebo DiD as a same-outcome-alternative-group falsification is the stronger
+paper (Miller, Johnson, and Wherry 2021 is the Mixtape's instance).
+
+Estimate it as the saturated OLS three-way interaction or its event-study form with
+group-by-year, unit-by-year, and group-by-unit fixed effects and the triple interaction with
+year dummies (both in references/details.md), clustered at the level treatment was applied.
+Keep the caveat that DDD is not simply the difference of two DiDs once covariates or staggered
+not-yet-treated comparisons enter (Ortiz-Villavicencio and Sant'Anna, via Baker et al. 2026).
 
 ## Functional form and nonlinear outcomes
 
@@ -280,21 +433,36 @@ option with the homogeneity assumption it needs, which is the selection criterio
 a cluster-level Fisher randomization test, exact under the sharp null when timing is as good as
 random.
 
+Two Mixtape rules to disarm. Chapter 9 reads Card and Krueger's two-state minimum wage design off
+a t-statistic of about 2 and calls it significant; at the assignment level that is G = 2 with one
+treated cluster, every MacKinnon-Nielsen-Webb concern zone firing at once and a CV1 standard
+error that can be too small by a factor of five or more. It is the canonical exemplar of the DiD
+idea and not a template for inference, and a modern version of it lands on the few-clusters map
+or the synthetic-control handoff. Chapter 8's rule of thumb, fewer than 30 clusters too small and
+30 to 40 probably enough, is unsafe in both directions: CV1 can be reliable at G = 20 in
+favorable cases and unreliable at G = 200 in unfavorable ones. Run the battery instead of
+counting clusters.
+
 ## Beyond the absorbing binary treatment
 
 - Treatments that turn on and off (promotions, price changes): dCDH estimators require
   no-carryover; for advertising and pricing that assumption is usually wrong, so check it and
-  prefer the intertemporal extension (`DIDmultiplegt`/`did_multiplegt_dyn`).
+  prefer the intertemporal extension (`DIDmultiplegtDYN` in R, `did_multiplegt_dyn` in Stata).
 - Continuous treatment intensity: ATT(d|d) is identified under standard PT, but causal-response
   parameters need strong PT across doses (Callaway, Goodman-Bacon, Sant'Anna).
 - Exposure designs (baseline exposure share times a national change): the linear-interaction
   coefficient is an average marginal effect, roughly kappa + 2 phi E[M], not E[tau_s]; add the
   squared-exposure interaction when heterogeneity is plausible and report both (AAFP 2025).
-- Triple differences: not simply the difference of two DiDs once covariates or staggered NYT
-  comparisons enter (Ortiz-Villavicencio and Sant'Anna, via Baker et al.).
 - Repeated cross-sections (brand trackers, surveys, transaction data with one row per unit):
   fine without covariates; with covariates, test compositional stability (Sant'Anna-Xu
-  Hausman-type check) before pooling. Unit fixed effects are unavailable, so the Wooldridge
+  Hausman-type check) before pooling. The failure is compositional change: who is sampled moves
+  with treatment timing in a way correlated with Y(0), so PT breaks with nobody mistreated (Hong
+  2013 on Napster, where internet users got older, poorer, and less likely to hold a degree as
+  the treatment spread). Two diagnostics: covariate means across periods by group, and a DiD run
+  with each strictly exogenous covariate as the outcome, where a significant interaction is
+  differential compositional drift. Hong's fix is two period-specific propensity scores, one pre
+  and one post, as inverse probability weights in a WLS DiD; Sant'Anna-Xu is the modern test.
+  Unit fixed effects are unavailable, so the Wooldridge
   (2026) design puts cohort dummies in their place with covariates centered within
   cohort-period cells; it covers staggered adoption and nonlinear outcomes in one pooled QMLE,
   weights ATT(g,t) by the cell sizes N_gt when aggregating, and clusters at the assignment
@@ -302,9 +470,27 @@ random.
   the SEs are believable, so collapse thin cohorts to exposure-time effects. You cannot verify
   that covariates are time-invariant when each unit is seen once. Say so.
 
+## The design stage, before you look at the outcome
+
+In order, each finished before the next. Nothing before the last step needs the outcome, and
+that deferral is the discipline (Rubin 2008's design trumps analysis, via the Mixtape ch. 10).
+
+1. Write the target parameter in potential outcomes: which population, which weights.
+2. Count units per cohort, including never-treated and always-treated, with cohort shares. A
+   cohort holding a sixth of the treated units dominates every aggregation, and always-treated
+   units have to be found and dropped before anything else runs.
+3. Plot the treatment rollout, unit by period (`panelView`, Mou, Liu, and Xu 2023).
+4. Choose the control group and commit before results exist. The more random the assignment, the
+   less the choice matters; the less random, the more selection drives it.
+5. Choose unconditional or conditional parallel trends.
+6. Check covariate balance and overlap.
+7. Only now plot average outcomes by cohort.
+
 ## Diagnostics battery
 
-Report with every DiD analysis, in roughly this order:
+Report with every DiD analysis, in roughly this order. Items 1 to 10 ask whether the estimator
+is doing what it claims; 11 to 13 ask whether something other than the treatment produced the
+pattern, and 11 runs before any of the rest:
 
 1. Raw group-mean time-series plot (the anatomy plot; it contains every number the estimator
    uses) and the ATT(g,t) matrix in calendar and event time.
@@ -317,13 +503,39 @@ Report with every DiD analysis, in roughly this order:
    the covariate is strictly exogenous.
 6. Propensity overlap plot when covariates enter.
 7. TWFE alongside the robust estimator; if they diverge, Goodman-Bacon decomposition
-   (bacondecomp) and dCDH negative-weight diagnostics (TwoWayFEWeights) to show why.
+   (bacondecomp) and dCDH negative-weight diagnostics (TwoWayFEWeights) to show why. Run the
+   weight diagnostics to explain a divergence, never as a standing robustness table, and do not
+   read all-positive Bacon weights as a licence for TWFE.
 8. Building-block heterogeneity scan by cohort, gap, and time since adoption.
 9. Composition checks: balanced event time, fixed cohort set.
 10. Outcome concentration (Lorenz, Gini, top-decile share) and the estimand each reported
     specification targets; the Ciani-Fisher variance-shift regression whenever a log outcome
     is reported; the Roth-Sant'Anna functional-form check when the transformation is
     contestable; for nonlinear models, the event study on the index scale.
+11. Bite: evidence that the treatment changed the thing it was supposed to change.
+12. Falsifications, both families, read by the rule below.
+13. Mechanism: why the effect happened, and evidence consistent with that story.
+
+## The evidence battery
+
+Bite comes first in time and is the cheapest thing in this file. Before estimating effects on the
+outcome you care about, show the treatment changed what it was supposed to change: take-up,
+exposure, eligibility, enrollment, price paid, impressions delivered. With no first stage there
+is no reason to expect a reduced form, and the project can die here before the expensive
+machinery runs. Snow tested the salt content of tap water himself when households did not know
+their supplier: measure the treatment yourself and do not trust the merge.
+
+Falsification has two families, the same outcome on an alternative group your treatment cannot
+have touched and the same group on an alternative outcome your treatment cannot move. Read a
+null as suggestive evidence for parallel trends, of the same evidentiary class as a clean
+pre-trend; a rejection does not prove the main result spurious, it revives a rival explanation
+you now have to answer. Mechanism is the third item: say why the effect happened and show
+something consistent with it.
+
+Falsifications and event studies answer different questions, and the Mixtape (ch. 9) ranks
+falsifications higher for judging parallel trends. The event study plus HonestDiD bounds how
+large a PT violation the conclusion survives; a falsification tests whether one named rival
+explanation makes a prediction that fails. Run both.
 
 ## R implementation
 
@@ -340,7 +552,8 @@ atts <- att_gt(yname = "y", tname = "period", idname = "unit",
                xformla = NULL,                   # or ~ x1 + x2 for conditional PT
                control_group = "notyettreated",  # states the PT variant you impose
                est_method = "dr", clustervars = "cluster",
-               base_period = "universal",        # REQUIRED for the honest_did chain
+               base_period = "universal",        # long differences, not short gaps (Roth 2026);
+                                                 # the honest_did chain also requires it
                data = df)
 es <- aggte(atts, type = "dynamic", min_e = -15, max_e = 15, cband = TRUE)
 ```

--- a/skills/did/references/canon.md
+++ b/skills/did/references/canon.md
@@ -176,6 +176,41 @@ AEA Papers and Proceedings 116: 75-80. Key: `wooldridge2026nonlinear`.
 - Quote: "Assumption CPT imposes the parallel trends assumption on G^{-1}(E[Y_t(∞) | D, X_t]).
   In general, CPT does not hold for E[Y_t(∞) | D, X_t]" (p. 76).
 
+## Ghanem, Sant'Anna, and Wüthrich
+
+"Selection and Parallel Trends". Key: `ghanem2022selection` (still a preprint, SSRN 4215029;
+the circulating version is dated 2024, which is how the Mixtape cites it).
+
+- Role: the assignment-mechanism half of parallel trends, and the source for SKILL.md's "Why
+  these units were treated". Read alongside Marx, Tamer, and Tang (2024) on forward-looking
+  choice.
+- Settles: which selection mechanisms are compatible with PT (common constant trend, selection
+  on baseline Y(0), selection on fixed effects, selection on observables, imperfect foresight)
+  and which is not (selection on realized gains, Heckman-Urzua-Vytlacil essential heterogeneity,
+  after Roy 1951); and that selection on baseline Y(0) breaks pre-trends mechanically while
+  leaving PT intact, because the baseline is both the selection point and the omitted category.
+- Binds when: reading a pre-trend picture; deciding whether a baseline dip is a problem; setting
+  the HonestDiD relative-magnitudes anchor.
+- Implement: names no software. The mechanism table and the HonestDiD interaction are in
+  details.md, the latter labeled as the skill's own judgment.
+
+## Roth (2026), event-study interpretation
+
+The Japanese Economic Review 77(2): 275-288, "Interpreting event-studies from recent
+difference-in-differences methods". Key: `roth2026interpreting`. The Mixtape cites the 2024
+working paper; this is the published version.
+
+- Role: what an event-study coefficient means once the estimator is not OLS.
+- Settles: short gaps versus long differences (a rolling baseline estimates a different quantity
+  from a universal one, and OLS can only produce the latter); the BJS kink at t = -1, which
+  comes from fitting the counterfactual on the whole pre-period, so imputation pre-period
+  coefficients are a valid pre-trend test only if PT holds in every period and are not
+  comparable to CS or TWFE coefficients.
+- Binds when: choosing `base_period`; reading someone else's CS or dCDH event study; deciding
+  whether to overlay estimators on one plot.
+- Implement: `base_period = "universal"` in R's did; `long2` in Stata's csdid (csdid2 already
+  defaults to long differences).
+
 ## Named disagreements the skill carries
 
 - TWFE in practice: Baker et al. and Arkhangelsky-Imbens against routine use; AAFP find it
@@ -198,7 +233,7 @@ AEA Papers and Proceedings 116: 75-80. Key: `wooldridge2026nonlinear`.
 ## Excluded
 
 - de Chaisemartin and D'Haultfoeuille, "Credible Answers to Hard Questions" (SSRN 4487202,
-  384pp): dropped from canon by human decision 2026-07-28. Their coverage here rests on their
+  384pp): dropped from canon by user decision 2026-07-28. Their coverage here rests on their
   published papers as relayed by the surveys, plus the public companion ecosystem:
   github.com/Credible-Answers (did_multiplegt_dyn and relatives), SSC cc_xd_didtextbook,
   anzonyquispe.github.io/did_book solutions in Stata, R, and Python.
@@ -213,12 +248,24 @@ re-checked with bibcheck at manuscript time. Keys: `goodmanbacon2021timing` (dec
 published ReStat 108(4) on 2026-07-17, superseding NBER w29873); `borusyak2024revisiting`
 (imputation, efficiency); `wooldridge2025mundlak` (ETWFE, supersedes the 2021 SSRN WP);
 `santanna2020doubly` (doubly robust); `rambachan2023credible` (honest inference);
-`roth2022pretest` (pretest power); `ghanem2022selection` (selection mechanisms; preprint);
+`roth2022pretest` (pretest power); `ghanem2022selection` (selection mechanisms; preprint;
+promoted to its own entry above 2026-08-26);
 `caetano2024covariates` (covariate TWFE; preprint; the four-author time-varying-covariates paper
 is separate); `harmon2022efficient` (pre-period averaging precision; unpublished WP, R&R
 ReStat); `chen2025efficient` (efficient combination; preprint); `roth2023functional`
 (functional form); `chen2024logs` (zeros and logs); `abadie2023clustering` (clustering);
 `gardner2022twostage` (two-stage; preprint, revised co-authored version circulates).
+
+Added 2026-08-26 from the Mixtape gap analysis (chapters 8, 9, 10), each Crossref-verified on
+that date: `marx2024parallel` (forward-looking choice and PT, JPE: Micro 2(1)); `olden2022triple`
+(the triple-difference parallel-bias assumption, Econometrics Journal 25(3));
+`santanna2026compositional` (compositional changes; published Journal of Econometrics 253,
+article 106147, superseding the 2023 working paper the Mixtape cites); `kahnlang2019promise`
+(explain the level difference before differencing it away; JBES 38(3), online 2019, print issue
+2020); `callaway2024continuous` (continuous treatment, NBER WP 32117; preprint, R package
+contdid); `hong2013napster` (compositional change in repeated cross-sections, the Napster
+exemplar; JAE 28(2)). All six are cited in prose in SKILL.md or details.md and previously had
+no key.
 
 Added 2026-08-26 through the two new canon entries, resolver-verified against Crossref on that
 date: `wooldridge2023simple` (nonlinear DiD with panel data, Econometrics Journal 26(3));
@@ -228,3 +275,28 @@ revised April 2026, preprint, cited by Wooldridge as Deb et al. 2025); `santossi
 `correia2020ppmlhdfe` (ppmlhdfe); `ciani2019multiplicative` (multiplicative DiD and the
 variance-shift diagnostic, J. Econometric Methods 8(1)). Wooldridge 1997 (the QMLE consistency
 result the companion cites) is cited in prose only; it has no entry yet.
+
+## Exemplar rows
+
+The recognition table's canonical cases. New keys were Crossref-verified and merged into causal.bib 2026-08-26. One
+line each, with the design shape the case is the precedent for.
+
+- Miller, Johnson, and Wherry 2021 (`miller2021medicaid`), the never-treated comparison with the
+  full evidence battery, and the model of a complete DiD paper: bite three ways, event studies, a
+  same-outcome-alternative-group falsification, and a mechanism.
+- Braghieri, Levy, and Makarin 2022 (`braghieri2022social`), the staggered rollout across
+  institutions with adoption dates rebuilt from an archive, TheFacebook by way of the Wayback
+  Machine.
+- Baker, Callaway, Cunningham, Goodman-Bacon, and Sant'Anna 2026 (`baker2026did`), forward
+  engineering from estimand to estimator, with the Medicaid application as the working template.
+  Key already resolves in causal.bib, and the paper has its own canon section above.
+- Winkler, Hotz-Behofsits, Wlomert, Papies, and Liaukonyte 2026 (`winkler2026tiktok`), estimand
+  first on a heavy-tailed outcome, the UMG-TikTok withdrawal. Key already resolves in causal.bib,
+  and the paper has its own canon section above.
+- Hong 2013 (`hong2013napster`), compositional change in repeated cross-sections, Napster and
+  music spending in the Consumer Expenditure Survey. Key merged into causal.bib with the Mixtape
+  gap-analysis batch.
+- Gruber 1994 (`gruber1994incidence`), triple differences, and the origin of the design, with the
+  ineligible group sitting inside the same treated states.
+- Card and Krueger 1994 (`card1994minimum`), the idea rather than the inference: the DiD
+  exemplar and the bite figure, but G = 2 with one treated cluster, so not an inference template.

--- a/skills/did/references/details.md
+++ b/skills/did/references/details.md
@@ -2,27 +2,30 @@
 
 Heavy reference content the SKILL.md points into. Current as of 2026-08-26.
 
-## Package index (verified 2026-07-28)
+## Package index (verified 2026-07-28; CRAN versions and release dates re-checked 2026-08-26)
 
 | Package | Where | Version seen | Role |
 |---|---|---|---|
-| did | CRAN; bcallaway11.github.io/did | 2.5.1 | Callaway-Sant'Anna att_gt/aggte |
-| HonestDiD | CRAN; github.com/asheshrambachan/HonestDiD | 0.2.8 | Rambachan-Roth, both restrictions; README ships the aggte adapter |
-| didimputation | CRAN; github.com/kylebutts/didimputation | 0.5.1 | BJS imputation |
-| did2s | CRAN | | Gardner two-stage |
-| fixest | CRAN; lrberge.github.io/fixest | 0.14.2 | sunab (Sun-Abraham), TWFE (pinned also in iv's details; update the two pins together on refresh) |
+| did | CRAN; bcallaway11.github.io/did | 2.5.1 (2026-07-08) | Callaway-Sant'Anna att_gt/aggte; aggte types simple, group, calendar, dynamic |
+| HonestDiD | CRAN; github.com/asheshrambachan/HonestDiD | 0.2.8 (2026-04-12) | Rambachan-Roth, both restrictions; README ships the aggte adapter |
+| didimputation | CRAN; github.com/kylebutts/didimputation | 0.5.1 (2026-03-09) | BJS imputation |
+| did2s | CRAN | 1.2.1 (2026-03-05) | Gardner two-stage |
+| DRDID | CRAN; psantanna.com/DRDID | 1.3.0 (2026-06-10) | Sant'Anna-Zhao 2x2 doubly robust building block that did calls; drdid/ipwdid/ordid for a two-period design estimated directly |
+| panelView | CRAN; yiqingxu.org/packages/panelview | 1.3.1 (2026-05-14) | treatment rollout plot, unit by period (Mou, Liu, and Xu 2023); design-stage step 3 |
+| fixest | CRAN; lrberge.github.io/fixest | 0.14.2 (2026-06-26) | sunab (Sun-Abraham), TWFE (pinned also in iv's details; update the two pins together on refresh) |
 | pretrends | GitHub ONLY: github.com/jonathandroth/pretrends | master | pretest power, slope_for_power |
-| staggered | CRAN; github.com/jonathandroth/staggered | 1.2.2 | efficient random-timing estimators |
-| TwoWayFEWeights | CRAN; github.com/Credible-Answers/twowayfeweights | 2.1.0 | dCDH negative-weight diagnostics |
-| bacondecomp | CRAN; github.com/evanjflack/bacondecomp | 0.1.1 | Goodman-Bacon decomposition |
-| etwfe | CRAN; grantmcdermott.com/etwfe | 0.6.2 | Wooldridge extended TWFE, linear and nonlinear (family = "poisson", "logit", "negbin" through fixest::feglm); a nonlinear family forces ivar = NULL and enters cohort and period as explicit dummies (emfx cannot compute SEs with absorbed FEs in nonlinear models); controls on the RHS of fml are demeaned by cohort and the xvar moderator by cohort-by-period cell (source, not docs); nothing unit-level is used, so repeated cross sections run unchanged (run on simulated repeated-cross-section data 2026-08-26, pilot only); emfx returns APEs (predict = "response") or index-scale effects (predict = "link") and compresses to cohort-period cells above 500,000 rows unless compress = FALSE; verified 2026-08-26 |
+| staggered | CRAN; github.com/jonathandroth/staggered | 1.2.2 (2025-01-09) | efficient random-timing estimators |
+| TwoWayFEWeights | CRAN; github.com/Credible-Answers/twowayfeweights | 2.1.0 (2026-05-27) | dCDH negative-weight diagnostics |
+| bacondecomp | CRAN; github.com/evanjflack/bacondecomp | 0.1.1 (2020-01-24) | Goodman-Bacon decomposition; last released 2020 and still the only R implementation |
+| etwfe | CRAN; grantmcdermott.com/etwfe | 0.6.2 (2026-03-23) | Wooldridge extended TWFE, linear and nonlinear (family = "poisson", "logit", "negbin" through fixest::feglm); a nonlinear family forces ivar = NULL and enters cohort and period as explicit dummies (emfx cannot compute SEs with absorbed FEs in nonlinear models); controls on the RHS of fml are demeaned by cohort and the xvar moderator by cohort-by-period cell (source, not docs); nothing unit-level is used, so repeated cross sections run unchanged (run on simulated repeated-cross-section data 2026-08-26, pilot only); emfx returns APEs (predict = "response") or index-scale effects (predict = "link") and compresses to cohort-period cells above 500,000 rows unless compress = FALSE; verified 2026-08-26 |
 | jwdid (Stata) | SSC; github.com/friosavila/stpackages | 2.0 (2024-05-04) | Wooldridge ETWFE; no ivar means repeated cross-section; method(poisson), method(logit), method(ppmlhdfe); covariates demeaned and interacted by default (xasis to disable); verified 2026-08-26 |
 | ppmlhdfe (Stata) | SSC | | PPML with high-dimensional FEs (Correia-Guimarães-Zylkin 2020); R equivalent fixest::fepois |
-| DIDmultiplegt / did_multiplegt_dyn | CRAN/SSC; github.com/Credible-Answers | | dCDH intertemporal, on/off treatments |
-| summclust | ARCHIVED from CRAN 2025-11-02; install from s3alfisc.r-universe.dev | 0.7.0 | CV3 cluster-jackknife vcov, leverage, partial leverage, leave-one-cluster-out betas |
-| fwildclusterboot | ARCHIVED from CRAN 2024-05-29; install from s3alfisc.r-universe.dev | 0.14.3 | boottest wild cluster bootstrap: WCR/WCU, Rademacher/Webb weights, MNW "33" variants |
-| clubSandwich | CRAN | 0.7.0 | CR2 vcovCR + Satterthwaite coef_test, the CRAN-resident cross-check |
-| sandwich | CRAN | | vcovBS(type = "jackknife"), a CRAN-resident CV3 route for linear models, no leverage diagnostics |
+| DIDmultiplegtDYN | CRAN; github.com/Credible-Answers | 2.4.0 (2026-06-30) | dCDH intertemporal, on/off treatments; the R port of Stata's did_multiplegt_dyn and the name to use. The older DIDmultiplegt (2.1.0, 2026-02-17) is the static estimator and is not the one the skill's reversal rule calls |
+| csdid / csdid2 (Stata) | SSC (Rios-Avila) | | Callaway-Sant'Anna in Stata. csdid defaults to short gaps and needs `long2`; csdid2 defaults to long differences and is faster. Both from the Mixtape ch. 10 code blocks, option names not API-verified here |
+| summclust | ARCHIVED from CRAN 2025-11-02; install from s3alfisc.r-universe.dev | 0.7.0 (r-universe build 2026-08-03; last CRAN release 0.7.2, 2023-08-10) | CV3 cluster-jackknife vcov, leverage, partial leverage, leave-one-cluster-out betas |
+| fwildclusterboot | ARCHIVED from CRAN 2024-05-29; install from s3alfisc.r-universe.dev | 0.14.3 (r-universe build 2026-08-01; ahead of the last CRAN release 0.13.0) | boottest wild cluster bootstrap: WCR/WCU, Rademacher/Webb weights, MNW "33" variants |
+| clubSandwich | CRAN | 0.7.0 (2026-05-04) | CR2 vcovCR + Satterthwaite coef_test, the CRAN-resident cross-check |
+| sandwich | CRAN | 3.1-3 (2026-08-03) | vcovBS(type = "jackknife"), a CRAN-resident CV3 route for linear models, no leverage diagnostics |
 
 Never-treated coding by package: did and didimputation use 0 (didimputation also accepts NA);
 staggered uses Inf; sunab treats any cohort value outside the observed periods as never-treated
@@ -36,6 +39,36 @@ mechanically. Recode per package; never recycle blindly.
 Cluster-inference rows verified 2026-07-29. Install the archived pair with
 install.packages(c("summclust", "fwildclusterboot"), repos = "https://s3alfisc.r-universe.dev").
 boottest's fixest method takes feols objects only and disallows weights with fixed effects.
+
+## Exemplar designs: what each one teaches
+
+The recognition table is in SKILL.md; this is the longer read on each row.
+
+- Miller, Johnson, and Wherry (2021), ACA Medicaid expansion and near-elderly mortality. The
+  Mixtape's model of a complete DiD paper: bite shown three ways (eligibility, enrollment, and
+  the share uninsured, the last of which shows some enrollment came from people with no coverage
+  at all), event studies, a same-outcome-alternative-group falsification on the 65-and-over
+  population, main results (0.13pp, 9.3% of the sample mean), and a mechanism. Never-treated
+  comparison states.
+- Braghieri, Levy, and Makarin (2022), the staggered rollout of TheFacebook across colleges and
+  student mental health. The staggered exemplar: treatment dates built from the Wayback Machine
+  (the platform announced each new school on its front page) and linked to an existing
+  repeated-cross-section student survey, with the outcome z-scored so effects read in standard
+  deviations. Also the Mixtape's instance of the multi-estimator plot it argues against.
+- Baker, Callaway, Cunningham, Goodman-Bacon, and Sant'Anna (2026), Medicaid. The build order,
+  forward-engineered from estimand to estimator, with the AEA replication package (materials
+  25430, 25431) as a working R and Stata template.
+- Winkler et al. (2026), UMG's TikTok withdrawal. Estimand first on a heavy-tailed outcome:
+  53,753 matched song pairs, log OLS +0.0063 against PPML -0.0310 on the same panel.
+- Hong (2013), Napster and music spending in the Consumer Expenditure Survey. Compositional
+  change in a repeated cross-section: internet users got older, poorer, and less likely to hold
+  a college degree between 1997 and 2000, and those covariates predict Y(0), so who is sampled
+  breaks parallel trends without anyone being mistreated.
+- Gruber (1994), state-mandated maternity benefits. The origin of triple differences, with the
+  ineligible group (single men aged 20-40 and older workers) inside the same states.
+- Card and Krueger (1994), NJ versus PA fast food. The exemplar of the DiD idea, the bite figure
+  (mass at the new minimum), and primary data the authors collected twice themselves. Not an
+  inference template: at the assignment level it is G = 2 with one treated cluster.
 
 ## Few-clusters map (choose by the homogeneity you believe)
 
@@ -103,6 +136,54 @@ and nominal size, screening pays when |delta_s| / (2 - theta) < delta. Caveat ca
 screened BJS can be more biased than screened regression under linear divergent trends, because
 BJS baselines on the whole pre-period average (short lags worst).
 
+## Selection mechanisms and parallel trends (Ghanem-Sant'Anna-Wüthrich; Marx-Tamer-Tang)
+
+Source: the Mixtape ch. 9 section on treatment assignment mechanisms, which reads
+`ghanem2022selection` and Marx, Tamer, and Tang (2024). The two columns come apart, which is the
+whole point of the table: a mechanism can leave PT intact and still wreck the pre-trend picture.
+
+| Mechanism | Parallel trends | Pre-trends | What to do |
+|---|---|---|---|
+| Common constant trend in Y(0) | cannot be violated, for any assignment rule | clean | nothing; covariates are unnecessary here |
+| Selection on baseline Y(0) (enrolled below a threshold on Y) | holds | broken mechanically, a dip at t = -1, because the baseline is both the selection point and the omitted category | no fix, because no problem. Do not re-base to t = -2: PT held from the original baseline. See the HonestDiD note below |
+| Selection on fixed effects (only certain types enroll) | holds | clean | nothing |
+| Selection on observables | holds conditional on X | clean given X | conditional PT: RA, IPW, or DR |
+| Imperfect foresight about own gains | holds | clean | nothing |
+| Selection on realized gains (Perfect Doctor, essential heterogeneity) | broken | E[Y(0)] diverges before and after, so pre-trends usually show it | DiD is biased by construction; clean pre-trends are no defense. Route out |
+
+HonestDiD interaction, the skill's own judgment and stated in neither source: relative
+magnitudes anchors on the largest pre-treatment violation, so a mechanical baseline dip from
+selection on baseline Y(0) inflates the anchor and the robust interval with it. Prefer
+smoothness there, or recompute the anchor from the pre-treatment periods excluding the selection
+period, and say which. The mirror-image failure is that under selection on realized gains the
+pretest-plus-HonestDiD chain passes a design that is biased by construction.
+
+## Triple differences: assumption and specifications (Olden and Møen 2022; Gruber 1994)
+
+Identifying assumption (parallel bias), with D the treatment level (experimental vs
+non-experimental states) and G the group (eligible vs placebo):
+
+    E[dY(0) | D=1, G=1] - E[dY(0) | D=0, G=1] = E[dY(0) | D=1, G=0] - E[dY(0) | D=0, G=0]
+
+The main DiD equals ATT plus its own non-parallel-trends bias, the placebo-group DiD equals its
+non-parallel-trends bias alone, and subtracting the second from the first leaves the ATT when
+the two biases match. Eight averages and seven subtractions. The placebo DiD is not required to
+be zero; a zero one means the main DiD was already unbiased.
+
+Saturated OLS (Gruber's own form), with tau the post dummy, delta the eligible-group dummy, and
+D the treated-unit dummy:
+
+    Y = a + b2 tau + b3 delta + b4 D + b5 (delta x tau) + b6 (tau x D) + b7 (delta x D)
+        + b8 (delta x tau x D) + e
+
+b8 is the DDD estimate, and only in exactly this saturated specification. Event-study form:
+replace the post dummy with period dummies (t = -1 omitted) throughout, so the regression carries
+group-by-period, unit-by-period, and group-by-unit fixed effects plus the triple interaction with
+each period dummy; the DDD leads and lags are the coefficients on that last set. Cluster at the
+level at which treatment was applied. Present the main DiD event study, the placebo-group event
+study, and the DDD event study together, since the design's claim is that the first two share a
+bias term.
+
 ## Covariate balance: normalized differences
 
 (X-bar_T - X-bar_C) / sqrt((S_T^2 + S_C^2)/2), reported for baseline levels and for pre-period
@@ -117,7 +198,13 @@ if X is strictly exogenous; if treatment can move X, the imbalance may be a trea
   overlap by extrapolation; credibility rests on that extrapolation.
 - IPW: reweight control trends by p(X)/(1-p(X)) so the control covariate distribution matches
   the treated. Noisy as control p(X) approaches 1; trim at 0.995 (package default), keep the
-  trim, use bias correction (Ma-Sasaki-Wang) if trimming more aggressively.
+  trim, use bias correction (Ma-Sasaki-Wang) if trimming more aggressively. Only the control
+  group is weighted, which is why extreme scores matter on that side only. The arithmetic is
+  brutal and hides inside a histogram: p = 0.99991 gives 0.99991/0.00009 = 11,110, and in the
+  Mixtape's CAPS data p = 0.999971 gives 34,481, so one control unit outweighs thousands. Eleven
+  CAPS control municipalities sat above 0.995. Count the near-1 control scores by hand, since
+  a density plot hides them, and check whether your package trims: R's did does, and Stata
+  routines vary.
 - DR: combine; consistent if either model is right, efficient if both are (Sant'Anna-Zhao).
 - Event studies: long differences Y_t - Y_{g-1}; propensity model period-invariant, outcome
   model per-period. Staggered: group-time propensity P(G=g | X, in g or not-yet-treated at t).
@@ -143,7 +230,16 @@ plausible, add the exposure-squared interaction and report both.
 ## Repeated cross-sections and unbalanced panels (Baker et al. 2026)
 
 Unconditional DiD needs only group-time means: repeated cross-sections and unbalanced panels are
-fine with the estimand reinterpreted (ATT among units sampled post). With covariates: if the
+fine with the estimand reinterpreted (ATT among units sampled post), provided missingness is
+independent of Y(0) given X. That is weaker than missing at random (Wooldridge 2010) and it is
+the condition that matters, because PT is a statement about Y(0). When dropout is caused by the
+outcome (churned users, delisted stores, closed accounts, the worker who leaves because earnings
+fell), PT breaks and forcing balance by dropping units does not fix it: reason about the
+mechanism instead. Options once the mechanism is understood are imputation of the missing
+untreated cells (Heckman 1979; Athey et al. 2021; BJS 2024) and the chained DiD of Bellego,
+Benatia, and Dortet-Bernadet (2024), which chains short-run effects across adjacent-period
+overlaps and so discards nothing. Report attrition rates by cohort either way, since
+differential attrition is itself a PT diagnostic. With covariates: if the
 joint distribution of (D, X) is time-invariant, pool across periods for precision; if
 composition may change, do not pool, target ATT(2 | sampled in 2), and run the Sant'Anna-Xu
 Hausman-type comparison. Staggered warning: the Sun-Abraham regression with unit FEs on
@@ -162,6 +258,11 @@ unbalanced data no longer equals the CS estimator; replace unit FEs with group d
 - fixest::sunab equals CS-never numerically on balanced panels; on unbalanced panels the
   equivalence fails (see above).
 - lpdid (local projections DiD) is equivalent to the CS-NYT plug-in (Dube-Girardi-Jorda-Taylor).
+- dCDH weight diagnostics (TwoWayFEWeights) are not a staggered-adoption tool. Any within
+  regression with a time-varying treatment and heterogeneous effects has an implicit weighting
+  problem, so the diagnostic is available to a plain fixed-effects fit on an on/off treatment
+  too, even with no cohorts and no adoption date. The template files it under divergence
+  diagnostics because that is where it usually earns its run, not because staggering is required.
 - Stacked regression (clean-controls stacks) appears in marketing practice and in the AMA
   Marketing News routing source (Li, Luo, and Pattabhiramaiah 2024; 'AMA' hereafter); its
   implicit variance weights are a known problem (Baker et al.), so prefer Callaway-Sant'Anna

--- a/skills/did/scripts/did_template.R
+++ b/skills/did/scripts/did_template.R
@@ -28,8 +28,12 @@ set.seed(94305)
 library(did); library(HonestDiD); library(fixest)
 
 ## ---- 1. Group-time ATTs (Callaway-Sant'Anna) -------------------------------
-# base_period = "universal" is REQUIRED for the honest_did sensitivity chain below
-# (the helper hard-errors otherwise). control_group states the PT variant you impose:
+# base_period = "universal" gives long differences: every event-study coefficient is measured
+# against a fixed t = -1, which is what OLS event studies do and what readers expect. The
+# alternative, a rolling baseline, produces short gaps, a different quantity (Roth 2026).
+# Stata equivalents: csdid needs long2, csdid2 already defaults to long differences.
+# The honest_did chain below also requires it (the helper hard-errors otherwise).
+# control_group states the PT variant you impose:
 # "notyettreated" = PT-NYT (default here), "nevertreated" = PT-Nev.
 atts <- att_gt(
   yname = YNAME, tname = TNAME, idname = IDNAME, gname = GNAME,
@@ -47,6 +51,10 @@ summary(atts)
 # +/-15 is AAFP's window for a 41-period panel; set min_e/max_e from your own q and m.
 es  <- aggte(atts, type = "dynamic", min_e = -15, max_e = 15, cband = TRUE)
 att <- aggte(atts, type = "group")
+# Calendar-time aggregation, ATT(t): the target when the question is about a specific period
+# (a season, a platform change, a macro shock). Simple, group, calendar, and dynamic are four
+# different parameters built from the same ATT(g,t), never robustness checks for one another.
+cal <- aggte(atts, type = "calendar", cband = TRUE)
 ggdid(es)
 # Composition check: balanced-in-event-time aggregation (units observed over the window)
 # balance_e = 5 is a placeholder; set it to the horizon you report.
@@ -148,12 +156,23 @@ twfe <- feols(as.formula(paste(YNAME, "~ treat |", IDNAME, "+", TNAME)),
               data = df, cluster = df[[CLUSTER]])
 # sunab treats any cohort value outside the observed periods as never-treated;
 # recode 0 -> 10000 (do NOT feed the did-style 0, it would read as an early cohort).
+# Read the cross-check for what it is: Sun-Abraham's cohort 2x2s use the last-treated cohort or
+# never-treated, never the not-yet-treated, so against the CS-NYT fit in section 1 this compares
+# two assumptions on one dataset. Neither agreement nor divergence is a robustness result.
 df$first_treated_sunab <- ifelse(df[[GNAME]] == 0, 10000, df[[GNAME]])
 sa <- feols(as.formula(paste(YNAME, "~ sunab(first_treated_sunab,", TNAME, ") |",
                              IDNAME, "+", TNAME)),
             data = df, cluster = df[[CLUSTER]])
 
 ## ---- 6. Divergence diagnostics (run when TWFE and CS disagree) -------------
+# These two report opposite-looking things and both are right. bacon's weights sit on 2x2
+# comparisons and are always positive; they combine a sample share with the treatment-timing
+# variance Dbar(1 - Dbar), which peaks at 0.25 for a cohort treated at the panel midpoint, so
+# TWFE upweights mid-panel cohorts and panel length moves the estimate through the weights
+# alone. twowayfeweights' weights sit on unit-level treatment effects and can be negative.
+# All-positive bacon weights therefore do not license TWFE: under constant effects TWFE is
+# unbiased for the variance-weighted ATT, not the simple ATT. Run this to explain a divergence,
+# not as a standing robustness table.
 library(bacondecomp)
 bd <- bacon(as.formula(paste(YNAME, "~ treat")), data = df,
             id_var = IDNAME, time_var = TNAME)   # weights on each 2x2, incl. forbidden

--- a/skills/iv/SKILL.md
+++ b/skills/iv/SKILL.md
@@ -18,26 +18,55 @@ a methods paragraph with the limitation stated in first person at the point of t
 Refresh path: run the litreview skill on the method since the canon date and fold results into
 references/canon.md as flagged addenda.
 
-## When IV, and the four assumptions kept separate
+## Six designs to recognize
+
+Find your design here before reading about estimators. Fuller rows, with what each canonical
+case teaches, are in references/details.md.
+
+| Design | Canonical case | Marketing analogue | What kills it |
+|---|---|---|---|
+| Randomized encouragement with noncompliance | Oregon Medicaid lottery (Finkelstein et al. 2012) | ghost ads, PSA holdouts, invite-only betas | the offer itself moves the outcome, because the invitation signals |
+| Leniency routing | Philadelphia bail magistrates (Stevenson 2018) | moderation queues, credit underwriting, support-ticket routing | units re-enter the queue after seeing their assignment; monotonicity across case types |
+| Shift-share exposure | Bartik 1991; Autor-Dorn-Hanson 2013 | category demand growth from national demographic shifts weighted by sales shares | generic shares, which proxy exposure to any shock |
+| Formula or network exposure | Borusyak-Hull 2023, China high-speed rail | fraction of friends treated in seeding and referral programs | no recentering; connected users are mechanically more exposed |
+| Cost shifter for price | Wright 1928; Graddy's Fulton fish market | input costs, freight, Hausman other-market prices | the instrument-induced elasticity is not the one you face when you set price yourself |
+| Access or distance | the McClellan-Newhouse differential-distance trick | store, warehouse, or delivery-coverage proximity | distance correlates with everything; condition on generic distance |
+
+## When IV, and the five assumptions kept separate
 
 IV is the tool when unconfoundedness fails because treatment is chosen: agents select on
 anticipated gains (program participation, adoption, self-selected exposure), or the treatment is
 an equilibrium object like a price, where OLS mixes supply and demand slopes (the Fulton fish
 market numbers in references/details.md are the two-line demonstration). An instrument is an
 incentive or cost shifter: it changes the attractiveness of taking treatment without entering the
-potential outcomes.
+potential outcomes. A price elasticity estimated this way is the elasticity of the compliers the
+instrument moved, and need not be the elasticity a firm faces when it sets price itself: "when
+the firm lowers its price, it won't do so using storms" (Angrist, Graddy, and Imbens 2000). Route
+a pricing question to the PRTE ladder below, naming the policy that will move the price.
 
-Four assumptions, argued separately because they have different characters (Imbens 2014):
+Before you estimate, establish that the mechanism exists. An instrument is a treatment assignment
+mechanism, and the design's credibility comes from that mechanism operating in the world, not
+from the estimator. Interview whoever runs the assignment, the queue owner or the pricing
+manager, and ask who ended up treated and why. Do not ask them to name an instrument, which is
+not a question anyone outside this literature can answer. The best instruments come from
+institutional knowledge of a program and rarely from a new dataset (Angrist and Krueger 2001).
 
-1. Unconfounded assignment of the instrument. Can hold by design (randomized encouragement) or
+Five assumptions, argued separately because they have different characters (Imbens 2014):
+
+1. SUTVA, at the level of the instrument and not only the treatment: unit i's potential treatment
+   and potential outcomes depend on i's own instrument alone. The violation to name is
+   instrument-level spillover, a seeded user's friends changing behavior because of the seed
+   itself. The LATE framework does not accommodate it, being built on unit-level potential
+   treatment mappings, so the route is a partial-interference or network model (field-experiment).
+2. Unconfounded assignment of the instrument. Can hold by design (randomized encouragement) or
    conditionally on covariates. On its own it justifies the reduced-form ITT effects ONLY, never
    the IV ratio.
-2. Exclusion. Substantive in essentially every application; Imbens' line is that it holds by
+3. Exclusion. Substantive in essentially every application; Imbens' line is that it holds by
    design only in double-blind placebo trials. Argue it separately by compliance type: the
    instrument can push always-takers and never-takers toward outcome-relevant side actions even
    though it cannot change their treatment (draft-lottery never-takers stayed in school; a
    retention-offer trigger that also flags the account for priority support).
-3. Monotonicity (no defiers). Safe when the instrument is a one-directional incentive (letter,
+4. Monotonicity (no defiers). Safe when the instrument is a one-directional incentive (letter,
    subsidy, default). Strong in examiner and judge designs: by Vytlacil's theorem it is
    equivalent to every examiner ranking the cases identically and differing only in where the
    cutoff falls, which fails whenever examiners weight criteria differently or differ in skill
@@ -48,10 +77,12 @@ Four assumptions, argued separately because they have different characters (Imbe
    the weakening and the test; do not price a leniency design against the uniform condition.
    One-sided noncompliance buys the uniform version for free and turns the LATE into an effect
    on treated compliers.
-4. Relevance, tested with the discipline in the next section, never with a full-sample afterthought.
+5. Relevance, tested with the discipline in the next section, never with a full-sample afterthought.
 
-The estimand under all four is the complier average effect (LATE). Compliers are the focus
-because theirs is the only point-identified average, an honest second best. Report the compliance
+The estimand under all five is the complier average effect (LATE). Compliers are the focus
+because theirs is the only point-identified average, an honest second best. When the first stage
+varies across units, the LATE weights units by their first-stage responsiveness, so the compliers
+are defined by responsiveness and not by membership alone (Huntington-Klein 2020). Report the compliance
 shares (always-takers, never-takers, compliers, three lines of code) and, when the ATE was the
 stated target, Manski bounds alongside the LATE. When the stated question is a rollout or an
 incentive change (a bigger subsidy, wider eligibility, "what if we gave it to everyone"), name
@@ -74,13 +105,21 @@ The binding constraint in modern IV practice is inference, and the canon's posit
 - Confidence intervals only by inverting AR/CLR, never from the 2SLS standard error. Valid
   intervals cannot be symmetric in finite samples, and an unbounded AR interval is an honest
   statement that identification is not established, never something to suppress by switching
-  back to t-intervals.
+  back to t-intervals. The Mixtape (Cunningham, Causal Inference: The Remix, ch. 7) reports AR
+  intervals "for robustness"; this skill makes them the only interval, because the two disagree
+  in the chapter's own fish example: at an effective F of 22.929 the 2SLS estimate is -1.119 with
+  a robust standard error of 0.431, so the t-interval is about [-1.96, -0.27] against a printed
+  AR interval of [-2.186, -0.394]. Both ends move, and the AR interval is asymmetric.
 - Hold instruments to a robust first-stage F of about 50 (about 50/K^(3/4) with K instruments),
   not 10. F of 10 only controls two-tailed t size; below roughly 50, 2SLS is quite likely
   farther from the truth than OLS unless endogeneity is severe. The sample-F-to-certified-
   population-F ladder, and when a severe-endogeneity relaxation of this bar is credible, are
   in references/details.md. This bar prices 2SLS bias, so it moves with the estimator: it does
   not transfer to a jackknife estimator in a many-instrument design (see the leniency section).
+  The Mixtape calls an F of 17.6 "strong enough for identification" and the fish instrument
+  "strong (F > 22)", both inside the band this ladder distrusts (a sample F of 23.1 certifies a
+  population F of 10), so a reader who copies that language into a current submission will draw
+  the objection.
 - Below F = 3.84 do not run IV at all; the AR interval will be unbounded and rightly so.
 - The reason the t-test dies even at strong F is power asymmetry, a mechanism worth knowing when
   refereeing: the 2SLS standard error is spuriously small exactly when the estimate lands near
@@ -193,6 +232,11 @@ controls and points the opposite way; UJIVE has trace zero. Bias-corrected 2SLS 
 zero, but only under homoskedasticity. IJIVE does not fully clear the bias, though in practice
 it lands close. The trace algebra is in references/details.md.
 
+The Mixtape (ch. 7) demonstrates JIVE in its bail exercise, calling that treatment "somewhat
+backwards looking", and flags UJIVE itself as the more robust version. This skill runs UJIVE: by
+the trace argument above, many examiners and many controls at once leave JIVE's many-covariate
+bias live and pointing opposite to 2SLS's. Report JIVE beside UJIVE as a diagnostic.
+
 The five checks, in their order:
 
 1. Name the controls that buy as-good-as-random assignment, and let the assignment mechanism
@@ -202,7 +246,12 @@ The five checks, in their order:
    application these widened the intervals, because the first-stage noise the extra controls
    introduce outweighed the gain in the outcome equation). E[z|w] has to be linear in the
    covariates, which is automatic when w is fixed effects and otherwise needs interactions or
-   higher-order terms (sufficient in Kolesár 2013, necessary in Blandhol et al. 2026).
+   higher-order terms (sufficient in Kolesár 2013, necessary in Blandhol et al. 2026). Assignment
+   can be random and the design still broken if units act on the realization: Gaudet, Harris, and
+   St. John (1933) recorded defendants changing their plea to draw a different judge. Where the
+   data record it, instrument with the initial assignment instead of the final one, and ask the
+   administrators how often re-routing happens, since check 2 misses sorting on unobservables.
+   The platform analogue is the appealed moderation decision or the re-submitted ticket.
 2. Balance, run as the same UJIVE specification with the covariate as the outcome. This is the
    step that gets done wrong. Do not regress observables on a constructed leniency measure,
    which manufactures mechanical correlation and carries errors-in-variables bias even when the
@@ -211,7 +260,8 @@ The five checks, in their order:
    the same units as the treatment effect, so the two are directly comparable: in their patent
    reanalysis the balance coefficients came in about ten times smaller than the effects. The
    same machinery on a post-assignment variable tests exclusion (their instance is months under
-   review).
+   review). The Mixtape (ch. 7) calls balance "an absolute must" and says nothing about how, and
+   the two implementations a reader reaches for first are the two ruled out here.
 3. Estimate by UJIVE and report the alternatives beside it. 2SLS on the examiner dummies landing
    between OLS and UJIVE is the signature of many-instrument bias pulling toward OLS, and 2SLS
    standard errors 3 to 4 times tighter than UJIVE's are that same pathology showing up in the
@@ -295,14 +345,22 @@ design is the whole paper.
    assumptions; a violation means the design is internally inconsistent, and passing proves
    nothing. Worked flu-data numbers in references/details.md.
 4. OLS next to IV, always, and the OLS-proximity audit: t-significant IV near OLS with moderate
-   F is the configuration to distrust.
+   F is the configuration to distrust. When IV lands above OLS, name which explanation you are
+   claiming, measurement error in the endogenous regressor or higher complier returns, and why.
 5. Overid J (with CUE) where applicable, interpreted under the heterogeneity rule above.
 6. Balance of the instrument on predetermined covariates, with the design's controls and the
    design's standard errors (exposure-robust on the shift path; RI for recentered instruments).
    On the share path this is a pre-trends exercise and did-style scrutiny applies.
-7. TSLS-LIML divergence in overidentified designs as a cheap weak/many-instrument alarm.
+7. TSLS-LIML divergence in overidentified designs as a cheap weak/many-instrument alarm. Also
+   re-estimate with random draws in place of the instruments: the second stage typically still
+   looks reasonable while the first-stage F sits near one (Bound, Jaeger, and Baker 1995).
 8. Placebo outcomes: lagged outcomes as the dependent variable, RI-based for recentered
    designs (sharp null sidesteps the RI-with-heterogeneity complication).
+8b. Placebo first stage, bounded by the mechanism: name the margin the mechanism can reach and
+   show the instrument does not move treatment past it. Quarter of birth moves high-school
+   completion and not college completion, because compulsory schooling binds only through high
+   school (Angrist-Krueger 1991). A cost shifter should move price and not assortment, a
+   delivery-radius instrument purchase and not browsing.
 9b. Leniency designs run the battery in their own section instead: UJIVE balance regressions on
    the covariates and on a post-assignment variable, the [0, 1] monotonicity test, and the
    complier table. Item 7 is replaced there by reporting UJIVE next to OLS, 2SLS, and JIVE,
@@ -312,6 +370,17 @@ design is the whole paper.
    and re-solve, then to zero selection on gains. Infeasibility rejects that behavioral
    hypothesis and turns the OLS-IV gap of item 4 into a formal test; with unrestricted MTRs,
    infeasibility is item 3's Balke-Pearl falsification in general form.
+
+## Exhibits: three figures and one table
+
+Three figures carry an IV paper: the instrument's own variation, the first stage, and the reduced
+form (Angrist-Krueger 1991 for the pair, Cunningham-Finlay 2012 for the three-figure structure).
+Never plot the outcome against fitted treatment, a processed quantity that reads as opaque. Where
+a placebo series exists (an untreated market, an unaffected product category), plot it on the
+same axes so the reader can see the shock hit one thing. The table carries OLS beside IV, the
+first-stage coefficient on the instrument, the strength statistic (effective F, or sqrt(K) times
+(E[F] - 1) in a leniency design), N, and the AR interval in brackets under the point estimate,
+which puts the valid interval where a reader looks for it.
 
 ## The live disputes, carried honestly
 
@@ -425,5 +494,7 @@ Every claim traces to references/canon.md; keys live in causal-design/references
 - field-experiment: randomized encouragement designs end to end (including the ITT/LATE
   analysis) and randomization inference on a simple physically randomized instrument;
   recentered and formula instruments keep their RI machinery here.
+- causal-unstructured: the perceived-treatment design (actual feature instruments the perceived
+  feature) arrives here; the exclusion and weak-instrument discipline apply unchanged.
 - preregister: pre-specifying the instrument, specification, and weak-IV fallback before
   outcomes are seen (experiment-first skill; adapt its structure for quasi-experimental PAPs).

--- a/skills/iv/references/canon.md
+++ b/skills/iv/references/canon.md
@@ -169,9 +169,12 @@ version arXiv 2511.03572. User-supplied addendum, read 2026-08-04.
   the assignment is as good as random within a stratum. Judges, patent examiners, disability
   assessors, loan officers, child-protection investigators, radiologists, immigration officers,
   content moderators, and platform review queues that route by roster.
-- Scope limits: the clustering argument (Abadie-Athey-Imbens-Wooldridge) is proved for iid
-  assignment with a fixed number of examiners, and the extension to many examiners is asserted as
-  natural (their words) and never proved. MST-style extrapolation has not been formalized for
+- Scope limits: the fixed-number-of-examiners caveat recorded here is NOT a description of
+  Abadie-Athey-Imbens-Wooldridge, whose framework is asymptotic in the number of clusters and
+  treats growing cluster sizes explicitly (verified against the paper 2026-08-05; note in
+  notes/router/). It belongs to `frandsen2025cluster` or to Goldsmith-Pinkham-Hull-Kolesar's
+  reading of it, neither of which has been re-read; reattribute before quoting. What AAIW does
+  scope: linear estimators only, and only the sampling and assignment processes they model. MST-style extrapolation has not been formalized for
   many decision-makers or controls, so do not carry the extrapolation ladder into a leniency
   design without saying so.
 - Implement: the authors' own R package ManyIV (github.com/kolesarm/ManyIV), row in
@@ -230,3 +233,35 @@ companion examiner-design practitioner's guide in JEL); Blandhol et al. 2026 (li
 E[z|w] in the covariates as a necessary condition); Yap 2025 (many-weak-instrument inference
 that survives treatment-effect heterogeneity); Frandsen-Leslie-McIntyre 2025 (cluster jackknife
 IV, the leave-own-cluster-out route under clustered assignment).
+
+Added with the Mixtape chapter 7 pass (2026-08-26): Angrist-Graddy-Imbens 2000, REStud 67(3):
+499-527 (an IV demand elasticity is the compliers' elasticity, specific to the instrument that
+moved price, and not the elasticity a firm faces when it sets price itself); Angrist-Krueger
+2001, JEP 15(4): 69-85 (the best instruments come from institutional knowledge of a program and
+rarely from a new dataset, which is what the "before you estimate" paragraph in SKILL.md rests
+on). Both verified against Crossref 2026-08-26; BibTeX drafted as `angrist2000interpretation` and
+`angrist2001instrumental`, merged into causal.bib.
+
+## Exemplar rows
+
+The recognition table's canonical cases. New keys were Crossref-verified and merged into causal.bib 2026-08-26. One line each, with the design the case is the precedent for.
+
+- Finkelstein et al. 2012 (`finkelstein2012oregon`), randomized encouragement with noncompliance,
+  the Oregon Medicaid lottery with the ITT and the LATE reported side by side.
+- Baicker et al. 2013 (`baicker2013oregon`), the clinical-outcome companion to the same lottery,
+  and the paper the chapter points at for the lottery-as-instrument design.
+- Stevenson 2018 (`stevenson2018distortion`), leniency routing, Philadelphia bail magistrates,
+  where OLS finds nothing and IV carries the paper.
+- Bartik 1991 (`bartik1991who`) and Autor, Dorn, and Hanson 2013 (`autor2013china`), shift-share
+  exposure, the shares claim and the shifts claim as two separate identification arguments. Both
+  keys already resolve in causal.bib.
+- Borusyak and Hull 2023 (`borusyak2023nonrandom`), formula or network exposure, and the
+  recentering that a nonrandom exposure map requires. Key already resolves in causal.bib, and the
+  paper has its own canon section above.
+- Wright 1928 (`wright1928tariff`), the cost shifter for price, and the origin of the
+  simultaneity problem the design solves.
+- Graddy 2006 (`graddy2006fulton`), the Fulton fish market data behind the worked price-elasticity
+  example, read alongside `angrist2000interpretation` for what the recovered elasticity is.
+- McClellan, McNeil, and Newhouse 1994 (`mcclellan1994intensive`), the access or distance design,
+  and the differential-distance trick of conditioning on generic distance and instrumenting with
+  the specific version. The SKILL.md row names no year; this is the paper it points at.

--- a/skills/iv/references/details.md
+++ b/skills/iv/references/details.md
@@ -1,6 +1,6 @@
 # IV lookup details
 
-Heavy reference content the SKILL.md points into. Current as of 2026-08-04.
+Heavy reference content the SKILL.md points into. Current as of 2026-07-28.
 
 ## The F ladder (Keane-Neal Table 1)
 
@@ -122,6 +122,16 @@ mix of supply and demand slopes with ambiguous sign. Stormy-weather supply-shift
 elasticity -1.08 (0.46); TSLS with the trivalued instrument -1.014 (0.384), LIML -1.016
 (0.384). OLS understates the demand elasticity by half. A supply shifter identifies demand and
 a demand shifter identifies supply; without one side's shifter, that side stays unidentified.
+
+What the number is. The IV elasticity belongs to the compliers whose purchases the instrument
+moved, so a storm-instrumented elasticity describes buyers who responded to storm-driven price
+increases (Angrist, Graddy, and Imbens 2000). It need not be the elasticity a firm faces when it
+sets price itself, because when the firm lowers its price it will not do so using storms. The
+Mixtape (Cunningham, Causal Inference: The Remix, ch. 7) runs the same data with a binary Stormy
+instrument and day-of-week dummies and reports 2SLS -1.119 (0.431) against OLS -0.563 (0.152) at
+N = 111, so the two-line demonstration above is robust to the specification. Hand a pricing team
+that number only with the complier population named, and take a planned price change to the PRTE
+ladder instead.
 
 ## Leniency designs: the trace algebra and the worked numbers (GHK 2026)
 
@@ -255,6 +265,20 @@ Caveat the paper itself flags: passing the RI balance tests supports the counter
 specification, and does not directly certify shock exogeneity; the placebo-outcome test is the
 check aimed at that assumption.
 
+## The six designs, and what each canonical case teaches
+
+The recognition table in SKILL.md indexes designs by what kills them. This is the longer form,
+with the lesson each canonical case carries.
+
+| Design | Canonical case | What it teaches |
+|---|---|---|
+| Randomized encouragement with noncompliance | Oregon Medicaid lottery (Finkelstein et al. 2012; Baicker et al. 2013) | lottery IV under voluntary take-up, with the ITT and the LATE reported side by side across financial, utilization, and health outcomes; winning the lottery raised Medicaid enrollment by about 26 points |
+| Leniency routing | Philadelphia bail magistrates (Stevenson 2018) | the design end to end at 331,971 cases and eight judges, where OLS finds nothing (-0.001) and IV finds 15 to 21 percent on guilty pleas, so the estimator choice carries the paper |
+| Shift-share exposure | Bartik 1991; Autor-Dorn-Hanson 2013 | shares and shifts are two different identification claims, each with its own estimator, balance test, and disqualifier |
+| Formula or network exposure | Borusyak-Hull 2023, China high-speed rail | a formula-built instrument inherits endogeneity from its nonrandom exposure weights: 0.23 collapses to 0.08 after recentering |
+| Cost shifter for price | Wright 1928; Graddy's Fulton fish market (Graddy 2006) | simultaneity: observed price-quantity pairs are equilibria, a supply shifter identifies demand, and the elasticity recovered belongs to the instrument's compliers |
+| Access or distance | the McClellan-Newhouse differential-distance trick | condition on generic distance and instrument with the specific version, because raw distance proxies everything |
+
 ## Marketing translations
 
 - Price endogeneity: cost shifters and Hausman-style other-market prices routinely land F in
@@ -280,19 +304,23 @@ check aimed at that assumption.
   instrument with the specific version (the McClellan-Newhouse trick).
 
 ## Package index (verified against package docs 2026-07-28; the ivmte row on 2026-07-29;
-the ManyIV row against the cloned source and a live run on its `fhl` data on 2026-08-04)
+the ManyIV row against the cloned source and a live run on its `fhl` data on 2026-08-04;
+versions and publication dates re-checked against crandb and the GitHub HEADs on 2026-08-26,
+with no package ahead of the version recorded here, so the traps below stand as written)
 
 | Package | Version | Role | Traps |
 |---|---|---|---|
-| fixest | 0.14.2 (CRAN) | 2SLS with FE and clustered SEs; first stage via summary(est, stage = 1); fitstat(~ ivf1 + ivwald1 + sargan + wh) | IV part must be the LAST formula element, after fixed effects; fitstat keywords lowercase (pinned also in did's details; update the two pins together on refresh) |
-| ivreg | 0.6-8 (CRAN) | TSLS with diagnostics rows (weak instruments, Wu-Hausman, Sargan); successor to AER::ivreg | three-part form is y ~ exogenous \| endogenous \| instruments; in the two-part form, controls not repeated after the pipe silently become instruments; vcov. must be a function when diagnostics = TRUE |
-| ivmodel | 1.9.1 (CRAN) | AR.test and CLR with inversion CIs (matrix of interval rows; unions and unbounded sets happen), KClass/LIML/Fuller, heteroSE and clusterID options | KClass has a capital K; single endogenous regressor; takes data vectors, not formulas |
-| ivDiag | 1.0.6 (CRAN; yiqingxu.org/packages/ivDiag) | one-call audit: F.standard/robust/cluster/bootstrap/effective, AR with inverted CI, tF (Lee et al.), ltz local-to-zero | every variable passed as a name string; pulls the lfe dependency chain |
-| ShiftShareSE | 1.1.0 (CRAN, Kolesar) | reg_ss / ivreg_ss with method = "akm" / "akm0" (AKM0 = null-imposed, better small-K coverage); sector_cvar clusters shocks | X is the aggregated shift-share vector, shares go in W, the instrument never appears in the formula; the akm0 "se" is a normalized CI length, never a t-stat input |
-| ssaggregate | GitHub kylebutts/ssaggregate (0.0.0.9000, pushed 2025-11) | BHJ shock-level aggregation for the equivalent shift-level regression and the exposure-robust F | dev version, no CRAN release or visible tests; n/s/l/t are strings while vars/controls are formulas; template keeps a hand-coded fallback |
-| bpbounds | 0.1.8 (CRAN) | Balke-Pearl inequality checks and ACE bounds (binary Y, X; Z with 2-3 categories) | xtabs order is positional treatment-outcome-instrument with margin = 3 on the instrument |
+| fixest | 0.14.2 (CRAN, 2026-06-26) | 2SLS with FE and clustered SEs; first stage via summary(est, stage = 1); fitstat(~ ivf1 + ivwald1 + sargan + wh) | IV part must be the LAST formula element, after fixed effects; fitstat keywords lowercase (pinned also in did's details; update the two pins together on refresh) |
+| ivreg | 0.6-8 (CRAN, 2026-07-10) | TSLS with diagnostics rows (weak instruments, Wu-Hausman, Sargan); successor to AER::ivreg | three-part form is y ~ exogenous \| endogenous \| instruments; in the two-part form, controls not repeated after the pipe silently become instruments; vcov. must be a function when diagnostics = TRUE |
+| ivmodel | 1.9.1 (CRAN, 2023-04-09) | AR.test and CLR with inversion CIs (matrix of interval rows; unions and unbounded sets happen), KClass/LIML/Fuller, heteroSE and clusterID options | KClass has a capital K; single endogenous regressor; takes data vectors, not formulas |
+| ivDiag | 1.0.6 (CRAN, 2023-09-17; yiqingxu.org/packages/ivDiag) | one-call audit: F.standard/robust/cluster/bootstrap/effective, AR with inverted CI, tF (Lee et al.), ltz local-to-zero. The components are also exported one at a time: `eff_F()` returns the Montiel Olea-Pflueger effective F alone, `AR_test()` the AR test with its inverted CI alone, and `plot_coef()` draws the estimator comparison (OLS, 2SLS, and the AR interval), which is what the Mixtape's code calls. The template calls the omnibus `ivDiag()` and reads `$F_stat`, `$AR`, and `$tF` off one fit, so reach for the components only when you want a single number without the bootstrap | every variable passed as a name string; pulls the lfe dependency chain |
+| ShiftShareSE | 1.1.0 (CRAN, 2022-04-24, Kolesar) | reg_ss / ivreg_ss with method = "akm" / "akm0" (AKM0 = null-imposed, better small-K coverage); sector_cvar clusters shocks | X is the aggregated shift-share vector, shares go in W, the instrument never appears in the formula; the akm0 "se" is a normalized CI length, never a t-stat input |
+| ssaggregate | GitHub kylebutts/ssaggregate (0.0.0.9000, HEAD 22df939 dated 2025-11-02) | BHJ shock-level aggregation for the equivalent shift-level regression and the exposure-robust F | dev version, no CRAN release or visible tests; n/s/l/t are strings while vars/controls are formulas; template keeps a hand-coded fallback |
+| bpbounds | 0.1.8 (CRAN, 2026-07-13) | Balke-Pearl inequality checks and ACE bounds (binary Y, X; Z with 2-3 categories) | xtabs order is positional treatment-outcome-instrument with margin = 3 on the instrument |
 | ManyIV | GitHub kolesarm/ManyIV (0.0.2.9000, HEAD 0b82852 dated 2025-06-17; source read and run 2026-08-04) | the leniency-design workhorse and the package `goldsmithpinkham2026leniency` uses for its own checklist: `ujive(formula, data, subset, na.action, tol = 1e-8, dropleverage = TRUE)` with formula `y ~ d + controls \| instruments`, returning class `IVResults` whose `$estimate` is a data frame with rows ols / tsls / ujive / "old ujive" / ijive1 / jive1 and columns `estimate`, `se_text` (textbook robust), `se_hte` (heteroskedasticity- and treatment-effect-heterogeneity-robust, the column the paper's tables report, and it absorbs the Bekker many-instrument term), plus `$IVData$F` (homoskedastic first-stage F), `$IVData$k` (instruments after collinear drops), `$IVData$l` (controls), `$IVData$n`, `$drop_obs`. Also `IVreg(..., inference = "standard"/"md")` for Kolesár 2018 minimum-distance many-instrument SEs (JoE 204(1):86-100, distinct from Kolesár-Rothe 2018 on discrete running variables in the rdd skill) and `IVoverid()` for Sargan + modified Cragg-Donald | the endogenous variable must be the FIRST right-hand term (put it second and another regressor is silently treated as endogenous, verified by running both orders); NO cluster argument, so the leave-own-cluster-out UJIVE that clustered assignment requires has to be hand-coded; no null-imposed SE, so the Yap (2025) weak-IV test is hand-coded too; `dropleverage = TRUE` silently drops leverage-one and singleton-dummy rows, `FALSE` returns NaN for UJIVE with a warning; no weights argument; rough dev API (man pages still carry TODOs); for single-endogenous LIML/Fuller use ivmodel |
-| AER | 1.2-17 (CRAN) | legacy ivreg (two-part formula only), kept for compatibility notes | superseded by the ivreg package |
+| AER | 1.2-17 (CRAN, 2026-07-11) | legacy ivreg (two-part formula only), kept for compatibility notes | superseded by the ivreg package |
+| lfe | 3.1.1 (CRAN, 2025-02-11) | `felm(y ~ x \| fe \| (d ~ z))`, the IV route in the Mixtape's bail code | superseded by fixest, which is faster, is maintained, and gives the first stage and fitstat keywords the template uses |
+| SteinIV | 0.1-1 (CRAN, 2016-01-26) | `jive.est(y, X, Z)`, the JIVE the Mixtape runs on the Stevenson data | JIVE only, with no UJIVE and no heterogeneity-robust SE; superseded by ManyIV, which returns OLS, 2SLS, UJIVE, IJIVE, and JIVE from one call. Unchanged on CRAN since 2016 |
 | ivmte | 1.4.0 (CRAN, 2021-09-17; GitHub jkcshea/ivmte slightly ahead, last commit 2024-08-27) | MST bounds and extrapolation, single entry point ivmte(): target 'ate'/'att'/'atu'/'late'/'genlate' with genlate.lb/.ub the u-interval (the alpha dial) or custom target.weight0/1; MTR space via m0/m1 formulas with uSpline(degree, knots, intercept); ivlike list of regression formulas as the estimands; shape flags m0/m1/mte .lb/.ub/.inc/.dec enforced on the audit grid (initgrid.nx/.nu, audit.nx/.nu); bootstraps for inference; cite `shea2023ivmte` | needs one of gurobi/cplexapi/rmosek/lpsolveapi; the only fully free solver (lpSolveAPI) is roughly an order of magnitude slower and cannot run the regression-based direct criterion (QCQP, Gurobi or MOSEK only), so with it always supply ivlike moments; point = TRUE forces GMM and silently ignores every shape constraint; the unobservable in m0/m1 must match uname (default u); m0/m1 bounds default to the observed outcome range, which is the bounded-outcome assumption |
 
 R has no reliable CUE implementation; for the overidentified heteroskedastic case the canon's
@@ -302,5 +330,7 @@ the R fallback. Rotemberg weights: reference implementation at github.com/paulgp
 decomposition and labels it as our implementation.
 
 Stata mirror (the Keane-Neal workflow is Stata-first): ivregress 2sls/liml, ivreg2 (cue, J),
-weakiv (AR/CLR inversion, Finlay-Magnusson-Schaffer), weakivtest (effective F), ssaggregate,
-bartik_weight, manyiv.
+weakiv (AR/CLR inversion, Finlay-Magnusson-Schaffer), weakivtest (Pflueger-Wang effective F),
+twostepweakiv (Sun, AR intervals after 2sls, the pairing the Mixtape's code uses), ssaggregate,
+bartik_weight, manyiv. These are names and roles only: unlike the R rows above, no Stata API
+here has been verified against its help file.

--- a/skills/iv/scripts/iv_template.R
+++ b/skills/iv/scripts/iv_template.R
@@ -70,6 +70,14 @@ g$tF       # Lee et al. (2022) tF on the effective F, for the referee who asks
 # prior = c(0, 0.05) is an illustrative placeholder: set the prior on the direct effect
 # from your setting's plausible violation size.
 
+## ---- 3b. Exhibits: what to plot, and what the table carries -----------------
+# Three figures: the instrument's own variation, the first stage (d on z), and the reduced form
+# (y on z). Never plot y against fitted d, which is processed and reads as opaque. Where a
+# placebo series exists (an untreated market, an unaffected category), draw it on the same axes.
+# The table: OLS beside IV, the first-stage coefficient on z, the strength statistic (effective
+# F from g$F_stat, or sqrt(K) * (E[F] - 1) in section 6), N, and the AR interval in brackets
+# under the point estimate. ivDiag::plot_coef(g) draws the estimator comparison, not these three.
+
 ## ---- 4. Compliance shares, Balke-Pearl checks, Manski bounds (binary d, z) ---
 pi_a <- mean(df$d[df$z == 0])              # always-takers
 pi_n <- mean(1 - df$d[df$z == 1])          # never-takers

--- a/skills/rdd/SKILL.md
+++ b/skills/rdd/SKILL.md
@@ -15,6 +15,19 @@ methods paragraph with the limitation stated in first person at the point of the
 Refresh path: run the litreview skill on the method since the canon date and fold results into
 references/canon.md as flagged addenda.
 
+## Design shapes and the case that anchors each
+
+Each canonical case is a precedent a methods section can cite; details.md says what each teaches.
+
+| Design shape | Canonical case | Marketing analogue | What kills it |
+|---|---|---|---|
+| Age or tenure eligibility rule | Card, Dobkin, Maestas 2008 | trial expiry, anniversary status rolloff | something else switches at the same threshold |
+| Agency-measured score, sharp | Hansen 2015 | churn-score retention offers | reps or managers override the rule off-cutoff |
+| Heaped or rounded score | Almond et al. 2010; Barreca et al. 2011, 2016 | spend thresholds recorded in whole dollars | excess mass at round values that the density test misses |
+| Share crossing a fixed bar | Lee, Moretti, Butler 2004 | seller badge above an on-time-delivery rate | predetermined covariates already jump in the smallest window |
+| Admission cutoff, fuzzy first stage | Hoekstra 2009 | lead-score outreach with rep discretion | a first stage too weak to carry the ratio |
+| Boundary or geographic RD | Black 1999 | DMA advertising borders | the border sorts households, or ads spill across it |
+
 ## The design gate: is this an RD at all?
 
 An RD requires a score, a known cutoff, and a treatment rule that existed ex ante and is
@@ -24,6 +37,12 @@ most important threat. Lab-measured or third-party-computed scores resist it; se
 scores (customer spend near a tier threshold, follower counts near a monetization bar) invite
 exactly the sorting the density test detects, so the falsification battery carries more weight
 in marketing settings than in the medical originals.
+
+One more gate question, and the one sharp designs skip: list every rule, benefit, message, and
+flag that changes at this exact threshold, and say which of them is the treatment. Medicare
+starts at 65 and so does retirement, so Card, Dobkin, and Maestas (2008) went to a third dataset
+on the same running variable (the March CPS 1996-2004) and showed employment does not jump. When
+the confounder is not in your data, find a dataset on the same score where it is.
 
 Two red flags, the first disqualifying on its own (from the failed Oncotype-DX application in
 Cattaneo-Keele-Titiunik 2023):
@@ -71,16 +90,36 @@ Local linear regression, triangular kernel, MSE-optimal bandwidth, robust bias-c
 confidence intervals (Calonico-Cattaneo-Titiunik). Report both the conventional and the robust
 interval. The one-line justification: conventional 95 percent intervals at the MSE-optimal
 bandwidth cover only about 80 percent, and bias correction with the matching variance adjustment
-restores coverage at the same bandwidth.
+restores coverage at the same bandwidth. Two things get called robust: the Mixtape (Cunningham,
+Causal Inference: The Remix, ch. 6) moves between heteroskedasticity-robust OLS standard errors
+and rdrobust's Robust row without flagging the difference, and this skill keeps them apart
+because HC-robust errors leave the point estimate alone while rdrobust's Robust row recenters on
+the bias-corrected estimate and widens the interval by the variance of the bias estimate.
 
 Hard rules from the review, stated as prohibitions because that is how it states them:
 
 - Bandwidths must be data-driven and criterion-optimal; choosing one by hand "is discouraged."
   MSE-optimal for the point estimate, CE-optimal when the interval is the object. Distinct
-  left/right bandwidths are available when curvature differs by side.
+  left/right bandwidths are available when curvature differs by side. The Mixtape (ch. 6)
+  replicates Hansen 2015 with hand-picked bandwidths and a rectangular kernel, which is how RD
+  was done before 2014; this skill refuses that as a primary specification and keeps it only
+  for reproducing a paper that predates the criterion-optimal machinery.
+- Never cluster standard errors on the running variable. The Mixtape (ch. 6) reports the practice
+  as history, recommended by Lee 2008 and Lee and Card 2008 and then discouraged; this skill
+  states it as a prohibition because Kolesar and Rothe 2018 show it inflates Type I error. Use
+  heteroskedasticity-robust variance, honest intervals for a discrete score, and cluster only on
+  a real assignment unit that is not the score. Replicating or refereeing an older RD, expect to
+  find this and fix it.
 - Global polynomial fits are visualization only, never estimation (Gelman-Imbens): boundary
   behavior, counterintuitive weighting, overfitting.
-- Polynomial order: p = 1 default, p = 2 as the robustness check, never high order.
+- Polynomial order: p = 1 default, p = 2 as the robustness check, never high order. Underfitting
+  biases in the other direction, and the Mixtape's cubic simulation with a true zero effect makes
+  it vivid: -176,368.30 from a linear fit and 61,866.33 from a quadratic against 1.14 from the
+  cubic. Curvature is handled by narrowing the window, since the MSE-optimal bandwidth shrinks as
+  curvature rises. h_MSE also grows with p, so the p = 2 check runs on a wider window and a
+  different effective sample. In the Mixtape's Table 6.8 the left bandwidth goes 0.020, 0.033,
+  0.038 and the effective N 13,794, 16,774, 17,545 as the fit goes from no polynomial term to BAC
+  to BAC and BAC-squared. When p = 2 moves the estimate, check the window.
 - Covariates are for precision only; they cannot restore identification of the canonical RD
   parameter, and adjusting an invalid design changes the parameter rather than rescuing it. The
   point estimate should barely move when covariates enter; a large move signals imbalance.
@@ -118,7 +157,7 @@ monotonicity, so the iv skill's habits transfer:
 
 ## Falsification battery
 
-In the order the guide applies them, with each check's bandwidth convention:
+Run them in this order, with each check's bandwidth convention:
 
 1. Qualitative manipulation account (who computes the score, who knows the cutoff).
 2. Density continuity test (rddensity, robust bias-corrected) plus the exact binomial count
@@ -126,17 +165,27 @@ In the order the guide applies them, with each check's bandwidth convention:
    enough that a constant assignment probability is sensible). A discontinuous density is
    neither necessary nor sufficient for invalidity, but it demands an explanation; sorting can
    be administrative rather than strategic.
-3. Covariate and placebo-outcome balance: the full RD machinery with each predetermined
+3. Heaping: plot the raw histogram of the score at its finest granularity before any test. Excess
+   mass at round values (hundreds, integers, instrument ticks) comes from rounding or a coarse
+   measuring technology, a separate threat from strategic sorting, and the density test can pass
+   while heaping biases the estimate. Almond et al. 2010 found no sorting at the 1500-gram
+   very-low-birth-weight cutoff, and the donut in Barreca et al. 2011 (with Barreca, Lindo, and
+   Waddell 2016 on the heaping mechanics) still cut the one-year mortality effect by about half
+   on a 2 percent sample reduction. Run the donut
+   whatever the density test says.
+4. Covariate and placebo-outcome balance: the full RD machinery with each predetermined
    covariate as the outcome, a fresh MSE-optimal bandwidth per covariate, robust p-values. A
    failure on a covariate that plausibly drives the outcome invalidates the design. The
    equivalence-test formulation (null of imbalance) is the more honest variant when you want to
    claim balance affirmatively.
-4. Placebo cutoffs: re-run at artificial cutoffs, one side of the true cutoff at a time so
+5. Placebo cutoffs: re-run at artificial cutoffs, one side of the true cutoff at a time so
    treatment effects do not contaminate the placebo.
-5. Donut hole: drop the observations at and immediately adjacent to the cutoff, keep the
+6. Donut hole: drop the observations at and immediately adjacent to the cutoff, keep the
    original bandwidth, re-estimate. Binds hardest where agents can time their crossing (spend
-   thresholds). Large swings mean the effect rides on the most manipulable observations.
-6. Bandwidth and window sensitivity: instability at or below the chosen bandwidth is the
+   thresholds). Large swings mean the effect rides on the most manipulable observations. The
+   donut estimate is a different parameter, local to a wider neighborhood, and the write-up
+   should describe it as one.
+7. Bandwidth and window sensitivity: instability at or below the chosen bandwidth is the
    warning sign; failure far above it is expected by construction and not damning.
 
 Ex-post power calculations from observed effects are unreliable; when a null matters, report
@@ -179,6 +228,12 @@ summary(rddensity(x, c = cutoff))             # manipulation
 w <- rdwinselect(x, Z, c = cutoff)            # local-randomization window
 rdrandinf(y, x, cutoff = cutoff, wl = w$w_left, wr = w$w_right)
 ```
+
+Four figures carry a credible RD: the density of the score, take-up against the score, covariate
+balance, and the outcome in bin means. If you cannot see the effect in the bin means you are
+underpowered or it is not there. Report the estimate against the mean of the dependent variable,
+so a small coefficient on a large base reads as a precise null (0.6 points on an 84.6 percent
+base, in the Mixtape's balance table).
 
 Package index with versions and links in references/details.md. Stata and Python mirrors of the
 whole suite live at rdpackages.github.io; the guide ships full replication code in all three.

--- a/skills/rdd/references/canon.md
+++ b/skills/rdd/references/canon.md
@@ -63,6 +63,35 @@ elections); Gelman-Imbens 2019 (against global polynomials); Calonico-Cattaneo-F
 (CE-optimal bandwidths); Calonico-Cattaneo-Farrell-Titiunik 2019 (covariates);
 Cattaneo-Titiunik-Vazquez-Bare 2017 (inference comparison, binomial test) and 2019 (power);
 Card-Lee-Pei-Weber 2015 (kink); Imbens-Wager 2019 and Armstrong-Kolesar (honest school);
-Kolesar-Rothe 2018 (discrete scores); Pei-Lee-Card-Weber (polynomial order);
+Kolesar-Rothe 2018 (discrete scores, and the prohibition on clustering standard errors by the
+running variable, which binds for continuous scores too); Pei-Lee-Card-Weber (polynomial order);
 Cattaneo-Idrobo-Titiunik Foundations and Extensions volumes; Ludwig-Miller 2007 (placebo-outcome
 exemplar); Calonico-Cattaneo-Titiunik 2015 (RD plots); Hartman (equivalence testing).
+
+Added 2026-08-26 from the Mixtape ch. 6 pass. BibTeX is Crossref-verified and merged into causal.bib: Imbens-Kalyanaraman 2012 (`imbens2012optimal`,
+the origin of the data-driven MSE-optimal bandwidth rule this skill enforces); Lee-Card 2008
+(`lee2008specification`, specification error with a discrete running variable, and the origin of
+the clustering-on-the-score practice Kolesar-Rothe overturned); Calonico-Cattaneo-Farrell-Titiunik
+2017 (`calonico2017rdrobust`, the rdrobust software paper a methods section cites for the
+implementation).
+
+## Exemplar rows
+
+The recognition table's canonical cases, Crossref-verified and merged into causal.bib 2026-08-26. One line each, with the design shape the case is the precedent for.
+
+- Card, Dobkin, and Maestas 2008 (`card2008impact`), the age or tenure eligibility rule, and the
+  compound-treatment discipline that goes with it.
+- Hansen 2015 (`hansen2015punishment`), the agency-measured sharp score, breathalyzer BAC at 0.08.
+- Almond, Doyle, Kowalski, and Williams 2010 (`almond2010estimating`), the heaped or rounded score
+  at the 1500-gram very-low-birth-weight cutoff, where the density test passes and heaping biases
+  the estimate anyway.
+- Barreca, Guldi, Lindo, and Waddell 2011 (`barreca2011saving`), the donut-hole re-estimate at that
+  same cutoff, which is where the halved one-year mortality effect comes from.
+- Barreca, Lindo, and Waddell 2016 (`barreca2016heaping`), the heaping methodology behind the donut,
+  and the general case against reading a passing density test as clearance.
+- Lee, Moretti, and Butler 2004 (`lee2004voters`), a share crossing a fixed bar, and the
+  covariate-balance exhibit as bin means panel by panel.
+- Hoekstra 2009 (`hoekstra2009effect`), the admission cutoff with a fuzzy first stage, and the
+  take-up plot shown before any outcome.
+- Black 1999 (`black1999schools`), the boundary or geographic RD, and the precedent behind the
+  DMA-border translation.

--- a/skills/rdd/references/details.md
+++ b/skills/rdd/references/details.md
@@ -2,16 +2,23 @@
 
 Heavy reference content the SKILL.md points into. Current as of 2026-07-28.
 
-## Package index (verified 2026-07-28; suite home rdpackages.github.io)
+## Package index (every row re-verified against CRAN 2026-08-26; suite home rdpackages.github.io)
 
 | Package | CRAN version | Role | Traps |
 |---|---|---|---|
-| rdrobust | 4.0.0 (2026-05) | rdrobust, rdbwselect, rdplot | `all=` removed from rdrobust(), now summary(fit, all=TRUE); cluster= needs vce="cr1/2/3" (use cr2, our default across these skills, following the small-G cluster-robust literature); masspoints="adjust" default |
-| rddensity | 3.0 (2026-05) | density + built-in binomial table, rdplotdensity | argument is camelCase `massPoints`; binomial via bino/binoW/binoNW |
-| rdlocrand | 2.0 (2026-05) | rdwinselect, rdrandinf, rdsensitivity, rdrbounds | rdwinselect needs covariates; level=0.15 default is the loose balance threshold by design |
-| rdpower | 3.0 (2026-05) | rdpower, rdsampsi, rdmde | `rdpow` is the Stata name only; data = cbind(Y, X) |
-| rdmulti | 2.0.0 (2026-05) | rdmc, rdms, rdmcplot | C is an observation-level cutoff vector |
-| RDHonest | GitHub (kolesarm/RDHonest) | honest-school intervals | manual smoothness constant M; the canon's critique applies |
+| rdrobust | 4.0.0 (2026-05-16) | rdrobust, rdbwselect, rdplot | `all=` removed from rdrobust(), now summary(fit, all=TRUE); cluster= needs vce="cr1/2/3" (use cr2, our default across these skills, following the small-G cluster-robust literature); masspoints="adjust" default |
+| rddensity | 3.0 (2026-05-21) | density + built-in binomial table, rdplotdensity | argument is camelCase `massPoints`; binomial via bino/binoW/binoNW; imports lpdensity (>= 2.2), so R needs no separate install where Stata does |
+| rdlocrand | 2.0 (2026-05-14) | rdwinselect, rdrandinf, rdsensitivity, rdrbounds | rdwinselect needs covariates; level=0.15 default is the loose balance threshold by design |
+| rdpower | 3.0 (2026-05-17) | rdpower, rdsampsi, rdmde | `rdpow` is the Stata name only; data = cbind(Y, X) |
+| rdmulti | 2.0.0 (2026-05-17) | rdmc, rdms, rdmcplot | C is an observation-level cutoff vector |
+| binsreg | 2.2 (2026-08-21) | binsreg, binsregselect, binstest: the general binscatter tool (Cattaneo, Crump, Farrell, Feng 2024) | no cutoff argument, so fit each side with subset= or by=; bins are quantile-spaced by default (binspos="qs"); rdplot with its IMSE-optimal bins stays the default RD figure |
+| RDHonest | 1.0.1 (2024-12-16) | honest-school intervals | manual smoothness constant M; the canon's critique applies; the only package here without a 2026 release, so pin it and re-check before relying on it |
+
+The chapter's footnote 8 sends R users to cran.r-project.org/web/packages/rdd, which is the old
+orphaned `rdd` package and not rddensity. Do not use `rdd` or any other pre-rdpackages
+implementation. The chapter's other R loads (fixest for the hand-bandwidth OLS, haven for .dta)
+are not RD tools and stay out of this index; lpdensity stays out too, since R users get it as an
+rddensity dependency and never call it directly.
 
 Replication repos: github.com/rdpackages-replication/{CKT_2023_SIM, CIT_2024_CUP, CIT_2020_CUP}.
 rdrr.io serves stale 2023 builds of these packages; never verify signatures there. The fuzzy
@@ -26,9 +33,10 @@ our addition and should be labeled as such.
 | Qualitative manipulation account | written before estimation | design suspect regardless of tests |
 | Density test (rddensity, RBC) | own bandwidth; show the plot | sorting (strategic or administrative); explain or walk away |
 | Binomial count test | small windows; constant assignment probability must be sensible, so keep the window narrow (a trending density fails it mechanically) | same as density; works for discrete scores |
+| Raw histogram for heaping | finest granularity of the score, before any formal test | excess mass at round values from rounding or coarse measurement; the density test can pass anyway, so run the donut regardless |
 | Covariate / placebo-outcome balance | fresh MSE-optimal bandwidth PER covariate; RBC p-values; equivalence-test variant to claim balance affirmatively | invalid if the covariate plausibly drives the outcome |
 | Placebo cutoffs | one side of the true cutoff at a time | unexplained jump undermines continuity |
-| Donut hole | drop cutoff-adjacent observations, KEEP the original bandwidth | effect rides on the most manipulable observations |
+| Donut hole | drop cutoff-adjacent observations, KEEP the original bandwidth | effect rides on the most manipulable observations; the surviving estimate is a different parameter, local to a wider neighborhood |
 | Bandwidth sensitivity | instability at or below chosen h is the warning; failure far above is expected | curvature or manipulation, not a license to cherry-pick |
 | Take-up plot (fuzzy) | before estimation | off-cutoff jumps = soft rule = likely fatal |
 
@@ -83,6 +91,34 @@ Ex-post power from observed effects is unreliable. For nulls that matter, report
 detectable effects (rdpower: rdpow, rdsampsi). For ex-ante design (choosing which threshold
 experiment to run), rdsampsi gives the required N near the cutoff.
 
+## Canonical cases and what each teaches
+
+The long form of the recognition table in SKILL.md. All six are worked in Cunningham, Causal
+Inference: The Remix, ch. 6.
+
+- Card, Dobkin, and Maestas 2008 (AER 98(5)), Medicare at 65. The compound-treatment discipline.
+  Retirement also happens at 65, so the authors brought in a third dataset on the same running
+  variable (March CPS 1996-2004) and showed employment does not jump there. That is the move
+  when the confounder you need to rule out is absent from your own data.
+- Hansen 2015 (AER 105(4)), the 0.08 BAC threshold for a DUI charge in Washington State. The
+  end-to-end workflow: histogram, density test, covariate balance as both table and figure,
+  linear and quadratic outcome plots, then rdrobust. The score is measured by the arresting
+  agency with a breathalyzer, which is what makes it resistant to manipulation.
+- Almond, Doyle, Kowalski, and Williams 2010 (QJE 125(2)) with Barreca, Guldi, Lindo, and
+  Waddell 2011 (QJE 126(4)) and Barreca, Lindo, and Waddell 2016 (Economic Inquiry 54(1)), the
+  1500-gram very-low-birth-weight cutoff. The one published RD the
+  chapter overturns. The density test found no sorting, heaping at round gram values biased the
+  estimate anyway, and the donut cut the one-year mortality effect by about half while dropping
+  2 percent of the sample.
+- Lee, Moretti, and Butler 2004 (QJE 119(3)), US House Democratic vote share at 50 percent. The
+  covariate-balance exhibit: predetermined district characteristics as bin means across the
+  cutoff, one panel each.
+- Hoekstra 2009 (REStat 91(4)), flagship-university admission test score. The take-up plot as the
+  gate before estimation. He shows the jump in the probability of attending before he shows
+  anything about earnings.
+- Black 1999 (QJE 114(2)), school-district zoning boundaries. The origin of the spatial RD, and
+  the precedent behind the DMA-border translation below, which otherwise cites nobody.
+
 ## Marketing translations (from the medical guide, adapted)
 
 - Fuzzy algorithmic triggers: churn-score retention offers, lead-score outreach, credit
@@ -94,6 +130,10 @@ experiment to run), rdsampsi gives the required N near the cutoff.
 - Threshold designs with self-influenced scores: spend-based loyalty tiers, follower-count
   monetization bars. Manipulation is live (customers time purchases); density, binomial, and
   donut tests carry more weight here than in medicine.
+- Compound treatment at one threshold: a spend value that switches on free shipping, a status
+  badge, and a lifecycle email is three treatments at one cutoff, and the RD identifies the
+  bundle. Enumerate what fires at that value before writing the design down, then either name
+  the one you claim and defend it or report the bundle as the estimand.
 - Multi-cutoff: tiered programs (silver/gold/platinum). Geographic RD: DMA advertising borders.
 - Bunching at price breaks is adjacent but distinct; bunching identification needs parametric
   assumptions and is out of scope here.

--- a/skills/rdd/scripts/rdd_template.R
+++ b/skills/rdd/scripts/rdd_template.R
@@ -16,6 +16,12 @@ d  <- df$takeup              # observed treatment (fuzzy designs only)
 Z  <- as.matrix(df[, c("cov1", "cov2")])   # predetermined covariates
 CUT <- 350                   # the cutoff
 set.seed(94305)
+# Which side of the cutoff does the institutional rule treat? rdrobust treats x >= c, so every
+# hand-written comparison below is `x >= CUT` and never `x > CUT`. Check yours matches before
+# running anything. The Mixtape (Cunningham, Causal Inference: The Remix, ch. 6) writes
+# `df$dui = (df$bac1 > 0.08)` in its R code where its Stata code uses `bac1>=0.08`; this skill
+# fixes the convention here because the strict inequality moves every observation sitting
+# exactly on the cutoff to the control side, and a heaped score puts many of them there.
 
 library(rdrobust); library(rddensity); library(rdlocrand); library(rdpower)
 
@@ -34,10 +40,18 @@ length(unique(x))
 # MSE-optimal bandwidth (bwselect="mserd" default), robust bias-corrected CIs.
 fit <- rdrobust(y, x, c = CUT)
 summary(fit, all = TRUE)          # Conventional + Bias-Corrected + Robust rows
+# The Robust row is NOT the HC-robust standard error from lm() or feols(vcov = "hc1"). It
+# recenters the estimate on the bias-corrected value and widens the interval by the variance of
+# the bias estimate itself. Never describe the two as the same thing in a table note.
 
 # With covariates (precision only; the point estimate should barely move):
 fit_cov <- rdrobust(y, x, c = CUT, covs = Z)
-# With clustering (note the vce requirement in 4.0.0):
+# With clustering (note the vce requirement in 4.0.0). NEVER put the running variable, or any
+# bin or rounding of it, in cluster=: Kolesar and Rothe (2018) show that clustering on the score
+# inflates Type I error. Cluster only on a real sampling or assignment unit (customer, store,
+# market). The Mixtape (ch. 6) records the Lee (2008) and Lee and Card (2008) practice as
+# historical; this skill bans it outright, and when you replicate or referee an older RD, expect
+# to find it and take it out.
 # fit_cl <- rdrobust(y, x, c = CUT, cluster = df$cluster, vce = "cr2")
 # Robustness variants: p = 2, uniform kernel, CE-optimal bandwidth:
 fit_p2 <- rdrobust(y, x, c = CUT, p = 2)

--- a/skills/synthetic-control/SKILL.md
+++ b/skills/synthetic-control/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: synthetic-control
-description: Design, estimate, validate, and write up a synthetic control analysis, including synthetic difference-in-differences, augmented/penalized variants, and factor-model/matrix-completion relatives for panel counterfactuals. Produces advice with citations, R estimation and diagnostics code, and a drafted methods paragraph. TRIGGER on "synthetic control", "synthetic DiD", "SDID", "donor pool", "comparative case study", "weighted counterfactual", "geo holdout", "CausalImpact", "matrix completion", "interactive fixed effects", "gsynth", "generalized synthetic control", or any setting where one or a few aggregate units (a state, market, DMA, category, platform region) got treated and untreated units must form the counterfactual. Staggered-adoption panels with many treated units belong to did; design triage across methods belongs to causal-design. Prospective geo experiments (choosing treatment markets by design) belong to field-experiment.
+description: Design, estimate, validate, and write up a synthetic control analysis, including synthetic difference-in-differences, augmented/penalized variants, and factor-model/matrix-completion relatives for panel counterfactuals. Produces advice with citations, R estimation and diagnostics code, and a drafted methods paragraph. TRIGGER on "synthetic control", "synthetic DiD", "SDID", "staggered SDID", "donor pool", "comparative case study", "weighted counterfactual", "geo holdout", "CausalImpact", "matrix completion", "interactive fixed effects", "gsynth", "generalized synthetic control", or any setting where one or a few aggregate units (a state, market, DMA, category, platform region) got treated and untreated units must form the counterfactual. Staggered-adoption panels with many treated units belong to did; design triage across methods belongs to causal-design. Prospective geo experiments (choosing treatment markets by design) belong to field-experiment.
 ---
 
 # Synthetic control
@@ -15,6 +15,18 @@ with the limitation stated in first person at the point of the choice.
 Refresh path: run the litreview skill on the method since the canon date and fold results into
 references/canon.md as flagged addenda.
 
+## Which precedent your design looks like
+
+| Design shape | Canonical case | Marketing analogue | What kills it |
+|---|---|---|---|
+| One treated region, outcome co-moves across regions | Basque terrorism (Abadie and Gardeazabal 2003) | a single-market launch | donors whose outcome does not co-move with the treated region |
+| One treated unit, a regulation, other units running their own versions of it | California Prop 99 (Abadie, Diamond, and Hainmueller 2010) | a regulation hitting one state's category sales | already-treated donors left in the pool |
+| One treated unit, pool restricted to genuine peers | German reunification (Abadie, Diamond, and Hainmueller 2015) | a platform policy change in one country | a pool wide enough that fit gets bought from dissimilar donors |
+| Mid-pack treated unit, smooth series, long pre-period | Texas prison construction (the Mixtape's data exercise) | a geo rollout in one DMA | a treated unit at the top or the bottom of the donor range |
+| Comparison units picked by hand and defended in a footnote | Mariel Boatlift (Card 1990; Peri and Yasenov 2019) | a hand-picked matched-market holdout | no test exists on the hand-picked choice. Synthetic control replaces it |
+
+references/details.md carries what each case is the precedent for.
+
 ## The feasibility gate: is SC usable here at all?
 
 The method's originator is explicit that mechanical applications are risky and that there are
@@ -25,6 +37,9 @@ situations where the honest answer is to walk away. Check before estimating:
 - A long pre-period. But a long T0 cannot repair a bad fit: the bias bound is derived under
   (near-)perfect predictor fit, and when pre-period fit is poor the recommendation is to not
   use synthetic control, full stop.
+- Enough post-intervention periods. Abadie, Diamond, and Hainmueller (2015) also require a
+  sizable number of them when the effect emerges gradually after the intervention or changes
+  over time, so a long pre-period with two post-periods does not pass this gate.
 - The converse trap: good pre-period fit with a short T0 or a noisy outcome can be spurious
   overfitting on transitory shocks, and a larger donor pool makes overfitting easier, so a
   bigger J is not automatically better.
@@ -70,7 +85,13 @@ regression weights in the reunification example).
 The degrees of freedom, each with a discipline:
 
 - Predictors: pre-intervention outcomes PLUS substantive covariates. Pre-outcomes alone push
-  excluded covariates into the unobserved loadings and raise the bias bound.
+  excluded covariates into the unobserved loadings and raise the bias bound. The Mixtape
+  (Cunningham, Causal Inference: The Remix, synthetic-control chapter) reports that
+  researchers increasingly rely solely on lagged outcomes as covariates (Ben-Michael, Feller,
+  and Rothstein 2021); this skill rejects the drift because the excluded covariates are what
+  inflate Abadie's bias bound. The exception is an outcome series known to be driven by
+  strongly co-moving common factors, which is why one pre-period average sufficed for
+  reunification.
 - V: inverse-variance as the simple default; better, minimize pre-period MSPE or pick V by a
   training/validation split of the pre-period. Cross-validated V is not always unique, so show
   the estimate is stable across reasonable V choices.
@@ -83,7 +104,9 @@ The degrees of freedom, each with a discipline:
 One continuous decision path, not competing methods:
 
 - DiD is the special case of the SC factor model with constant factor loadings. If the treated
-  unit's pre-trend parallels a plausible comparison average, use did.
+  unit's pre-trend parallels a plausible comparison average, use did. Long pre-periods are
+  load-bearing for SC identification. DiD needs one pre-period to identify the ATT and more
+  only for credibility, so the SC pre-period gate does not transfer to a DiD routing decision.
 - When the pre-period plot shows the donor average diverging from the treated unit before
   treatment, parallel trends has already failed and SC is the tool. The sharpest known
   routing result: under selection on lagged outcomes with autocorrelated errors, DiD is
@@ -95,9 +118,17 @@ One continuous decision path, not competing methods:
   out. The price is a stable-bias assumption on that gap. In simulations calibrated to real
   panels, SDID typically outperforms DiD, SC, and matrix completion. Practical default: run
   canonical SC when the gate passes cleanly; when level fit is the sticking point, move to
-  SDID and say why.
+  SDID and say why. Reporting discipline: plot the time weights beside the trajectory figure
+  so readers see which pre-years carry the counterfactual, and plot the unit weights so they
+  see which donors do. The intercept means the treated and synthetic series will not overlay,
+  so the visual pre-fit check canonical SC leans on is weaker here. No accepted substitute
+  exists yet. The four assumptions SDID actually makes are in references/details.md.
 - Staggered adoption with many treated units forecloses the standard SC estimator; that is
-  did territory (or multisynth / the factor-model estimators, below).
+  did territory (or multisynth / the factor-model estimators, below). Staggered SDID is the
+  exception: the appendix of Arkhangelsky et al. (2021), section 2.3 of the
+  Stata Journal SDID article (Clarke, Pailanir, Athey, and Imbens 2024), and Porreca (2022).
+  No CRAN package covers it. Porreca ships code at
+  github.com/zachporreca/staggered_adoption_synthdid.
 
 ## Inference
 
@@ -122,7 +153,8 @@ The primary mode is design-based permutation, honest about its limits:
 1. Pre-period fit, the entry gate: table the treated unit's predictor values against the
    synthetic unit's and plot both trajectories over the whole pre-period. Visible gaps in
    either mean do not proceed (tighten the pool, change predictors or transformation,
-   bias-correct, move to SDID, or abandon).
+   bias-correct, move to SDID, or abandon). The balance table has one value per variable per
+   group, so it is a display, not a test.
 2. Backdating (in-time placebo, the Heckman-Hotz preprogram test): move the intervention date
    back, re-estimate on pre-data only. Pass has two parts: no effect opens during the fake
    post-period, and the gap still opens at the true date with the same sign and shape. A
@@ -136,7 +168,9 @@ The primary mode is design-based permutation, honest about its limits:
    not hinge on one donor. When it does, check whether that donor had its own intervention or
    shock.
 5. Robustness across predictor sets, V choices, and tightened donor pools; drift as the pool
-   tightens signals interpolation bias from dissimilar donors.
+   tightens signals interpolation bias from dissimilar donors. Searching over pre-treatment
+   lag choices raises the false-positive rate (Ferman, Pinto, and Possebom 2020), so
+   pre-commit the predictor set or report every specification tried.
 6. Outcome-transformation check when levels are hard to match (levels vs differences vs
    growth rates vs pre-mean deviations), remembering the noise-amplification tradeoff and
    that matching changes alone is not credible when the level itself drives dynamics.

--- a/skills/synthetic-control/references/canon.md
+++ b/skills/synthetic-control/references/canon.md
@@ -73,3 +73,27 @@ CausalImpact); Firpo-Possebom 2018 (sensitivity, confidence sets); Heckman-Hotz 
 (preprogram test); Amjad-Shah-Shen 2018 (robust SC denoising); Athey-Imbens 2017 (the
 "most important innovation" framing); Klossner et al. 2018 (V non-uniqueness); Liu-Wang-Xu
 2024 (counterfactual estimators guide, fect).
+
+Added 2026-08-26 from the Mixtape's synthetic-control chapter (Cunningham, Causal Inference:
+The Remix), Crossref-verified, keys merged into causal.bib: Ferman-Pinto-Possebom
+2020 (`ferman2020cherry`, JPAM 39(2): 510-532; specification search over pre-treatment lag
+choices raises the false-positive rate, and the recommendation is to present results across
+multiple specifications); Porreca 2022 (`porreca2022synthetic`, Economics Letters 220: 110874;
+SDID with staggered treatment timing, code at
+github.com/zachporreca/staggered_adoption_synthdid); Clarke-Pailanir-Athey-Imbens 2024
+(`clarke2024synthetic`, Stata Journal 24(4): 557-598; the Stata `sdid` implementation, with
+the staggered-timing discussion in section 2.3). Author order on the last one: Crossref and
+the published article put Clarke first, while the Mixtape's reference list gives it as "Athey,
+Clarke, Imbens, and Pailanir"; cite the published order.
+
+## Exemplar rows
+
+The recognition table's worked precedents. The three Abadie rows (Basque terrorism, California
+Prop 99, German reunification) are already in the primary-papers paragraph above as
+`abadie2003economic`, `abadie2010synthetic`, and `abadie2015comparative`, and the Texas prison row
+is the Mixtape's own data exercise with no paper behind it. The two remaining rows were Crossref-verified and merged into causal.bib 2026-08-26.
+
+- Card 1990 (`card1990impact`), comparison units picked by hand and defended in a footnote, the
+  Mariel Boatlift design that motivated the method because no test exists on the hand-picked four.
+- Peri and Yasenov 2019 (`peri2019labor`), the synthetic-control redo of that same design, which is
+  the precedent for replacing a hand-picked holdout with a weighted donor pool.

--- a/skills/synthetic-control/references/details.md
+++ b/skills/synthetic-control/references/details.md
@@ -26,6 +26,31 @@ nuclear-norm penalty). Divergence among them is a specification diagnostic. The 
 routing result: under selection on lagged outcomes with autocorrelated errors, DiD is
 inconsistent even as T0 grows while SC is consistent and asymptotically unbiased.
 
+## What SDID assumes
+
+The SKILL.md boundary bullet prices SDID at one clause, a stable-bias assumption on the level
+gap. That is the intuition. Arkhangelsky et al. (2021) state four assumptions, and these are
+what a referee asks about:
+
+1. Errors: the rows of the error matrix are independent, identically distributed Gaussian
+   vectors with bounded eigenvalues in their covariance matrix. Stronger than DiD or SC
+   normally assume, which is independence with no distribution attached.
+2. Sample sizes: the number of control units N_co and the number of pre-treatment periods
+   T_pre must both be large, and ideally the product of treated units N_tr and post-treatment
+   periods T_post is large too. The design wants a balance between T_pre and N_co.
+3. Systematic component: L has a limited number of large singular values.
+4. Weighting: oracle weights derived from L remove systematic differences between treated and
+   control groups. This is parallel trends applied after reweighting. It asks for parallelism
+   and does not require exact balance.
+
+The Mixtape (Cunningham, Causal Inference: The Remix, synthetic-control chapter) says of the
+SDID outcome model that "here we are not depending on the low matrix assumption" and then
+states Assumption 3 as a limited number of large singular values, which is a low-rank
+assumption. This skill treats SDID as leaning on approximate low rank in its systematic
+component, because the difference from matrix completion is that the rank restriction is not
+what the estimator regularizes toward. In a methods section cite Assumption 3, not that
+sentence, or a referee reading the same chapter will catch it.
+
 ## V and predictor mechanics
 
 - V default ladder: inverse-variance rescaling (simple), pre-period MSPE minimization
@@ -64,6 +89,15 @@ inconsistent even as T0 grows while SC is consistent and asymptotically unbiased
   moderate-to-large donor pool and roughly similar outcome variances across treated and
   control groups. Divergence across the applicable procedures signals the data shape does
   not support the chosen one.
+- The Mixtape (Cunningham, Causal Inference: The Remix, synthetic-control chapter) offers
+  randomization inference, jackknife, and bootstrap as equal SDID options and tells the reader
+  to select one that aligns with the data's structure. This skill names the choice instead,
+  because a reader with a single treated unit who follows that instruction will pick the
+  jackknife and get an invalid interval: with one treated unit synthdid's placebo vcov is the
+  only valid method, and the block bootstrap and jackknife need many treated units. The
+  chapter routes matrix-completion inference through a nonparametric bootstrap; gsynth's and
+  fect's parametric-bootstrap CIs are biased in both directions (Li and Sonnier 2023), so
+  prefer subsampling or the corrected inference there.
 - Backdating doubles as a bias estimate: if biases are stable in time, subtract the
   pre-period "effect" (the DiD-flavored corrections of Arkhangelsky et al. and
   Chernozhukov-Wuthrich-Zhu).
@@ -90,8 +124,10 @@ inconsistent even as T0 grows while SC is consistent and asymptotically unbiased
 |---|---|---|---|
 | Canonical, one treated aggregate unit | ADH SC | abadie2010synthetic | Synth / tidysynth (+ SCtools placebos) |
 | Imperfect pre-fit | augmented (ridge) SC | benmichael2021augmented | augsynth |
+| Imperfect pre-fit, donors sharing the treated unit's aggregate shocks | demeaned SC, centers outcomes on their pre-treatment mean to remove shared exposure to aggregate shocks; reduces bias under imperfect fit, raises variance in small samples, ships with the authors' specification test for whether it is suitable | ferman2021synthetic | demean by hand, no package |
 | Disaggregated / many treated | penalized SC | abadie2021penalized | pensynth |
 | Level gaps, stable-bias plausible | synthetic DiD | arkhangelsky2021synthetic | synthdid |
+| Staggered adoption where SDID is still the right estimator | staggered synthetic DiD | arkhangelsky2021synthetic appendix; clarke2024synthetic sec 2.3; porreca2022synthetic | no CRAN package; Porreca's code at github.com/zachporreca/staggered_adoption_synthdid |
 | N and T both modest-plus | IFE / generalized SC | xu2017generalized | gsynth, fect |
 | Same, nuclear-norm route | matrix completion | athey2021matrix | fect (mc), MCPanel |
 | Prediction intervals | scpi | cattaneo2021prediction | scpi |
@@ -107,6 +143,16 @@ The AMA routing source's 'augmented DiD' (Li and Van den Bulte 2023, convex-hull
 different estimator from the augmented (ridge) SC row above (Ben-Michael et al.); do not conflate
 the two.
 
+## Worked precedents (the rows behind SKILL.md's recognition table)
+
+| Application | Source | What it is the precedent for |
+|---|---|---|
+| Basque terrorism | Abadie and Gardeazabal 2003 | The origin. A single treated region, GDP per capita, an outcome that co-moves across Spanish regions |
+| California Prop 99 | Abadie, Diamond, and Hainmueller 2010 | Donor discipline (drop states running their own tobacco programs), the balance table, the 2x pruning rule, the RMSPE-ratio p-value |
+| German reunification | Abadie, Diamond, and Hainmueller 2015 | Restricting the pool to OECD economies, the SC-versus-regression weight table, cross-validated V, the in-time placebo |
+| Texas prison construction | Cunningham's Mixtape data exercise (`texas.dta`) | A mid-pack treated unit, the full placebo pipeline, and the excellent-fit case where augmented SC equals classic SC |
+| Mariel Boatlift | Card 1990; Peri and Yasenov 2019 | Why ad hoc comparison-city selection motivated the method, and what the synthetic-control redo changed |
+
 ## Marketing translations
 
 - Geo rollouts: a pricing, assortment, or feature change in one DMA/country with untouched
@@ -115,7 +161,7 @@ the two.
 - Regulation: state-level advertising or privacy rules hitting one state (the Prop 99
   template, literally a marketing-regulation outcome).
 - Platform shocks: a policy change hitting one category, region, or creator tier; channel- or
-  creator-level panels on a video platform where channels co-move.
+  streamer-level panels where channels co-move (Twitch-YouTube style data).
 - Anticipation: forward-buying before announced price changes; shift T0 to the
   announcement, not the enactment.
 - Interference: national campaigns contaminate donor markets; drop exposed donors or sign
@@ -127,13 +173,21 @@ the two.
 
 ## Package index (verified against package docs 2026-07-28)
 
+Versions and GitHub pins re-checked 2026-08-26 against CRANDB and the repos: every row below
+was already current, nothing moved. CRAN publication dates at that check: tidysynth 0.2.1
+(2025-03-24), Synth 1.1-10 (2026-04-29), SCtools 0.3.3.1 (2025-01-27), pensynth 0.8.2
+(2026-05-07), scpi 4.0.1 (2026-06-10), gsynth 1.4.0 (2026-03-27), fect 2.4.5 (2026-05-30),
+CausalImpact 1.4.1 (2025-09-26). GitHub HEAD at that check: augsynth 0.2.0 @ 7a90ea4
+(2026-06-03), synthdid 0.0.9 @ 70c1ce3 (2024-01-15), scinference @ 567c688 (2021-05-13),
+MCPanel 0.0 @ 6b2706f (2017-11-17, unmaintained since).
+
 | Package | Version | Role | Traps |
 |---|---|---|---|
 | tidysynth | 0.2.1 (CRAN) | modern ADH pipeline: synthetic_control, generate_predictor/weights/control, grab_significance (RMSPE-ratio table), plot_placebos | ipop tuning args are snake_case (margin_ipop/sigf_ipop/bound_ipop); the package's OWN examples use dot-case names that fall into ... and are silently ignored; needs >= 20 donors for p < .05 |
 | Synth | 1.1-10 (CRAN, 2026-04, still maintained) | original dataprep/synth/synth.tab/path.plot/gaps.plot | unit and time variables must be numeric; time.plot defaults to the pre-period, extend it explicitly; dot-case Margin.ipop here (opposite of tidysynth); no placebo machinery of its own |
-| SCtools | 0.3.3.1 (CRAN) | in-space placebos for Synth objects: generate.placebos, mspe.test, plot_placebos | strategy = "multiprocess" deprecated (use "multisession"); prunes at 20x MSPE by default vs tidysynth's 2x |
+| SCtools | 0.3.3.1 (CRAN) | in-space placebos for Synth objects: generate.placebos, mspe.test, plot_placebos, mspe.plot (post/pre MSPE ratio dotplot or histogram) | strategy = "multiprocess" deprecated (use "multisession" or "multicore"; the default is "sequential"); mspe.plot prunes nothing by default (discard.extreme = FALSE), and mspe.limit = 20 is the multiple of the treated unit's pre-MSPE applied only when discard.extreme = TRUE, against tidysynth's 2x; plot.hist = TRUE switches the dotplot to a histogram, which is what you want with many controls |
 | synthdid | 0.0.9 (GitHub synth-inference, not on CRAN) | SDID: panel.matrices, synthdid_estimate, sc_estimate/did_estimate trio, vcov(placebo/jackknife/bootstrap) | single treated unit: placebo is the ONLY valid vcov method; panel.matrices matches columns by position unless named; balanced panel, block adoption only |
-| augsynth | 0.2.0 (GitHub ebenmichael, not on CRAN) | augmented SC (progfunc = "ridge"), conformal summary; multisynth for staggered many-treated | current signature has t_int AFTER data (the repo README shows the old order); fixedeff default differs (FALSE single, TRUE multisynth) |
+| augsynth | 0.2.0 (GitHub ebenmichael, not on CRAN) | augmented SC (progfunc = "ridge"), conformal summary; multisynth for staggered many-treated | current signature has t_int AFTER data (the repo README shows the old order); fixedeff default differs (FALSE single, TRUE multisynth); the slight penalty term in the weight solver leaves some weights infinitesimally positive and negative where a hard non-negativity constraint would give exact zeros, so tiny negative weights are not extrapolation; plot() takes inf_type ("conformal" default, "jackknife+", "jackknife", "permutation", "permutation_rstat", "None") and plot_type ("estimate", "outcomes", "cv", "placebo"), and the older cv = TRUE just forces plot_type = "cv" |
 | pensynth | 0.8.2 (CRAN) | penalized SC with cross-validated lambda (cv_pensynth) | Synth orientation, units in COLUMNS; Z1/Z0 hold-out outcome matrices are required for CV |
 | scpi | 4.0.1 (CRAN) | scdata/scest/scpi prediction intervals, scplot; multi-treated variants scdataMulti/scplotMulti | w.constr is a list (list(name = "simplex")), not a string; default solver is CLARABEL (ECOS tutorials stale); scpi() is simulation-heavy |
 | gsynth | 1.4.0 (CRAN) | generalized SC / IFE (Xu 2017) | estimator default is now "gsynth"; "ife" means IFE-with-EM; force default "unit" (fect's is "two-way"); GitHub README stale at 1.3.1; parametric bootstrap CIs biased in both directions (Li and Sonnier 2023, li2023statistical); prefer subsampling or the corrected inference |
@@ -142,6 +196,6 @@ the two.
 | scinference | 0.0.0.9000 (GitHub kwuthrich, commit 567c688, 2021) | conformal and cross-fit t-test inference (Chernozhukov-Wuthrich-Zhu) | underscore argument names; default alpha 0.10; CIs need an explicit ci_grid; research code, pin the commit |
 | MCPanel | GitHub susanathey/MCPanel | original matrix-completion code | fect method = "mc" is the maintained route |
 
-Stata and Python mirrors exist (Stata sdid and synth/synth_runner; Python pysyncon, and scpi
+Stata and Python mirrors exist (Stata sdid, synth/synth_runner, allsynth; Python pysyncon, and scpi
 ships its own Python interface) but were NOT API-verified in this pass; check signatures
 against their docs before citing them in a methods section.

--- a/skills/synthetic-control/scripts/synth_template.R
+++ b/skills/synthetic-control/scripts/synth_template.R
@@ -114,12 +114,28 @@ setup <- panel.matrices(panel, unit = "unit", time = "year",
                         outcome = "y", treatment = "treated")   # names, not positions
 tau_sdid <- synthdid_estimate(setup$Y, setup$N0, setup$T0)
 sqrt(vcov(tau_sdid, method = "placebo"))    # single treated unit: placebo is the ONLY option
-plot(tau_sdid); synthdid_units_plot(tau_sdid)
+# Reporting discipline: two weight figures, not one. synthdid_plot() draws the time
+# weights lambda as a ribbon under the trajectories (lambda.plot.scale sets their
+# height, default 3), so readers see which pre-years carry the counterfactual;
+# synthdid_units_plot() shows which donors do. plot(tau_sdid) dispatches to
+# synthdid_plot(). Both default to se.method = "jackknife", invalid with one treated
+# unit, so pass "placebo". Signatures read off the synthdid GitHub source (master),
+# NOT the pinned 0.0.9 build: not API-verified.
+synthdid_plot(tau_sdid, lambda.plot.scale = 3, se.method = "placebo")
+synthdid_units_plot(tau_sdid, se.method = "placebo")
+# The SDID intercept means the treated and synthetic series will NOT overlay, so the
+# visual pre-fit check canonical SC leans on is weaker here, with no accepted
+# substitute yet. overlay = 1 subtracts the DiD-style level adjustment so parallelness
+# is readable; it is a plotting aid, not the missing test.
+synthdid_plot(tau_sdid, overlay = 1)
 # The SC-DID-SDID trio on one panel is itself a diagnostic (divergence = the
 # additive or convex restriction is doing work):
 tau_sc  <- sc_estimate(setup$Y, setup$N0, setup$T0)
 tau_did <- did_estimate(setup$Y, setup$N0, setup$T0)
-# Requires block adoption on a balanced panel; staggered adoption -> multisynth/fect.
+# Requires block adoption on a balanced panel; staggered adoption -> multisynth/fect,
+# or staggered SDID (Arkhangelsky et al. 2021 appendix; Clarke, Pailanir, Athey, and
+# Imbens 2024 sec 2.3; Porreca 2022), which has no CRAN package: Porreca's code is at
+# github.com/zachporreca/staggered_adoption_synthdid.
 
 ## ---- 8. Augmented SC (imperfect fit that must stay in) -----------------------
 # devtools::install_github("ebenmichael/augsynth")       # not on CRAN
@@ -128,6 +144,12 @@ asyn <- augsynth(y ~ treated, unit = unit, time = year, data = df,
                  progfunc = "ridge", scm = TRUE)   # t_int inferred; pass by name if set
 summary(asyn)                                      # conformal inference by default
 plot(asyn)
+# plot() takes inf_type to switch inference: "conformal" (default), "jackknife+",
+# "jackknife", "permutation", "permutation_rstat", "None". plot_type = "cv" draws the
+# cross-validation MSE over the ridge lambda; the older cv = TRUE spelling just forces
+# plot_type = "cv" and is kept for backwards compatibility.
+plot(asyn, inf_type = "jackknife+")
+plot(asyn, plot_type = "cv")
 # Report raw SC and augmented side by side; a large augmentation term means the
 # convex weights alone could not match, which is information, not decoration.
 # Staggered many-treated: multisynth(y ~ treated, unit = unit, time = year,


### PR DESCRIPTION
A read of Causal Inference: The Mixtape against the five causal skills. Each of rdd, iv, did, synthetic-control, and causal-design gains a recognition table of canonical natural experiments, so a setting can be matched to a design by the shape of the assignment rather than by the method name, and every package index was re-checked against CRAN with versions and release dates. rdd adds heaping and clustering rules for the running variable; iv adds the five assumptions kept separate, where an instrument comes from, and the exhibits an IV paper owes a reader; did adds the selection mechanisms that license parallel trends, triple differences, and the evidence battery, with SUTVA and no anticipation added to the assumption list; synthetic-control adds what SDID assumes, how to report it, and the staggered case; causal-design adds a plain panel fixed effects section for the case with no comparison group and no adoption date. The shared bib gains 35 entries verified against Crossref, plus three keys the causal-design canon newly cites.

```
 skills/causal-design/SKILL.md                     | 118 ++++-
 skills/causal-design/references/canon.md          |  97 ++--
 skills/causal-design/references/causal.bib        | 551 ++++++++++++++++++++++
 skills/causal-design/references/details.md        |  32 +-
 skills/did/SKILL.md                               | 263 ++++++++++-
 skills/did/references/canon.md                    |  76 ++-
 skills/did/references/details.md                  | 135 +++++-
 skills/did/scripts/did_template.R                 |  23 +-
 skills/iv/SKILL.md                                | 103 +++-
 skills/iv/references/canon.md                     |  41 +-
 skills/iv/references/details.md                   |  54 ++-
 skills/iv/scripts/iv_template.R                   |   8 +
 skills/rdd/SKILL.md                               |  73 ++-
 skills/rdd/references/canon.md                    |  31 +-
 skills/rdd/references/details.md                  |  56 ++-
 skills/rdd/scripts/rdd_template.R                 |  16 +-
 skills/synthetic-control/SKILL.md                 |  48 +-
 skills/synthetic-control/references/canon.md      |  24 +
 skills/synthetic-control/references/details.md    |  62 ++-
 skills/synthetic-control/scripts/synth_template.R |  26 +-
 20 files changed, 1676 insertions(+), 161 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUELNHqf1rNHMKQx2x3QQf